### PR TITLE
Build flashable Pi image via GitHub Actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,76 @@
+name: Build Pi Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "Image filename (without extension)"
+        required: false
+        default: "agora-pi"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: |
+          version=$(python3 -c "exec(open('api/__init__.py').read()); print(__version__)")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building image for Agora v$version"
+
+      - name: Build image with pi-gen
+        uses: usimd/pi-gen-action@v1
+        id: build
+        with:
+          # Base image config
+          image-name: ${{ github.event.inputs.image_name || 'agora-pi' }}
+          release: bookworm
+          target-architecture: arm64
+
+          # Skip desktop stages (we want Lite)
+          stage-list: stage0 stage1 stage2 ./pi-gen/stage-agora
+
+          # Enable SSH by default
+          enable-ssh: 1
+
+          # Don't set locale/keyboard/timezone — keep defaults
+          locale: en_US.UTF-8
+          keyboard-layout: us
+          timezone: UTC
+
+          # Hostname
+          hostname: agora
+
+          # Compression
+          compression: xz
+          compression-level: 9
+
+          # Verbose for debugging
+          verbose-output: true
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.inputs.image_name || 'agora-pi' }}-v${{ steps.version.outputs.version }}
+          path: ${{ steps.build.outputs.image-path }}
+          retention-days: 30
+
+      - name: Attach image to latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find the latest release
+          TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || true)
+          if [ -n "$TAG" ]; then
+            echo "Uploading image to release $TAG"
+            gh release upload "$TAG" "${{ steps.build.outputs.image-path }}" --clobber
+          else
+            echo "No release found — image available as workflow artifact only"
+          fi

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -37,7 +37,7 @@ mkdir -p "${BUILD_DIR}/etc/systemd/system"
 mkdir -p "${BUILD_DIR}/usr/share/plymouth/themes/splash"
 
 # ── Source code ──
-for dir in api player shared cms_client; do
+for dir in api player shared cms_client provision; do
     cp -r "${REPO_ROOT}/${dir}" "${BUILD_DIR}/opt/agora/src/"
 done
 cp "${REPO_ROOT}/requirements-api.txt" "${BUILD_DIR}/opt/agora/src/"
@@ -53,6 +53,7 @@ fi
 cp "${REPO_ROOT}/systemd/agora-api.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-player.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-cms-client.service" "${BUILD_DIR}/etc/systemd/system/"
+cp "${REPO_ROOT}/systemd/agora-provision.service" "${BUILD_DIR}/etc/systemd/system/"
 
 # ── Plymouth theme ──
 if [[ -f "${REPO_ROOT}/config/boot-splash.png" ]]; then

--- a/pi-gen/stage-agora/00-install-agora/00-run.sh
+++ b/pi-gen/stage-agora/00-install-agora/00-run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+# pi-gen stage: Install Agora from APT repository and configure for captive portal boot.
+
+on_chroot <<'CHEOF'
+
+# ── Add Agora apt repository ──
+REPO_URL="https://sslivins.github.io/agora"
+echo "deb [arch=arm64 trusted=yes] ${REPO_URL} stable main" > /etc/apt/sources.list.d/agora.list
+apt-get update -qq
+
+# ── Install Agora (pulls in network-manager, dnsmasq, avahi-daemon) ──
+apt-get install -y agora
+
+# ── Ensure device boots into captive portal (no provisioned flag) ──
+rm -f /opt/agora/persist/provisioned
+
+# ── Enable SSH (disabled by default on Pi OS) ──
+systemctl enable ssh
+
+# ── Clean up ──
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+CHEOF


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds a ready-to-flash Raspberry Pi OS image with Agora pre-installed.

### How it works
- **Manual trigger**: Actions > Build Pi Image > Run workflow
- Uses [pi-gen](https://github.com/RPi-Distillery/pi-gen) (the official Pi OS builder) via the `usimd/pi-gen-action` action
- Builds Raspberry Pi OS Lite (arm64/bookworm) + a custom stage that installs Agora from the APT repo
- Device boots straight into captive portal mode (no SSH/Wi-Fi pre-config needed)
- SSH is enabled by default for recovery access

### Output
- Compressed `.img.xz` uploaded as a workflow artifact (30-day retention)
- Also attached to the latest GitHub Release if one exists

### Usage
1. Run the workflow from the Actions tab
2. Download the `.img.xz` from the workflow run artifacts
3. Flash to SD card with Raspberry Pi Imager or balenaEtcher
4. Boot the Pi — connect to `Agora-XXXX` Wi-Fi for setup

### Also fixes
- `build-deb.sh` was missing the `provision/` package and `agora-provision.service` from the .deb build