### PR TITLE
fix: add QEMU arm64 emulation + timezone dropdown

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,9 +8,31 @@ on:
         required: false
         default: "agora-pi"
       timezone:
-        description: "Timezone (e.g. America/New_York, Europe/London, Etc/UTC)"
+        description: "Timezone"
         required: false
+        type: choice
         default: "America/New_York"
+        options:
+          - "America/New_York"
+          - "America/Chicago"
+          - "America/Denver"
+          - "America/Los_Angeles"
+          - "America/Anchorage"
+          - "Pacific/Honolulu"
+          - "America/Toronto"
+          - "America/Vancouver"
+          - "America/Sao_Paulo"
+          - "Europe/London"
+          - "Europe/Paris"
+          - "Europe/Berlin"
+          - "Europe/Moscow"
+          - "Asia/Tokyo"
+          - "Asia/Shanghai"
+          - "Asia/Kolkata"
+          - "Asia/Dubai"
+          - "Australia/Sydney"
+          - "Pacific/Auckland"
+          - "Etc/UTC"
 
 permissions:
   contents: write
@@ -28,6 +50,11 @@ jobs:
           version=$(python3 -c "exec(open('api/__init__.py').read()); print(__version__)")
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Building image for Agora v$version"
+
+      - name: Set up QEMU for arm64 emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Build image with pi-gen
         uses: usimd/pi-gen-action@v1


### PR DESCRIPTION
The build-image workflow was failing because the GitHub Actions runner (x86_64) had no arm64 emulation support for pi-gen's cross-build.

**Fixes:**
- Add \docker/setup-qemu-action@v3\ step to register binfmt_misc for arm64 before pi-gen runs
- Change timezone input from free text to a dropdown with common timezone options