### PR TITLE
Fix captive portal password field and initial focus

### DIFF
--- a/provision/templates/setup.html
+++ b/provision/templates/setup.html
@@ -19,14 +19,14 @@
                 <h2>Wi-Fi Network</h2>
                 <label for="wifi-ssid">Network</label>
                 <div class="wifi-select-row">
-                    <select id="wifi-ssid" required>
+                    <select id="wifi-ssid" required autofocus>
                         <option value="">Scanning…</option>
                     </select>
                     <button type="button" class="btn-scan" onclick="scanNetworks()" id="scan-btn">Scan</button>
                 </div>
 
                 <label for="wifi-password">Password</label>
-                <input type="password" id="wifi-password" placeholder="Enter Wi-Fi password">
+                <input type="password" id="wifi-password" placeholder="Enter Wi-Fi password" autocomplete="off" data-1p-ignore data-lpignore="true">
             </div>
 
             <!-- CMS -->


### PR DESCRIPTION
Two small UX fixes for the captive portal setup page:

1. **Password field** — Added `autocomplete=off`, `data-1p-ignore`, and `data-lpignore=true` to prevent browsers and password managers from offering to generate/save a password for the WiFi field.
2. **Initial focus** — Added `autofocus` to the SSID `<select>` so the page opens with focus on the network selector instead of the CMS address field.