### PR TITLE
feat: report playback errors to CMS in status heartbeats

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -410,6 +410,8 @@ class CMSClient:
                     "uptime_seconds": int(time.monotonic()),
                     "storage_used_mb": used_mb,
                     "cpu_temp_c": _get_cpu_temp(),
+                    "error": current_data.get("error"),
+                    "error_timestamp": current_data.get("updated_at") if current_data.get("error") else None,
                 }
                 await ws.send(json.dumps(status_msg))
             except websockets.ConnectionClosed:


### PR DESCRIPTION
Include the \error\ field from \current.json\ (written by the player on pipeline errors or missing assets) in the periodic status heartbeat sent to the CMS. Also includes \error_timestamp\ so the CMS knows when the error first occurred.

This enables the CMS to surface device errors on the dashboard — making it possible to detect problems like codec mismatches or missing assets without SSH-ing into each device.

### What changed
- \cms_client/service.py\: \_status_loop()\ now includes \error\ and \error_timestamp\ from \current.json\ in the status message

### Companion PR
CMS side: sslivins/agora-cms#35