### PR TITLE
fix: handle video-only files (no audio) in player pipeline

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -31,6 +31,12 @@ class AgoraPlayer:
         'alsasink device="hdmi:CARD=vc4hdmi,DEV=0"'
     )
 
+    VIDEO_PIPELINE_NO_AUDIO = (
+        'filesrc location="{path}" ! '
+        "qtdemux name=dmux "
+        "dmux.video_0 ! queue ! h264parse ! v4l2h264dec ! kmssink sync=false"
+    )
+
     IMAGE_PIPELINE_JPEG = (
         'filesrc location="{path}" ! '
         "jpegparse ! jpegdec ! videoconvert ! videoscale add-borders=true ! "
@@ -101,6 +107,20 @@ class AgoraPlayer:
 
     # ── Pipeline management ──
 
+    @staticmethod
+    def _has_audio(path: Path) -> bool:
+        """Return True if the video file contains an audio stream."""
+        gi.require_version("GstPbutils", "1.0")
+        from gi.repository import GstPbutils
+
+        try:
+            discoverer = GstPbutils.Discoverer.new(5 * Gst.SECOND)
+            info = discoverer.discover_uri(path.as_uri())
+            return len(info.get_audio_streams()) > 0
+        except Exception:
+            # If discovery fails, assume audio exists (safer default)
+            return True
+
     def _teardown(self) -> None:
         if self.pipeline:
             self.pipeline.set_state(Gst.State.NULL)
@@ -108,7 +128,11 @@ class AgoraPlayer:
 
     def _build_pipeline(self, path: Path, is_video: bool) -> Gst.Pipeline:
         if is_video:
-            pipeline_str = self.VIDEO_PIPELINE.format(path=path)
+            if self._has_audio(path):
+                pipeline_str = self.VIDEO_PIPELINE.format(path=path)
+            else:
+                logger.info("No audio track detected, using video-only pipeline")
+                pipeline_str = self.VIDEO_PIPELINE_NO_AUDIO.format(path=path)
         elif path.suffix.lower() in (".jpg", ".jpeg"):
             pipeline_str = self.IMAGE_PIPELINE_JPEG.format(path=path)
         else:
@@ -243,6 +267,35 @@ class AgoraPlayer:
             self.pipeline = self._build_pipeline(path, is_video)
             self.pipeline.set_state(Gst.State.PLAYING)
             self._update_current(mode=PlaybackMode.PLAY, asset=desired.asset)
+            # Schedule a health check to verify the pipeline actually started
+            GLib.timeout_add_seconds(
+                5, self._check_pipeline_health, desired.asset,
+            )
+
+    def _check_pipeline_health(self, asset_name: str) -> bool:
+        """Verify the pipeline reached PLAYING state. Returns False (no repeat)."""
+        if not self.pipeline:
+            return False
+        # Only check if we're still supposed to be playing this asset
+        if (
+            not self.current_desired
+            or self.current_desired.asset != asset_name
+            or self.current_desired.mode != PlaybackMode.PLAY
+        ):
+            return False
+
+        _, state, _ = self.pipeline.get_state(0)
+        if state != Gst.State.PLAYING:
+            logger.error(
+                "Pipeline health check failed for %s: state is %s (expected PLAYING)",
+                asset_name, state.value_nick if state else "NULL",
+            )
+            self._update_current(
+                mode=PlaybackMode.PLAY,
+                asset=asset_name,
+                error=f"Pipeline failed to reach PLAYING state ({state.value_nick if state else 'NULL'})",
+            )
+        return False
 
     # ── State file watcher ──
 

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1,0 +1,128 @@
+"""Tests for player service — pipeline selection logic."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from shared.models import PlaybackMode, DesiredState
+
+
+@pytest.fixture
+def player():
+    """Create an AgoraPlayer instance with mocked GStreamer."""
+    with patch.dict("sys.modules", {
+        "gi": MagicMock(),
+        "gi.repository": MagicMock(),
+    }):
+        # Must patch before importing since player imports Gst at module level
+        import importlib
+        import player.service as svc
+        importlib.reload(svc)
+
+        p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
+        p.pipeline = None
+        p.current_desired = None
+        yield p
+
+
+class TestPipelineSelection:
+    """Verify _build_pipeline picks the correct pipeline string based on audio presence."""
+
+    def test_video_with_audio_uses_audio_pipeline(self, player, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.touch()
+
+        with patch.object(type(player), "_has_audio", return_value=True):
+            with patch("player.service.Gst") as mock_gst:
+                mock_gst.parse_launch.return_value = MagicMock()
+                player._build_pipeline(video, is_video=True)
+
+                pipeline_str = mock_gst.parse_launch.call_args[0][0]
+                assert "alsasink" in pipeline_str
+                assert "dmux.audio_0" in pipeline_str
+                assert "sync=true" in pipeline_str
+
+    def test_video_without_audio_uses_no_audio_pipeline(self, player, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.touch()
+
+        with patch.object(type(player), "_has_audio", return_value=False):
+            with patch("player.service.Gst") as mock_gst:
+                mock_gst.parse_launch.return_value = MagicMock()
+                player._build_pipeline(video, is_video=True)
+
+                pipeline_str = mock_gst.parse_launch.call_args[0][0]
+                assert "alsasink" not in pipeline_str
+                assert "dmux.audio_0" not in pipeline_str
+                assert "sync=false" in pipeline_str
+
+    def test_image_ignores_audio_check(self, player, tmp_path):
+        img = tmp_path / "image.png"
+        img.touch()
+
+        with patch.object(type(player), "_has_audio") as mock_has_audio:
+            with patch("player.service.Gst") as mock_gst:
+                mock_gst.parse_launch.return_value = MagicMock()
+                player._build_pipeline(img, is_video=False)
+
+                mock_has_audio.assert_not_called()
+                pipeline_str = mock_gst.parse_launch.call_args[0][0]
+                assert "imagefreeze" in pipeline_str
+
+
+class TestPipelineHealthCheck:
+    """Verify _check_pipeline_health reports errors when pipeline fails to start."""
+
+    def test_reports_error_when_not_playing(self, player, tmp_path):
+        """Pipeline stuck in PAUSED should report an error."""
+        with patch("player.service.Gst") as mock_gst:
+            mock_gst.State.PLAYING = "PLAYING"
+
+            mock_state = MagicMock()
+            mock_state.value_nick = "paused"
+
+            mock_pipeline = MagicMock()
+            mock_pipeline.get_state.return_value = (None, mock_state, None)
+            player.pipeline = mock_pipeline
+
+            player.current_desired = DesiredState(
+                mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
+            )
+
+            with patch.object(player, "_update_current") as mock_update:
+                player._check_pipeline_health("test.mp4")
+                mock_update.assert_called_once()
+                call_kwargs = mock_update.call_args[1]
+                assert call_kwargs["error"] is not None
+                assert "PLAYING" in call_kwargs["error"]
+
+    def test_no_error_when_pipeline_is_playing(self, player, tmp_path):
+        """Pipeline in PLAYING state should not report an error."""
+        with patch("player.service.Gst") as mock_gst:
+            playing_state = MagicMock()
+            playing_state.value_nick = "playing"
+            mock_gst.State.PLAYING = playing_state
+
+            mock_pipeline = MagicMock()
+            mock_pipeline.get_state.return_value = (None, playing_state, None)
+            player.pipeline = mock_pipeline
+
+            player.current_desired = DesiredState(
+                mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
+            )
+
+            with patch.object(player, "_update_current") as mock_update:
+                player._check_pipeline_health("test.mp4")
+                mock_update.assert_not_called()
+
+    def test_skips_check_when_asset_changed(self, player):
+        """Health check should be a no-op if a different asset is now playing."""
+        player.pipeline = MagicMock()
+        player.current_desired = DesiredState(
+            mode=PlaybackMode.PLAY, asset="other.mp4", loop=True
+        )
+
+        with patch.object(player, "_update_current") as mock_update:
+            player._check_pipeline_health("test.mp4")
+            mock_update.assert_not_called()


### PR DESCRIPTION
## Problem

Videos without audio tracks (like Sony_4k60_AV1.mp4) caused a **black screen** on the Pi. The player pipeline hardcodes `dmux.audio_0` which expects an audio pad. When no audio exists, the pad never links, causing the pipeline to silently fail to render video. No GStreamer error was emitted, so the CMS showed the device as playing normally.

## Root Cause

Sony_4k60_AV1.mp4 source has no audio track. The H.264 variant also has no audio. The hardcoded `VIDEO_PIPELINE` with `dmux.audio_0 ! queue ! decodebin ! ... ! alsasink` silently failed.

## Fix

1. **Video-only pipeline** (`VIDEO_PIPELINE_NO_AUDIO`): New pipeline template without the audio branch, using `sync=false` on kmssink
2. **Audio detection** (`_has_audio()`): Probes video files using `GstPbutils.Discoverer` before building the pipeline  
3. **Pipeline health check** (`_check_pipeline_health()`): After 5 seconds, verifies the pipeline reached PLAYING state. If not, reports the error to `current.json` so the CMS can surface it

## Tests

- 6 new tests in `tests/test_player_service.py`
  - Pipeline selection: video with audio, video without audio, image skips audio check
  - Health check: reports error when stuck, no error when playing, skips when asset changed