### PR TITLE
Disable cloud-init in pi-gen image build

### DIFF
--- a/pi-gen/stage-agora/00-install-agora/00-run.sh
+++ b/pi-gen/stage-agora/00-install-agora/00-run.sh
@@ -11,6 +11,9 @@ apt-get update -qq
 # ── Install Agora (pulls in network-manager, dnsmasq, avahi-daemon) ──
 apt-get install -y agora
 
+# ── Disable cloud-init (not needed on embedded Pi, saves ~6s boot time) ──
+touch /etc/cloud/cloud-init.disabled
+
 # ── Ensure device boots into captive portal (no provisioned flag) ──
 rm -f /opt/agora/persist/provisioned
 


### PR DESCRIPTION
cloud-init probes for cloud metadata services that don't exist on embedded Pi devices. It sits directly on the critical boot path (blocks NetworkManager startup), adding ~6s of wasted time.

**Tested on device (192.168.1.53):**
- Boot time: 32.4s → 25.3s (7.1s saved)
- Player service start: 18.3s → 13.1s (5.2s earlier)
- Pipeline PLAYING: ~35.6s → ~29.4s (6.2s earlier)

Single-line change: \	ouch /etc/cloud/cloud-init.disabled\ in the pi-gen stage.