### PR TITLE
ci: generate changelog from conventional commits in releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,9 +56,32 @@ Two processes, communicating via JSON state files on disk (`desired.json` and `c
 
 - **`main` is sacred** — never commit directly to `main`.
 - All changes must be made on a feature branch and merged via pull request.
-- Branch naming: `feature/<short-description>`, `fix/<short-description>`, `chore/<short-description>`.
+- Branch naming: `feat/<short-description>`, `fix/<short-description>`, `chore/<short-description>`, `perf/<short-description>`, `refactor/<short-description>`, `docs/<short-description>`, `test/<short-description>`, `ci/<short-description>`.
 - **Never merge a PR** unless the user explicitly asks you to. Creating PRs is fine; merging requires explicit approval.
 - Bump the version in `api/__init__.py` and `docs/openapi.yaml` when shipping user-facing changes.
+- **After creating a PR, always check CI status** using `gh pr checks <number>` or `gh run list`. Monitor until all checks pass. If any fail, inspect the logs with `gh run view <run-id> --log-failed`, fix issues, push fixes, and re-check until green.
+
+## Commit Messages — Conventional Commits
+
+All commit messages **must** use [Conventional Commits](https://www.conventionalcommits.org/) format. The release workflow auto-generates changelogs from these prefixes.
+
+**Format:** `<type>(<optional scope>): <description>`
+
+| Prefix | When to use | Example |
+|---|---|---|
+| `feat:` | New feature or capability | `feat: add device group scheduling` |
+| `fix:` | Bug fix | `fix: prevent player crash on missing asset` |
+| `perf:` | Performance improvement | `perf: reduce GStreamer pipeline startup time` |
+| `refactor:` | Code restructuring (no behavior change) | `refactor: extract asset validation helper` |
+| `test:` | Adding or updating tests only | `test: add OOBE provisioning flow tests` |
+| `docs:` | Documentation only | `docs: update OpenAPI spec for new endpoints` |
+| `ci:` | CI/CD workflow changes | `ci: add changelog generation to release workflow` |
+| `chore:` | Maintenance, deps, tooling | `chore: bump FastAPI to 0.115` |
+
+- Use the **imperative mood** in descriptions: "add" not "added", "fix" not "fixes".
+- Optional scope in parentheses: `fix(player): handle missing codec gracefully`.
+- Keep the first line under 72 characters.
+- Add a blank line + body for complex changes.
 
 ## Hardware Target
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,12 +43,105 @@ jobs:
       - name: Build .deb package
         run: bash packaging/build-deb.sh "${{ steps.version.outputs.version }}"
 
+      - name: Generate changelog
+        id: changelog
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if [ -z "$PREV_TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+          echo "Generating changelog: ${PREV_TAG:-initial}..${TAG}"
+
+          FEATURES=$(git log ${RANGE} --oneline --no-merges --grep="^feat" | sed 's/^[a-f0-9]* feat[^:]*: //' || true)
+          FIXES=$(git log ${RANGE} --oneline --no-merges --grep="^fix" | sed 's/^[a-f0-9]* fix[^:]*: //' || true)
+          PERF=$(git log ${RANGE} --oneline --no-merges --grep="^perf" | sed 's/^[a-f0-9]* perf[^:]*: //' || true)
+          REFACTORS=$(git log ${RANGE} --oneline --no-merges --grep="^refactor" | sed 's/^[a-f0-9]* refactor[^:]*: //' || true)
+          TESTS=$(git log ${RANGE} --oneline --no-merges --grep="^test" | sed 's/^[a-f0-9]* test[^:]*: //' || true)
+          DOCS=$(git log ${RANGE} --oneline --no-merges --grep="^docs" | sed 's/^[a-f0-9]* docs[^:]*: //' || true)
+          CI_CHANGES=$(git log ${RANGE} --oneline --no-merges --grep="^ci" | sed 's/^[a-f0-9]* ci[^:]*: //' || true)
+          CHORE=$(git log ${RANGE} --oneline --no-merges --grep="^chore" | sed 's/^[a-f0-9]* chore[^:]*: //' || true)
+
+          # Collect commit hashes that matched a category
+          MATCHED=$(git log ${RANGE} --oneline --no-merges --grep="^feat\|^fix\|^perf\|^refactor\|^test\|^docs\|^ci\|^chore" --format="%h" || true)
+          # All commits
+          ALL=$(git log ${RANGE} --oneline --no-merges --format="%h %s" || true)
+          # Other = commits not matching any conventional prefix
+          OTHER=""
+          while IFS= read -r line; do
+            hash=$(echo "$line" | cut -d' ' -f1)
+            if ! echo "$MATCHED" | grep -q "^${hash}$"; then
+              msg=$(echo "$line" | cut -d' ' -f2-)
+              OTHER="${OTHER}${msg}"$'\n'
+            fi
+          done <<< "$ALL"
+          OTHER=$(echo "$OTHER" | sed '/^$/d')
+
+          {
+            echo "## Agora ${TAG}"
+            echo ""
+            if [ -n "$FEATURES" ]; then
+              echo "### ✨ Features"
+              echo "$FEATURES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$FIXES" ]; then
+              echo "### 🐛 Fixes"
+              echo "$FIXES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$PERF" ]; then
+              echo "### ⚡ Performance"
+              echo "$PERF" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$REFACTORS" ]; then
+              echo "### ♻️ Refactors"
+              echo "$REFACTORS" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$TESTS" ]; then
+              echo "### 🧪 Tests"
+              echo "$TESTS" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$DOCS" ]; then
+              echo "### 📝 Documentation"
+              echo "$DOCS" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$CI_CHANGES" ]; then
+              echo "### 🔧 CI"
+              echo "$CI_CHANGES" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$CHORE" ]; then
+              echo "### 🧹 Chores"
+              echo "$CHORE" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            if [ -n "$OTHER" ]; then
+              echo "### 📦 Other"
+              echo "$OTHER" | while IFS= read -r line; do echo "- $line"; done
+              echo ""
+            fi
+            echo "---"
+            echo ""
+            echo "**Full diff:** [\`${PREV_TAG:-initial}...${TAG}\`](https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${TAG})"
+          } > /tmp/release_body.md
+
+          echo "📋 Generated changelog:"
+          cat /tmp/release_body.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          name: Agora ${{ steps.version.outputs.tag }}
+          body_path: /tmp/release_body.md
           files: build/*.deb
-          generate_release_notes: true
 
   publish-apt:
     needs: release


### PR DESCRIPTION
## Changes

- **Release workflow**: Replace \generate_release_notes: true\ with conventional commit changelog generation. Categorizes commits into Features, Fixes, Performance, Refactors, Tests, Docs, CI, Chores, and Other sections. Includes a diff link to the previous tag.

- **Copilot instructions**: Add conventional commit rules and expanded branch naming prefixes (\eat/\, \ix/\, \perf/\, \efactor/\, \	est/\, \docs/\, \ci/\, \chore/\) to ensure all future commits follow the format the changelog generator expects.