### PR TITLE
fix: switch NTP from CMS server to public Debian pools

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -190,11 +190,7 @@ systemctl disable wpa_supplicant 2>/dev/null || true
 systemctl enable NetworkManager 2>/dev/null || true
 systemctl restart NetworkManager 2>/dev/null || true
 
-# ── Configure NTP to use CMS server (Pi has no battery-backed RTC) ──
-# Install the configure-ntp script and run it to set up timesyncd.
-# On first install, defaults to agora-cms.local; the CMS client service
-# re-runs this script on each start to pick up the actual CMS host
-# from /opt/agora/persist/cms_config.json.
+# ── Configure NTP with public pools (Pi has no battery-backed RTC) ──
 chmod +x "${AGORA_BASE}/src/scripts/configure-ntp.sh"
 bash "${AGORA_BASE}/src/scripts/configure-ntp.sh" || true
 

--- a/pi-gen/stage-agora/00-install-agora/00-run.sh
+++ b/pi-gen/stage-agora/00-install-agora/00-run.sh
@@ -68,16 +68,11 @@ sed -i 's/console=tty1/console=tty3/g' /boot/firmware/cmdline.txt 2>/dev/null ||
 # Force HDMI connector detection with 1080p mode on kernel cmdline
 sed -i 's/rootwait/rootwait video=HDMI-A-1:1920x1080@60D/' /boot/firmware/cmdline.txt 2>/dev/null || true
 
-# ── Configure NTP to use CMS server (Pi has no battery-backed RTC) ──
-# The agora package installs configure-ntp.sh which reads cms_config.json.
-# On fresh images there's no CMS config yet, so set the default (agora-cms.local).
-# The CMS client service re-runs the script on each start to pick up
-# the actual CMS host after provisioning.
+# ── Configure NTP with public pools (Pi has no battery-backed RTC) ──
 mkdir -p /etc/systemd/timesyncd.conf.d
 cat > /etc/systemd/timesyncd.conf.d/agora.conf <<'NTP_EOF'
 [Time]
-NTP=agora-cms.local
-FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+NTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
 NTP_EOF
 systemctl enable systemd-timesyncd
 

--- a/scripts/configure-ntp.sh
+++ b/scripts/configure-ntp.sh
@@ -1,36 +1,24 @@
 #!/bin/bash
-# Configure systemd-timesyncd to use the CMS server as NTP source.
-# Reads cms_host from /opt/agora/persist/cms_config.json.
-# Falls back to agora-cms.local if no config exists.
+# Configure systemd-timesyncd to use public NTP pools.
+# Removes any previous CMS-based NTP configuration.
 set -e
 
-CMS_CONFIG="/opt/agora/persist/cms_config.json"
 TIMESYNCD_CONF="/etc/systemd/timesyncd.conf.d/agora.conf"
-FALLBACK="agora-cms.local"
+NTP_SERVERS="0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"
 
-# Extract cms_host from JSON config (no jq dependency — use python)
-if [ -f "$CMS_CONFIG" ]; then
-    CMS_HOST=$(python3 -c "import json; print(json.load(open('$CMS_CONFIG')).get('cms_host', '$FALLBACK'))" 2>/dev/null || echo "$FALLBACK")
-else
-    CMS_HOST="$FALLBACK"
-fi
-
-# Only rewrite if the NTP server changed
-CURRENT=""
+# Only rewrite if the config doesn't match
 if [ -f "$TIMESYNCD_CONF" ]; then
     CURRENT=$(grep -oP '^NTP=\K.*' "$TIMESYNCD_CONF" 2>/dev/null || true)
-fi
-
-if [ "$CURRENT" = "$CMS_HOST" ]; then
-    exit 0
+    if [ "$CURRENT" = "$NTP_SERVERS" ]; then
+        exit 0
+    fi
 fi
 
 mkdir -p /etc/systemd/timesyncd.conf.d
 cat > "$TIMESYNCD_CONF" <<EOF
 [Time]
-NTP=$CMS_HOST
-FallbackNTP=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org
+NTP=$NTP_SERVERS
 EOF
 
 systemctl restart systemd-timesyncd 2>/dev/null || true
-echo "NTP configured to use $CMS_HOST"
+echo "NTP configured to use public pools"

--- a/systemd/agora-cms-client.service
+++ b/systemd/agora-cms-client.service
@@ -12,8 +12,7 @@ Environment=AGORA_BASE=/opt/agora
 Restart=always
 RestartSec=10
 
-# Configure NTP to use CMS server, then wait for network to settle
-ExecStartPre=/bin/bash /opt/agora/src/scripts/configure-ntp.sh
+# Wait for network to settle before connecting to CMS
 ExecStartPre=/bin/sleep 5
 
 StandardOutput=journal


### PR DESCRIPTION
Removes the CMS host as the NTP source and switches to public Debian pool servers instead.

### Changes
- **\scripts/configure-ntp.sh\** — rewrote to use \