### PR TITLE
fix: second-level schedule resolution for loop_count

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -148,10 +148,11 @@ def _save_auth_token(path: Path, token: str) -> None:
 
 # ── Schedule evaluation helpers ──
 
-def _parse_time(s: str) -> tuple[int, int]:
-    """Parse 'HH:MM' string to (hour, minute)."""
+def _parse_time(s: str) -> tuple[int, int, int]:
+    """Parse 'HH:MM' or 'HH:MM:SS' string to (hour, minute, second)."""
     parts = s.split(":")
-    return int(parts[0]), int(parts[1])
+    sec = int(parts[2]) if len(parts) > 2 else 0
+    return int(parts[0]), int(parts[1]), sec
 
 
 def _schedule_matches_now(entry: dict, now: datetime) -> bool:
@@ -167,17 +168,17 @@ def _schedule_matches_now(entry: dict, now: datetime) -> bool:
     if days and now.isoweekday() not in days:
         return False
 
-    sh, sm = _parse_time(entry["start_time"])
-    eh, em = _parse_time(entry["end_time"])
-    start_mins = sh * 60 + sm
-    end_mins = eh * 60 + em
-    cur_mins = now.hour * 60 + now.minute
+    sh, sm, ss = _parse_time(entry["start_time"])
+    eh, em, es = _parse_time(entry["end_time"])
+    start_secs = sh * 3600 + sm * 60 + ss
+    end_secs = eh * 3600 + em * 60 + es
+    cur_secs = now.hour * 3600 + now.minute * 60 + now.second
 
-    if start_mins <= end_mins:
-        if not (start_mins <= cur_mins < end_mins):
+    if start_secs <= end_secs:
+        if not (start_secs <= cur_secs < end_secs):
             return False
     else:
-        if not (cur_mins >= start_mins or cur_mins < end_mins):
+        if not (cur_secs >= start_secs or cur_secs < end_secs):
             return False
 
     return True

--- a/tests/test_schedule_eval.py
+++ b/tests/test_schedule_eval.py
@@ -22,16 +22,25 @@ from cms_client.service import _parse_time, _schedule_matches_now, _schedule_sta
 
 class TestParseTime:
     def test_basic(self):
-        assert _parse_time("09:30") == (9, 30)
+        assert _parse_time("09:30") == (9, 30, 0)
 
     def test_midnight(self):
-        assert _parse_time("00:00") == (0, 0)
+        assert _parse_time("00:00") == (0, 0, 0)
 
     def test_end_of_day(self):
-        assert _parse_time("23:59") == (23, 59)
+        assert _parse_time("23:59") == (23, 59, 0)
 
     def test_single_digit_hour(self):
-        assert _parse_time("9:05") == (9, 5)
+        assert _parse_time("9:05") == (9, 5, 0)
+
+    def test_with_seconds(self):
+        assert _parse_time("09:30:45") == (9, 30, 45)
+
+    def test_midnight_with_seconds(self):
+        assert _parse_time("00:00:00") == (0, 0, 0)
+
+    def test_end_of_day_with_seconds(self):
+        assert _parse_time("23:59:59") == (23, 59, 59)
 
 
 # ── _schedule_matches_now tests ──
@@ -151,9 +160,30 @@ class TestScheduleMatchesNow:
         entry = self._entry(start_time="12:00", end_time="12:00")
         assert _schedule_matches_now(entry, datetime(2026, 3, 28, 12, 0)) is False
 
-    def test_seconds_ignored(self):
-        """Matching is minute-level: 16:59:59 still matches 9:00-17:00."""
-        entry = self._entry()
+    def test_second_resolution_start_inclusive(self):
+        """Start time with seconds is inclusive."""
+        entry = self._entry(start_time="09:00:30", end_time="17:00:00")
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 29)) is False
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 30)) is True
+
+    def test_second_resolution_end_exclusive(self):
+        """End time with seconds is exclusive."""
+        entry = self._entry(start_time="09:00:00", end_time="09:00:03")
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 2)) is True
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 3)) is False
+
+    def test_three_second_window(self):
+        """A 3-second clip with loop_count=1 produces a 3-second window."""
+        entry = self._entry(start_time="09:00:00", end_time="09:00:03")
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 8, 59, 59)) is False
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 0)) is True
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 1)) is True
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 2)) is True
+        assert _schedule_matches_now(entry, datetime(2026, 3, 28, 9, 0, 3)) is False
+
+    def test_hh_mm_still_works(self):
+        """Legacy HH:MM format (no seconds) still works — seconds default to 0."""
+        entry = self._entry(start_time="09:00", end_time="17:00")
         now = datetime(2026, 3, 28, 16, 59, 59)
         assert _schedule_matches_now(entry, now) is True
 


### PR DESCRIPTION
## Summary

Upgrades the device-side schedule evaluator from minute-level to second-level resolution.

## Problem

When the CMS auto-computes \nd_time = start_time + (loop_count × duration)\ for short clips, the resulting window can be just a few seconds wide (e.g., a 3s clip with \loop_count=1\ → \nd_time\ is 3 seconds after \start_time\). The player was truncating times to \HH:MM\, making these windows indistinguishable from zero-width.

## Changes

### \cms_client/service.py\
- \_parse_time()\: Now returns \(hour, minute, second)\ tuple, handles both \HH:MM\ and \HH:MM:SS\ formats (backward-compatible)
- \_schedule_matches_now()\: Compares at second granularity instead of minute

### \	ests/test_schedule_eval.py\
- Added \_parse_time\ tests for \HH:MM:SS\ format
- Added second-resolution matching tests: start inclusive, end exclusive, 3-second window
- Added backward-compatibility test for legacy \HH:MM\ format
- Replaced \	est_seconds_ignored\ with proper second-level tests

## Companion PR

Requires sslivins/agora-cms#167 which changes the sync payload from \HH:MM\ to \HH:MM:SS\.

Closes #137 (with companion CMS PR)