### PR TITLE
fix(player): always bind ALSA at mpv launch; use mute IPC toggle (#113)

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -66,13 +66,19 @@ def _build_video_pipeline_no_audio_str(board: Board) -> str:
 MPV_IPC_SOCKET = "/tmp/mpv-socket"
 
 
-def _build_mpv_command(path: Path, *, audio: bool = True, loop: bool = False) -> list[str]:
+def _build_mpv_command(path: Path, *, muted: bool = True, loop: bool = False) -> list[str]:
     """Build the mpv command for media playback via DRM output.
 
     Used on Pi 4 and Pi 5 for both video and image playback.
     For video: uses drm-copy hwdec for hardware decoding.
     For images: uses image-display-duration=inf to hold the frame.
     Includes IPC socket for seamless content switching via loadfile.
+
+    The ALSA HDMI audio device is always bound at launch so that later
+    IPC ``loadfile`` swaps can carry audio (mpv cannot add an audio
+    output after the process is running). Mute state is runtime-toggleable
+    via ``set_property mute …`` — splash is muted, scheduled assets are
+    unmuted.
     """
     is_image = path.suffix.lower() in (".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp")
     cmd = [
@@ -84,16 +90,15 @@ def _build_mpv_command(path: Path, *, audio: bool = True, loop: bool = False) ->
         "--no-input-terminal",
         "--no-osc",
         f"--input-ipc-server={MPV_IPC_SOCKET}",
+        "--ao=alsa",
+        f"--audio-device=alsa/hdmi:CARD={alsa_card()},DEV=0",
     ]
     if is_image:
         cmd.append("--image-display-duration=inf")
-        cmd.append("--no-audio")
     else:
         cmd.append("--hwdec=drm-copy")
-        if not audio:
-            cmd.append("--no-audio")
-        else:
-            cmd.extend(["--ao=alsa", f"--audio-device=alsa/hdmi:CARD={alsa_card()},DEV=0"])
+    if muted:
+        cmd.append("--mute=yes")
     if loop:
         cmd.append("--loop=inf")
     cmd.append(str(path))
@@ -406,8 +411,15 @@ class AgoraPlayer:
 
     _IMAGE_EXTS = frozenset((".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"))
 
-    def _loadfile_mpv(self, path: Path, *, loop: bool = False) -> bool:
-        """Switch content in a running mpv via IPC socket. Returns True on success."""
+    def _loadfile_mpv(self, path: Path, *, loop: bool = False, muted: bool = True) -> bool:
+        """Switch content in a running mpv via IPC socket. Returns True on success.
+
+        ``muted`` controls the runtime ``mute`` property after the file is
+        loaded. Splash calls pass ``muted=True``; scheduled-asset calls pass
+        ``muted=False``. Because the underlying mpv process always launches
+        with ``--ao=alsa --audio-device=…`` bound (see ``_build_mpv_command``),
+        toggling mute via IPC is sufficient — no respawn needed.
+        """
         if self._mpv_process is None or self._mpv_process.poll() is not None:
             return False
         is_image = path.suffix.lower() in self._IMAGE_EXTS
@@ -419,6 +431,9 @@ class AgoraPlayer:
             loop_val = "inf" if loop else "no"
             sock.sendall(json.dumps({"command": ["set_property", "loop-file", loop_val]}).encode() + b"\n")
             sock.recv(512)  # read response
+            # Toggle mute to match the policy for the incoming content
+            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
+            sock.recv(512)
             # Set image-display-duration based on content type
             if is_image:
                 sock.sendall(json.dumps({"command": ["set_property", "image-display-duration", "inf"]}).encode() + b"\n")
@@ -446,6 +461,9 @@ class AgoraPlayer:
                 sock.close()
                 logger.warning("mpv IPC loadfile — no success in response: %s", resp[:200])
                 return False
+            # Re-assert mute after loadfile — mpv can reset per-file audio state
+            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
+            sock.recv(512)
             # When loading an image, toggle fullscreen to force DRM plane refresh
             if is_image:
                 time.sleep(0.2)
@@ -455,7 +473,9 @@ class AgoraPlayer:
                     sock.sendall(json.dumps({"command": ["set_property", "fullscreen", True]}).encode() + b"\n")
                     sock.recv(512)
             sock.close()
-            logger.info("mpv IPC loadfile succeeded for %s", path.name)
+            logger.info(
+                "mpv IPC loadfile succeeded for %s (mute=%s)", path.name, muted,
+            )
             return True
         except (OSError, json.JSONDecodeError, IndexError, KeyError) as e:
             logger.warning("mpv IPC loadfile failed: %s — will restart mpv", e)
@@ -468,8 +488,10 @@ class AgoraPlayer:
         Tries IPC loadfile first for seamless switching; falls back to
         full restart if IPC is unavailable.
         """
-        # Try seamless switch via IPC if mpv is already running
-        if self._loadfile_mpv(path, loop=loop):
+        # Try seamless switch via IPC if mpv is already running.
+        # Scheduled assets always play unmuted (policy: only scheduled
+        # content may produce audio; splash is always silent).
+        if self._loadfile_mpv(path, loop=loop, muted=False):
             self._current_path = path
             self._current_mtime = path.stat().st_mtime
             started = datetime.now(timezone.utc)
@@ -483,7 +505,7 @@ class AgoraPlayer:
         self._quit_plymouth()
         self._stop_mpv()
 
-        cmd = _build_mpv_command(path, audio=True, loop=loop)
+        cmd = _build_mpv_command(path, muted=False, loop=loop)
         logger.info("Starting mpv: %s", " ".join(cmd))
         try:
             self._mpv_process = subprocess.Popen(
@@ -784,13 +806,15 @@ class AgoraPlayer:
             self._current_mtime = splash.stat().st_mtime
             # Use mpv on Pi 4/5 for both video and image splash, GStreamer on Zero 2 W
             if self._player_backend == "mpv":
-                # Try seamless IPC switch first
-                if self._loadfile_mpv(splash, loop=True):
+                # Try seamless IPC switch first. Splash is always muted,
+                # regardless of whether the splash asset is an image or a
+                # video — only scheduled assets are allowed to produce audio.
+                if self._loadfile_mpv(splash, loop=True, muted=True):
                     logger.info("Showing splash via mpv IPC: %s", splash.name)
                 else:
                     self._teardown()
                     self._quit_plymouth()
-                    cmd = _build_mpv_command(splash, audio=True, loop=True)
+                    cmd = _build_mpv_command(splash, muted=True, loop=True)
                     logger.info("Showing splash via mpv: %s", splash.name)
                     try:
                         self._mpv_process = subprocess.Popen(

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1353,7 +1353,8 @@ class TestDisplayDetection:
 
 
 class TestBuildMpvCommand:
-    def test_basic_command_with_audio(self):
+    def test_default_command_is_muted_with_audio_device_bound(self):
+        """Default mpv spawn (splash-style) has the ALSA device bound but is muted."""
         with patch.dict("sys.modules", {
             "gi": MagicMock(),
             "gi.repository": MagicMock(),
@@ -1369,12 +1370,15 @@ class TestBuildMpvCommand:
             assert "--drm-connector=HDMI-A-1" in cmd
             assert "--fullscreen" in cmd
             assert "--no-terminal" in cmd
-            assert "--no-audio" not in cmd
+            assert "--no-audio" not in cmd, "audio device must be bound at launch"
             assert "--ao=alsa" in cmd
+            assert any(a.startswith("--audio-device=alsa/hdmi:") for a in cmd)
+            assert "--mute=yes" in cmd, "default spawn must be muted (splash policy)"
             assert "--loop=inf" not in cmd
             assert "test.mp4" in cmd[-1]
 
-    def test_command_without_audio(self):
+    def test_unmuted_command_for_scheduled_asset(self):
+        """Scheduled assets spawn unmuted but still bind the ALSA device."""
         with patch.dict("sys.modules", {
             "gi": MagicMock(),
             "gi.repository": MagicMock(),
@@ -1383,9 +1387,27 @@ class TestBuildMpvCommand:
             import player.service as svc
             importlib.reload(svc)
 
-            cmd = svc._build_mpv_command(Path("/test.mp4"), audio=False)
-            assert "--no-audio" in cmd
-            assert "--ao=alsa" not in cmd
+            cmd = svc._build_mpv_command(Path("/test.mp4"), muted=False)
+            assert "--no-audio" not in cmd
+            assert "--ao=alsa" in cmd
+            assert "--mute=yes" not in cmd
+
+    def test_image_splash_still_binds_audio_device(self):
+        """Image splash used to pass --no-audio; now it must keep the ALSA device
+        bound so a later IPC loadfile for a scheduled video can play audio."""
+        with patch.dict("sys.modules", {
+            "gi": MagicMock(),
+            "gi.repository": MagicMock(),
+        }):
+            import importlib
+            import player.service as svc
+            importlib.reload(svc)
+
+            cmd = svc._build_mpv_command(Path("/opt/agora/splash/default.png"))
+            assert "--no-audio" not in cmd
+            assert "--ao=alsa" in cmd
+            assert "--mute=yes" in cmd
+            assert "--image-display-duration=inf" in cmd
 
     def test_command_with_loop(self):
         with patch.dict("sys.modules", {
@@ -1711,11 +1733,13 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file response, hwdec response, loadfile response
+        # recv: loop-file, mute (pre-load), hwdec, loadfile, mute (post-load)
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":0,"error":"success"}\n',  # hwdec
             self._make_success_response(),             # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
@@ -1726,9 +1750,10 @@ class TestLoadfileMpv:
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
         assert b'"loop-file"' in sends[0]
         assert b'"inf"' in sends[0]  # loop=True → inf
-        assert b'"hwdec"' in sends[1]
-        assert b'"drm-copy"' in sends[1]
-        assert b'"loadfile"' in sends[2]
+        assert b'"mute"' in sends[1]
+        assert b'"hwdec"' in sends[2]
+        assert b'"drm-copy"' in sends[2]
+        assert b'"loadfile"' in sends[3]
 
     @patch("player.service.socket")
     @patch("player.service.time")
@@ -1742,23 +1767,25 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file, image-display-duration, hwdec, loadfile, then 6x fullscreen toggles
+        # recv: loop-file, mute, image-display-duration, hwdec, loadfile, mute (post-load), 6x fullscreen toggles
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":0,"error":"success"}\n',  # image-display-duration
             b'{"request_id":0,"error":"success"}\n',  # hwdec
             self._make_success_response(),             # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
         ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle (off+on)
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True)
         assert result is True
 
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-        # loop-file, image-display-duration, hwdec, loadfile, then 6 fullscreen toggles
-        assert b'"image-display-duration"' in sends[1]
-        assert b'"inf"' in sends[1]
-        assert b'"hwdec"' in sends[2]
-        assert b'"no"' in sends[2]
+        # loop-file, mute, image-display-duration, hwdec, loadfile, mute (post-load), 6x fullscreen
+        assert b'"image-display-duration"' in sends[2]
+        assert b'"inf"' in sends[2]
+        assert b'"hwdec"' in sends[3]
+        assert b'"no"' in sends[3]
 
     def test_image_loadfile_triggers_fullscreen_toggle(self, mpv_player):
         """Image loadfile should toggle fullscreen 3x for DRM plane refresh."""
@@ -1775,16 +1802,19 @@ class TestLoadfileMpv:
             mock_socket_mod.SOCK_STREAM = 1
             mock_sock.recv.side_effect = [
                 b'{"request_id":0,"error":"success"}\n',  # loop-file
+                b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
                 b'{"request_id":0,"error":"success"}\n',  # image-display-duration
                 b'{"request_id":0,"error":"success"}\n',  # hwdec
                 self._make_success_response(),             # loadfile
+                b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
             ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle
 
             result = mpv_player._loadfile_mpv(Path("/tmp/test.jpg"), loop=False)
             assert result is True
 
             sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-            assert len(sends) == 10
+            # loop-file, mute, img-dur, hwdec, loadfile, mute (post-load), 6x fullscreen
+            assert len(sends) == 12
             # Filter to only fullscreen commands
             fullscreen_sends = [s for s in sends if b'"fullscreen"' in s]
             assert len(fullscreen_sends) == 6
@@ -1809,15 +1839,17 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":0,"error":"success"}\n',  # hwdec
             self._make_success_response(),             # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
 
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-        # Only 3 commands: loop-file, hwdec, loadfile — no fullscreen
-        assert len(sends) == 3
+        # 5 commands: loop-file, mute, hwdec, loadfile, mute (post-load) — no fullscreen
+        assert len(sends) == 5
         for s in sends:
             assert b'"fullscreen"' not in s
 
@@ -1837,6 +1869,7 @@ class TestLoadfileMpv:
         bad_resp = '{"event":"end-file","reason":"error"}\n'.encode()
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":0,"error":"success"}\n',  # hwdec
             bad_resp,                                   # loadfile — no success
         ]
@@ -1895,9 +1928,10 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # First recv works, second times out
+        # First recv works, mute works, then hwdec times out
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file ok
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load) ok
             real_socket.timeout("timed out"),           # hwdec times out
         ]
 
@@ -1918,8 +1952,10 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":0,"error":"success"}\n',  # hwdec
             self._make_success_response(),             # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
@@ -1969,9 +2005,11 @@ class TestStartMpvIpcFallback:
             '{"data":{"playlist_entry_id":2},"request_id":0,"error":"success"}',
         ]
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',
-            b'{"request_id":0,"error":"success"}\n',
-            ("\n".join(lines) + "\n").encode(),
+            b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":0,"error":"success"}\n',  # hwdec
+            ("\n".join(lines) + "\n").encode(),       # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
         ]
 
         with patch.object(mpv_player, "_update_current"), \
@@ -2006,6 +2044,111 @@ class TestStartMpvIpcFallback:
             # Should have started a new process
             mock_subprocess.Popen.assert_called_once()
             assert mpv_player._mpv_process == mock_popen
+            # Regression: scheduled-asset fresh spawn must be unmuted
+            # (otherwise the long-lived mpv silently plays audio-bearing
+            # videos with --mute=yes — the #113 root cause)
+            cmd = mock_subprocess.Popen.call_args[0][0]
+            assert "--mute=yes" not in cmd
+            assert "--ao=alsa" in cmd
+
+
+# ── mute policy (issue #113: no audio after splash) ──
+
+
+class TestMutePolicy:
+    """Scheduled assets must play unmuted; splash must always be muted.
+
+    This ensures the long-lived mpv process is launched with the ALSA audio
+    device bound and that mute state is toggled via IPC across content swaps.
+    """
+
+    @patch("player.service.socket")
+    @patch("player.service.time")
+    def test_loadfile_for_scheduled_asset_sets_mute_false(self, mock_time, mock_socket_mod, mpv_player):
+        """_loadfile_mpv(muted=False) must send set_property mute false to running mpv."""
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mpv_player._mpv_process = mock_proc
+
+        mock_sock = MagicMock()
+        mock_socket_mod.socket.return_value = mock_sock
+        mock_socket_mod.AF_UNIX = 1
+        mock_socket_mod.SOCK_STREAM = 1
+        mock_sock.recv.side_effect = [
+            b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":0,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+        ]
+
+        result = mpv_player._loadfile_mpv(Path("/tmp/video.mp4"), loop=True, muted=False)
+        assert result is True
+
+        sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
+        mute_sends = [s for s in sends if b'"mute"' in s]
+        assert len(mute_sends) >= 2, "expected mute set before and after loadfile"
+        for s in mute_sends:
+            assert b"false" in s or b"False" in s, f"expected mute=false, got {s!r}"
+
+    @patch("player.service.socket")
+    @patch("player.service.time")
+    def test_loadfile_for_splash_sets_mute_true(self, mock_time, mock_socket_mod, mpv_player):
+        """_loadfile_mpv(muted=True) must send set_property mute true to running mpv."""
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mpv_player._mpv_process = mock_proc
+
+        mock_sock = MagicMock()
+        mock_socket_mod.socket.return_value = mock_sock
+        mock_socket_mod.AF_UNIX = 1
+        mock_socket_mod.SOCK_STREAM = 1
+        mock_sock.recv.side_effect = [
+            b'{"request_id":0,"error":"success"}\n',  # loop-file
+            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":0,"error":"success"}\n',  # image-display-duration
+            b'{"request_id":0,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
+            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+        ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # fullscreen toggles
+
+        result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True, muted=True)
+        assert result is True
+
+        sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
+        mute_sends = [s for s in sends if b'"mute"' in s]
+        assert len(mute_sends) >= 2, "expected mute set before and after loadfile"
+        for s in mute_sends:
+            assert b"true" in s or b"True" in s, f"expected mute=true, got {s!r}"
+
+    def test_show_splash_fresh_spawn_is_muted(self, mpv_player, tmp_path):
+        """When IPC fails, splash must be spawned with --mute=yes and --ao=alsa."""
+        # Set up a fake splash asset
+        splash_dir = tmp_path / "splash"
+        splash_dir.mkdir()
+        splash = splash_dir / "default.png"
+        splash.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        mpv_player._mpv_process = None  # No running mpv → IPC fails → fresh spawn
+        mpv_player._player_backend = "mpv"
+
+        with patch.object(mpv_player, "_find_splash", return_value=splash), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_quit_plymouth"), \
+             patch.object(mpv_player, "_stop_cage"), \
+             patch("player.service.subprocess") as mock_subprocess:
+            mock_popen = MagicMock()
+            mock_popen.pid = 999
+            mock_subprocess.Popen.return_value = mock_popen
+
+            mpv_player._show_splash()
+
+            mock_subprocess.Popen.assert_called_once()
+            cmd = mock_subprocess.Popen.call_args[0][0]
+            assert "--mute=yes" in cmd, "splash must always be muted"
+            assert "--ao=alsa" in cmd, "audio device must be bound even for splash"
+            assert any(a.startswith("--audio-device=alsa/hdmi:") for a in cmd)
 
 
 # ── _find_splash fallback chain ──

--- a/tests/test_wss_e2e.py
+++ b/tests/test_wss_e2e.py
@@ -24,11 +24,22 @@ import uvicorn
 
 
 @pytest.fixture(scope="module")
-def provision_server():
-    """Start the provision app on a local port for Playwright tests."""
-    from provision.app import app
+def provision_server(tmp_path_factory):
+    """Start the provision app on a local port for Playwright tests.
 
-    config = uvicorn.Config(app, host="127.0.0.1", port=18081, log_level="error", ws="none")
+    Isolates ``provision.app.PERSIST_DIR`` to a fresh tmp path so the
+    test run is independent of any persisted ``cms_config.json`` that
+    may exist on the developer/CI machine (e.g. from a prior provisioning
+    session). Without this, ``/api/cms/config`` leaks real state into the
+    reconfigure page and pre-checks the TLS checkbox.
+    """
+    import provision.app as provision_app
+
+    persist = tmp_path_factory.mktemp("provision_persist")
+    original_persist = provision_app.PERSIST_DIR
+    provision_app.PERSIST_DIR = persist
+
+    config = uvicorn.Config(provision_app.app, host="127.0.0.1", port=18081, log_level="error", ws="none")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -40,8 +51,11 @@ def provision_server():
         except (httpx.ConnectError, httpx.ReadTimeout):
             time.sleep(0.2)
 
-    yield "http://127.0.0.1:18081"
-    server.should_exit = True
+    try:
+        yield "http://127.0.0.1:18081"
+    finally:
+        server.should_exit = True
+        provision_app.PERSIST_DIR = original_persist
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# Fix: audio always bound at mpv launch; splash muted via IPC

Closes #113.

## Problem

On production Pi 5 (`f9f2c700f37c8b14`) the scheduled video played
without audio. The agora-player log over a 6-hour window showed exactly
one state transition for the asset:

```
mpv IPC loadfile succeeded for fafced84-…_capture.mp4
```

…meaning the content was swapped in via IPC `loadfile` on an existing
mpv process, not by spawning a fresh mpv. But the persistent mpv had
been launched earlier for the splash, and `_build_mpv_command` added
`--no-audio` whenever the initial content was an image (always true for
image splashes) **or** when the caller passed `audio=False`. Once mpv
is running without an ALSA output, **IPC cannot add one** — every
subsequent scheduled video plays silently for the life of that process.

## Fix

`player/service.py`:

- `_build_mpv_command(path, *, muted=True, loop=False)` — always append
  `--ao=alsa --audio-device=alsa/hdmi:CARD={alsa_card()},DEV=0`, so the
  audio output is open and ready for any later IPC `loadfile`. The
  previous `audio: bool` kwarg is replaced by `muted: bool`, which adds
  `--mute=yes` (runtime-toggleable). `--no-audio` is no longer emitted
  anywhere.
- `_loadfile_mpv(path, *, loop=False, muted=True)` — new `muted` kwarg.
  Sends `set_property mute …` both **before** the `loadfile` (so the
  swap lands with the right state) and **after** it (mpv can reset
  per-file audio properties during `loadfile replace`).
- `_start_mpv(...)` — scheduled-asset path now calls
  `_loadfile_mpv(..., muted=False)` on the IPC fast-path and
  `_build_mpv_command(..., muted=False)` on the fresh-spawn fallback.
  Regression assertion added to the test.
- `_show_splash(...)` — both the IPC fast-path and the fresh-spawn
  fallback now always set `muted=True`, including for video splashes
  (per the tightened policy: only scheduled assets may produce audio).

## Policy

- Splash: always muted (image or video).
- Scheduled assets: always unmuted.
- Per-schedule-item mute is explicitly **out of scope** — planned but
  not yet shipping.

## Tests

`tests/test_player_service.py` updated and extended:

- `TestBuildMpvCommand` rewritten — default spawn now binds ALSA and is
  muted; `muted=False` spawn is unmuted with ALSA bound; image splash
  spawn keeps ALSA bound (regression guard for #113).
- All existing `_loadfile_mpv` tests updated to account for the two
  new `set_property mute …` IPC roundtrips (pre-load + post-load).
- New `TestMutePolicy` class:
  - `test_loadfile_for_scheduled_asset_sets_mute_false`
  - `test_loadfile_for_splash_sets_mute_true`
  - `test_show_splash_fresh_spawn_is_muted`
- New regression assertion in `test_start_mpv_falls_back_to_restart`:
  fresh-spawn for a scheduled asset must not contain `--mute=yes` and
  must contain `--ao=alsa`.

`tests/test_player_service.py` now: **105 passed**. Full suite unchanged
in green/red ratio — pre-existing unrelated Playwright WSS E2E failures
are not in scope.

## Verification path once deployed

1. Reboot Pi 5 → splash spawns muted + audio device bound.
2. CMS pushes scheduled video → `_loadfile_mpv` sends `mute=false`
   before and after `loadfile replace` → audio plays.
3. Scheduled item ends → `_show_splash` → `loadfile` back to splash
   with `mute=true` → silent again.
