### PR TITLE
fix(#178): reliable HDMI display detection via per-board probe strategy

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -512,6 +512,7 @@ class CMSClient:
             "ssh_enabled": _is_ssh_enabled(),
             "local_api_enabled": _is_local_api_enabled(self.settings.persist_dir),
             "display_connected": current_data.get("display_connected"),
+            "display_ports": current_data.get("display_ports"),
         }
         await self._ws.send(json.dumps(status_msg))
 

--- a/hardware/__init__.py
+++ b/hardware/__init__.py
@@ -1,0 +1,6 @@
+"""Agora hardware abstraction layer.
+
+Groups hardware-specific probing logic (display detection, future expansions)
+behind per-board strategies. Board detection itself remains in ``shared.board``;
+this package consumes it.
+"""

--- a/hardware/display/__init__.py
+++ b/hardware/display/__init__.py
@@ -1,0 +1,27 @@
+"""Per-board HDMI display presence detection.
+
+Selects the most reliable probe strategy for the current board:
+
+* **Pi 5 / CM5** — ``/sys/class/drm/card*-HDMI-A-N/status`` (HPD IRQ driven,
+  reliable even with ``hdmi_force_hotplug=1`` set).
+* **Pi Zero 2 W / Pi 3 / Pi 4** — I²C EDID read at ``0x50`` on the HDMI DDC
+  bus.  Sysfs ``status`` is unreliable on the older VC4 HDMI driver when
+  ``hdmi_force_hotplug=1`` is set (it stays permanently ``connected``).
+* **Unknown boards** — ``NullProbe`` returns ``None`` for every port.
+
+Probes report **all** HDMI ports on the board so callers can expose richer
+UI later (e.g. "nothing on HDMI-0 but HDMI-1 is plugged in").  The primary
+port is always index 0 in the returned list.
+"""
+from __future__ import annotations
+
+from .base import DisplayProbe, PortStatus
+from .factory import build_probe, get_display_probe, reset_cached_probe
+
+__all__ = [
+    "DisplayProbe",
+    "PortStatus",
+    "build_probe",
+    "get_display_probe",
+    "reset_cached_probe",
+]

--- a/hardware/display/base.py
+++ b/hardware/display/base.py
@@ -1,0 +1,32 @@
+"""Abstract base class for HDMI display presence probes."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+# Re-export the canonical wire-level PortStatus model so hardware probes and
+# CurrentState share a single type (avoids pydantic/dataclass coercion
+# errors and keeps the wire schema in one place).
+from shared.models import PortStatus
+
+__all__ = ["DisplayProbe", "PortStatus"]
+
+
+class DisplayProbe(ABC):
+    """Strategy for detecting whether HDMI displays are connected.
+
+    ``PortStatus.connected`` is tri-state:
+
+    * ``True``  — display detected
+    * ``False`` — confirmed nothing attached
+    * ``None``  — could not determine (probe unavailable, transient error)
+    """
+
+    @abstractmethod
+    def probe_all(self) -> list[PortStatus]:
+        """Probe every HDMI port on the board.
+
+        Returns a list of :class:`PortStatus` in board port order (port 0 first).
+        The list length equals the board's HDMI port count; it is never empty
+        on a board with ports declared.  Individual ports may carry
+        ``connected=None`` if that port can't be determined.
+        """

--- a/hardware/display/drm_sysfs.py
+++ b/hardware/display/drm_sysfs.py
@@ -1,0 +1,79 @@
+"""DRM sysfs based HDMI probe (primary for Pi 5 / CM 5).
+
+Reads ``/sys/class/drm/card*-{drm_connector}/status`` for each HDMI port.
+The file contains ``connected``, ``disconnected`` or ``unknown``.  On Pi 5
+/ CM 5 this is HPD-IRQ driven and reliable, even when
+``hdmi_force_hotplug=1`` is set in ``/boot/firmware/config.txt`` (the RP1
+chip handles hot-plug natively and ignores the flag).
+
+On older Pis (VC4 HDMI driver) the same file will frequently report
+``connected`` regardless of physical state — use :mod:`i2c_edid` instead on
+those boards.
+"""
+from __future__ import annotations
+
+import glob
+import logging
+from pathlib import Path
+from typing import Optional
+
+from shared.board import HdmiPort
+
+from .base import DisplayProbe, PortStatus
+
+logger = logging.getLogger("agora.hardware.display.drm_sysfs")
+
+_SYSFS_ROOT = Path("/sys/class/drm")
+
+
+def _resolve_status_path(connector: str) -> Optional[Path]:
+    """Find the sysfs ``status`` file for a DRM connector name.
+
+    Matches ``/sys/class/drm/card*-{connector}/status``.  Returns ``None`` if
+    no such file exists on this kernel (e.g. a Pi without DRM KMS).
+    """
+    pattern = str(_SYSFS_ROOT / f"card*-{connector}" / "status")
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        return None
+    return Path(matches[0])
+
+
+def _read_status(path: Path) -> Optional[bool]:
+    """Read a DRM connector ``status`` file, mapping text to tri-state bool."""
+    try:
+        value = path.read_text().strip().lower()
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        logger.debug("DRM sysfs read failed for %s: %s", path, e)
+        return None
+    if value == "connected":
+        return True
+    if value == "disconnected":
+        return False
+    return None
+
+
+class DrmSysfsDisplayProbe(DisplayProbe):
+    """HDMI presence via ``/sys/class/drm/card*-{connector}/status``.
+
+    Each :class:`HdmiPort` passed in must carry a ``drm_connector`` value
+    (e.g. ``"HDMI-A-1"``).  Ports with no ``drm_connector`` or a missing
+    sysfs file report ``connected=None``.
+    """
+
+    def __init__(self, ports: list[HdmiPort]):
+        self._ports = list(ports)
+
+    def probe_all(self) -> list[PortStatus]:
+        out: list[PortStatus] = []
+        for port in self._ports:
+            connector = port.drm_connector
+            if not connector:
+                out.append(PortStatus(name=port.name, connected=None))
+                continue
+            path = _resolve_status_path(connector)
+            if path is None:
+                out.append(PortStatus(name=port.name, connected=None))
+                continue
+            out.append(PortStatus(name=port.name, connected=_read_status(path)))
+        return out

--- a/hardware/display/factory.py
+++ b/hardware/display/factory.py
@@ -1,0 +1,52 @@
+"""Board-aware factory for :class:`DisplayProbe` instances."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from shared.board import Board, HdmiPort, get_board, get_hdmi_ports
+
+from .base import DisplayProbe
+from .drm_sysfs import DrmSysfsDisplayProbe
+from .i2c_edid import I2cEdidDisplayProbe
+from .null import NullDisplayProbe
+
+logger = logging.getLogger("agora.hardware.display")
+
+_cached_probe: Optional[DisplayProbe] = None
+
+
+def build_probe(board: Board, ports: list[HdmiPort]) -> DisplayProbe:
+    """Return the best :class:`DisplayProbe` for *board* and *ports*.
+
+    * Pi 5 / CM 5 → :class:`DrmSysfsDisplayProbe`
+    * Pi Zero 2 W / Pi 3 / Pi 4 → :class:`I2cEdidDisplayProbe`
+    * Unknown → :class:`NullDisplayProbe`
+    """
+    if board is Board.PI_5:
+        return DrmSysfsDisplayProbe(ports)
+    if board in (Board.PI_4, Board.ZERO_2W):
+        return I2cEdidDisplayProbe(ports)
+    return NullDisplayProbe(ports)
+
+
+def get_display_probe() -> DisplayProbe:
+    """Return a cached :class:`DisplayProbe` for the current board."""
+    global _cached_probe
+    if _cached_probe is None:
+        board = get_board()
+        ports = get_hdmi_ports()
+        _cached_probe = build_probe(board, ports)
+        logger.info(
+            "Display probe: %s (board=%s, ports=%s)",
+            type(_cached_probe).__name__,
+            board.value,
+            [p.name for p in ports],
+        )
+    return _cached_probe
+
+
+def reset_cached_probe() -> None:
+    """Forget the cached probe instance (test-only helper)."""
+    global _cached_probe
+    _cached_probe = None

--- a/hardware/display/i2c_edid.py
+++ b/hardware/display/i2c_edid.py
@@ -1,0 +1,96 @@
+"""I²C EDID probe (primary for Pi Zero 2 W / Pi 3 / Pi 4).
+
+Opens the per-port HDMI DDC bus and attempts to talk to the EDID EEPROM at
+address ``0x50``.  A successful 1-byte read means a display is attached
+(the EEPROM ACKed).  ``EIO`` (errno 5) means no device is answering
+— interpreted as disconnected.
+
+Requires the ``i2c-dev`` kernel module to be loaded so ``/dev/i2c-N``
+exists.  :class:`I2cEdidDisplayProbe` attempts ``modprobe i2c-dev`` once at
+construction time; failure (e.g. module missing, not running as root) is
+logged at debug level and the probe will return ``None`` for any ports
+whose bus device is absent.
+
+This matches the behaviour of the legacy ``PlayerService._is_display_
+connected`` it replaces, generalised to multiple ports.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from typing import Optional
+
+from shared.board import HdmiPort
+
+from .base import DisplayProbe, PortStatus
+
+try:  # pragma: no cover - Windows dev environments have no fcntl
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None  # type: ignore[assignment]
+
+logger = logging.getLogger("agora.hardware.display.i2c_edid")
+
+_I2C_SLAVE = 0x0703
+_EDID_ADDR = 0x50
+
+
+def _try_load_i2c_dev() -> None:
+    """Best-effort ``modprobe i2c-dev``.
+
+    On provisioned Agora images this module is loaded via
+    ``/etc/modules-load.d``; this call is a safety net for fresh images /
+    dev environments.  Non-root or module-missing failures are silently
+    ignored.
+    """
+    try:
+        subprocess.run(
+            ["modprobe", "i2c-dev"],
+            check=False,
+            timeout=3,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError) as e:
+        logger.debug("modprobe i2c-dev failed: %s", e)
+
+
+def _probe_bus(i2c_bus: str) -> Optional[bool]:
+    """Probe a single HDMI DDC bus for an EDID EEPROM at 0x50.
+
+    Returns ``True`` on ACK+read, ``False`` on EIO NAK, ``None`` if the bus
+    device cannot even be opened (i.e. i2c-dev not loaded or bus absent),
+    or if this platform has no ``fcntl`` (e.g. running on Windows CI for
+    unit tests).
+    """
+    if _fcntl is None:
+        return None
+    try:
+        fd = os.open(i2c_bus, os.O_RDWR)
+    except OSError:
+        return None
+    try:
+        try:
+            _fcntl.ioctl(fd, _I2C_SLAVE, _EDID_ADDR)
+            os.read(fd, 1)
+            return True
+        except OSError:
+            return False
+    finally:
+        os.close(fd)
+
+
+class I2cEdidDisplayProbe(DisplayProbe):
+    """HDMI presence via EDID EEPROM probe over I²C DDC."""
+
+    def __init__(self, ports: list[HdmiPort], *, auto_load_module: bool = True):
+        self._ports = list(ports)
+        if auto_load_module:
+            _try_load_i2c_dev()
+
+    def probe_all(self) -> list[PortStatus]:
+        return [
+            PortStatus(name=p.name, connected=_probe_bus(p.i2c_bus))
+            for p in self._ports
+        ]

--- a/hardware/display/null.py
+++ b/hardware/display/null.py
@@ -1,0 +1,20 @@
+"""Null display probe for unknown/unsupported boards.
+
+Returns ``connected=None`` for every port.  Used as the final fallback when
+neither the DRM sysfs nor the I²C EDID strategies apply.
+"""
+from __future__ import annotations
+
+from shared.board import HdmiPort
+
+from .base import DisplayProbe, PortStatus
+
+
+class NullDisplayProbe(DisplayProbe):
+    """Always reports :class:`PortStatus` with ``connected=None``."""
+
+    def __init__(self, ports: list[HdmiPort]):
+        self._ports = list(ports)
+
+    def probe_all(self) -> list[PortStatus]:
+        return [PortStatus(name=p.name, connected=None) for p in self._ports]

--- a/player/service.py
+++ b/player/service.py
@@ -17,7 +17,8 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib, Gst  # noqa: E402
 
-from shared.board import Board, alsa_card, get_board, get_i2c_bus, player_backend, supported_codecs  # noqa: E402
+from shared.board import Board, alsa_card, get_board, player_backend, supported_codecs  # noqa: E402
+from hardware.display import PortStatus, get_display_probe  # noqa: E402
 from shared.models import CurrentState, DesiredState, PlaybackMode  # noqa: E402
 from shared.state import read_state, write_state  # noqa: E402
 
@@ -156,10 +157,6 @@ class AgoraPlayer:
         "imagefreeze ! kmssink driver-name=vc4 sync=false"
     )
 
-    # HDMI display detection via DDC/EDID I2C probe
-    _EDID_ADDR = 0x50
-    _I2C_SLAVE = 0x0703  # ioctl request code
-
     DEFAULT_SPLASH_CONFIG = "splash/default.png"
 
     def __init__(self, base_path: str = "/opt/agora"):
@@ -172,7 +169,7 @@ class AgoraPlayer:
         self.splash_config_path = self.persist_dir / "splash"
 
         self._board = get_board()
-        self._i2c_bus = get_i2c_bus()
+        self._display_probe = get_display_probe()
         self._player_backend = player_backend()
 
         self.pipeline: Optional[Gst.Pipeline] = None
@@ -188,6 +185,11 @@ class AgoraPlayer:
         self._pending_error: Optional[str] = None
         self._plymouth_quit: bool = False
         self._running = True
+        # Debounce state for display port connection changes (issue #178).
+        # Maps port name -> (candidate_new_value, consecutive_count).
+        # Only flips between True<->False require confirmation; transitions
+        # involving None (indeterminate) commit immediately.
+        self._display_pending: dict[str, tuple[Optional[bool], int]] = {}
 
         Gst.init(None)
 
@@ -743,29 +745,52 @@ class AgoraPlayer:
         combined = f"{raw} {debug}"
         return any(m in combined for m in cls._DISPLAY_ERROR_MARKERS)
 
-    @classmethod
-    def _is_display_connected(cls) -> Optional[bool]:
-        """Probe the HDMI DDC/EDID I2C bus to detect a connected display.
+    def _probe_display(self) -> tuple[Optional[bool], list[PortStatus]]:
+        """Probe all HDMI ports via the board-specific display probe.
 
-        Reads one byte from the EDID EEPROM at address 0x50 on the board's
-        primary HDMI I2C bus.  Returns True if the device responds (display
-        connected), False if it fails with an I/O error (no display), or
-        None if the I2C bus is not available.
+        Returns ``(primary_connected, all_ports)`` where ``primary_connected``
+        is the ``connected`` value for port 0 (or ``None`` if the board has
+        no ports or probing failed for it).
         """
-        i2c_bus = get_i2c_bus()
         try:
-            fd = os.open(i2c_bus, os.O_RDWR)
-        except OSError:
-            return None
-        try:
-            import fcntl
-            fcntl.ioctl(fd, cls._I2C_SLAVE, cls._EDID_ADDR)
-            os.read(fd, 1)
-            return True
-        except OSError:
-            return False
-        finally:
-            os.close(fd)
+            ports = self._display_probe.probe_all()
+        except Exception:
+            logger.debug("Display probe failed", exc_info=True)
+            return None, []
+        primary = ports[0].connected if ports else None
+        return primary, ports
+
+    def _debounce_display(
+        self, ports: list[PortStatus], previous: Optional[list[PortStatus]]
+    ) -> list[PortStatus]:
+        """Require two consecutive matching probes before flipping True<->False.
+
+        Transitions involving ``None`` (indeterminate) commit immediately.
+        Only applies in periodic polling; explicit ``_update_current`` calls
+        pass the raw probe result through.
+        """
+        prev_by_name: dict[str, Optional[bool]] = {}
+        if previous:
+            for p in previous:
+                prev_by_name[p.name] = p.connected
+        committed: list[PortStatus] = []
+        for port in ports:
+            prev = prev_by_name.get(port.name)
+            new = port.connected
+            if new == prev or new is None or prev is None:
+                # Instantaneous commit: no change, or a None endpoint.
+                self._display_pending.pop(port.name, None)
+                committed.append(port)
+                continue
+            # True<->False flip: require a second matching reading.
+            pending = self._display_pending.get(port.name)
+            if pending and pending[0] == new:
+                self._display_pending.pop(port.name, None)
+                committed.append(port)
+            else:
+                self._display_pending[port.name] = (new, 1)
+                committed.append(PortStatus(name=port.name, connected=prev))
+        return committed
 
     _RETRY_DELAY_MAX = 15
 
@@ -880,6 +905,7 @@ class AgoraPlayer:
             except Exception:
                 pipeline_state = "ERROR"
 
+        primary_connected, ports = self._probe_display()
         state = CurrentState(
             mode=mode,
             asset=asset,
@@ -889,7 +915,8 @@ class AgoraPlayer:
             started_at=started_at,
             playback_position_ms=self._query_position_ms(),
             pipeline_state=pipeline_state,
-            display_connected=self._is_display_connected(),
+            display_connected=primary_connected,
+            display_ports=ports or None,
             error=error,
         )
         write_state(self.current_path, state)
@@ -910,15 +937,26 @@ class AgoraPlayer:
         try:
             current = read_state(self.current_path, CurrentState)
             pos = self._query_position_ms()
-            display = self._is_display_connected()
+            _, raw_ports = self._probe_display()
+            ports = self._debounce_display(raw_ports, current.display_ports)
+            primary = ports[0].connected if ports else None
             changed = False
             if pos is not None and current.playback_position_ms != pos:
                 current.playback_position_ms = pos
                 changed = True
-            if current.display_connected != display:
-                if display is not None and current.display_connected is not None:
-                    logger.warning("Display %s", "connected" if display else "disconnected")
-                current.display_connected = display
+            if current.display_connected != primary:
+                if primary is not None and current.display_connected is not None:
+                    logger.warning(
+                        "Display %s",
+                        "connected" if primary else "disconnected",
+                    )
+                current.display_connected = primary
+                changed = True
+            old_ports = current.display_ports or []
+            old_map = {p.name: p.connected for p in old_ports}
+            new_map = {p.name: p.connected for p in ports}
+            if old_map != new_map:
+                current.display_ports = ports or None
                 changed = True
             if changed:
                 current.updated_at = datetime.now(timezone.utc)

--- a/shared/board.py
+++ b/shared/board.py
@@ -24,15 +24,23 @@ class Board(str, enum.Enum):
 
 @dataclass(frozen=True)
 class HdmiPort:
-    """I2C bus path for an HDMI port."""
-    name: str       # e.g. "HDMI-0", "HDMI-1"
-    i2c_bus: str    # e.g. "/dev/i2c-2"
+    """HDMI port metadata: I²C DDC bus path and DRM connector name.
+
+    ``drm_connector`` is the name used by the kernel DRM/KMS subsystem
+    (e.g. ``HDMI-A-1``, ``HDMI-A-2``).  It corresponds to
+    ``/sys/class/drm/card*-{drm_connector}/``.  Not all boards expose a
+    DRM sysfs status that's reliable — see ``hardware.display`` for the
+    board-aware probe selection.
+    """
+    name: str               # e.g. "HDMI-0", "HDMI-1"
+    i2c_bus: str            # e.g. "/dev/i2c-2"
+    drm_connector: str = ""  # e.g. "HDMI-A-1"
 
 
 # Per-board hardware capabilities
 _BOARD_CONFIG: dict[Board, dict] = {
     Board.ZERO_2W: {
-        "hdmi_ports": [HdmiPort("HDMI-0", "/dev/i2c-2")],
+        "hdmi_ports": [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")],
         "codecs": ["h264"],
         "has_wifi": True,
         "has_ethernet": False,
@@ -42,8 +50,8 @@ _BOARD_CONFIG: dict[Board, dict] = {
     },
     Board.PI_4: {
         "hdmi_ports": [
-            HdmiPort("HDMI-0", "/dev/i2c-1"),
-            HdmiPort("HDMI-1", "/dev/i2c-10"),
+            HdmiPort("HDMI-0", "/dev/i2c-1", "HDMI-A-1"),
+            HdmiPort("HDMI-1", "/dev/i2c-10", "HDMI-A-2"),
         ],
         "codecs": ["hevc", "h264"],
         "has_wifi": True,
@@ -54,8 +62,8 @@ _BOARD_CONFIG: dict[Board, dict] = {
     },
     Board.PI_5: {
         "hdmi_ports": [
-            HdmiPort("HDMI-0", "/dev/i2c-3"),
-            HdmiPort("HDMI-1", "/dev/i2c-4"),
+            HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1"),
+            HdmiPort("HDMI-1", "/dev/i2c-4", "HDMI-A-2"),
         ],
         "codecs": ["hevc"],
         "has_wifi": False,  # CM5 has no WiFi; Pi 5 board does — detected at runtime
@@ -68,7 +76,7 @@ _BOARD_CONFIG: dict[Board, dict] = {
 
 # Fallback for unknown boards
 _UNKNOWN_CONFIG: dict = {
-    "hdmi_ports": [HdmiPort("HDMI-0", "/dev/i2c-2")],
+    "hdmi_ports": [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")],
     "codecs": ["h264"],
     "has_wifi": True,
     "has_ethernet": False,
@@ -129,6 +137,15 @@ def get_i2c_bus() -> str:
 
 def get_i2c_buses() -> list[HdmiPort]:
     """Return all HDMI port I2C bus mappings for the current board."""
+    return list(_config()["hdmi_ports"])
+
+
+def get_hdmi_ports() -> list[HdmiPort]:
+    """Return all :class:`HdmiPort` entries for the current board.
+
+    Alias of :func:`get_i2c_buses` with a name that reflects post-#178
+    usage (the port carries I²C *and* DRM connector metadata).
+    """
     return list(_config()["hdmi_ports"])
 
 

--- a/shared/models.py
+++ b/shared/models.py
@@ -24,6 +24,16 @@ class DesiredState(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+class PortStatus(BaseModel):
+    """Connection status of a single HDMI port.
+
+    ``connected`` is tri-state: ``True`` (display attached),
+    ``False`` (nothing attached), or ``None`` (status not determinable).
+    """
+    name: str
+    connected: Optional[bool] = None
+
+
 class CurrentState(BaseModel):
     mode: PlaybackMode = PlaybackMode.SPLASH
     asset: Optional[str] = None
@@ -34,6 +44,7 @@ class CurrentState(BaseModel):
     playback_position_ms: Optional[int] = None
     pipeline_state: str = "NULL"
     display_connected: Optional[bool] = None
+    display_ports: Optional[list[PortStatus]] = None
     error: Optional[str] = None
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -105,21 +105,21 @@ class TestI2CBus:
         with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi Zero 2 W"):
             buses = get_i2c_buses()
             assert len(buses) == 1
-            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-2")
+            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")
 
     def test_pi_4_dual_ports(self):
         with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
             buses = get_i2c_buses()
             assert len(buses) == 2
-            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-1")
-            assert buses[1] == HdmiPort("HDMI-1", "/dev/i2c-10")
+            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-1", "HDMI-A-1")
+            assert buses[1] == HdmiPort("HDMI-1", "/dev/i2c-10", "HDMI-A-2")
 
     def test_pi_5_dual_ports(self):
         with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 5"):
             buses = get_i2c_buses()
             assert len(buses) == 2
-            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-3")
-            assert buses[1] == HdmiPort("HDMI-1", "/dev/i2c-4")
+            assert buses[0] == HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")
+            assert buses[1] == HdmiPort("HDMI-1", "/dev/i2c-4", "HDMI-A-2")
 
 
 # ── HDMI port count ──

--- a/tests/test_hardware_display.py
+++ b/tests/test_hardware_display.py
@@ -1,0 +1,245 @@
+"""Unit tests for the per-board HDMI :class:`DisplayProbe` strategies (#178)."""
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hardware.display import PortStatus, build_probe
+from hardware.display.drm_sysfs import DrmSysfsDisplayProbe
+from hardware.display.i2c_edid import I2cEdidDisplayProbe
+from hardware.display.null import NullDisplayProbe
+from shared.board import Board, HdmiPort
+
+
+# ── Factory ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "board,expected_cls",
+    [
+        (Board.PI_5, DrmSysfsDisplayProbe),
+        (Board.PI_4, I2cEdidDisplayProbe),
+        (Board.ZERO_2W, I2cEdidDisplayProbe),
+        (Board.UNKNOWN, NullDisplayProbe),
+    ],
+)
+def test_build_probe_picks_right_strategy(board, expected_cls):
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    # Prevent I2cEdidDisplayProbe's constructor from actually modprobing.
+    with patch("hardware.display.i2c_edid._try_load_i2c_dev"):
+        probe = build_probe(board, ports)
+    assert isinstance(probe, expected_cls)
+
+
+# ── NullDisplayProbe ────────────────────────────────────────────────
+
+
+def test_null_probe_returns_none_for_all_ports():
+    ports = [
+        HdmiPort("HDMI-0", "/dev/i2c-1", "HDMI-A-1"),
+        HdmiPort("HDMI-1", "/dev/i2c-10", "HDMI-A-2"),
+    ]
+    probe = NullDisplayProbe(ports)
+    result = probe.probe_all()
+    assert result == [
+        PortStatus(name="HDMI-0", connected=None),
+        PortStatus(name="HDMI-1", connected=None),
+    ]
+
+
+# ── DrmSysfsDisplayProbe ────────────────────────────────────────────
+
+
+def _drm_probe(ports):
+    return DrmSysfsDisplayProbe(ports)
+
+
+def test_drm_sysfs_connected(tmp_path):
+    card_dir = tmp_path / "card1-HDMI-A-1"
+    card_dir.mkdir()
+    (card_dir / "status").write_text("connected\n")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=True)]
+
+
+def test_drm_sysfs_disconnected(tmp_path):
+    card_dir = tmp_path / "card1-HDMI-A-1"
+    card_dir.mkdir()
+    (card_dir / "status").write_text("disconnected\n")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=False)]
+
+
+def test_drm_sysfs_unknown_status_is_none(tmp_path):
+    card_dir = tmp_path / "card1-HDMI-A-1"
+    card_dir.mkdir()
+    (card_dir / "status").write_text("unknown\n")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=None)]
+
+
+def test_drm_sysfs_file_missing_returns_none(tmp_path):
+    # No card dir at all.
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=None)]
+
+
+def test_drm_sysfs_empty_connector_returns_none(tmp_path):
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=None)]
+
+
+def test_drm_sysfs_multiple_ports(tmp_path):
+    (tmp_path / "card1-HDMI-A-1").mkdir()
+    (tmp_path / "card1-HDMI-A-1" / "status").write_text("connected")
+    (tmp_path / "card1-HDMI-A-2").mkdir()
+    (tmp_path / "card1-HDMI-A-2" / "status").write_text("disconnected")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([
+            HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1"),
+            HdmiPort("HDMI-1", "/dev/i2c-4", "HDMI-A-2"),
+        ])
+        assert probe.probe_all() == [
+            PortStatus(name="HDMI-0", connected=True),
+            PortStatus(name="HDMI-1", connected=False),
+        ]
+
+
+# ── I2cEdidDisplayProbe ─────────────────────────────────────────────
+
+
+def _i2c_probe(ports):
+    with patch("hardware.display.i2c_edid._try_load_i2c_dev"):
+        return I2cEdidDisplayProbe(ports)
+
+
+def test_i2c_edid_connected():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    fake_fcntl = MagicMock()
+    with patch("hardware.display.i2c_edid._fcntl", fake_fcntl), \
+         patch("hardware.display.i2c_edid.os.open", return_value=5) as mock_open, \
+         patch("hardware.display.i2c_edid.os.read", return_value=b"\x00") as mock_read, \
+         patch("hardware.display.i2c_edid.os.close") as mock_close:
+        probe = _i2c_probe(ports)
+        result = probe.probe_all()
+    assert result == [PortStatus(name="HDMI-0", connected=True)]
+    mock_open.assert_called_once_with("/dev/i2c-2", 2)  # O_RDWR
+    fake_fcntl.ioctl.assert_called_once_with(5, 0x0703, 0x50)
+    mock_read.assert_called_once_with(5, 1)
+    mock_close.assert_called_once_with(5)
+
+
+def test_i2c_edid_disconnected_eio():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    fake_fcntl = MagicMock()
+    with patch("hardware.display.i2c_edid._fcntl", fake_fcntl), \
+         patch("hardware.display.i2c_edid.os.open", return_value=5), \
+         patch("hardware.display.i2c_edid.os.read",
+               side_effect=OSError(errno.EIO, "I/O error")), \
+         patch("hardware.display.i2c_edid.os.close") as mock_close:
+        probe = _i2c_probe(ports)
+        result = probe.probe_all()
+    assert result == [PortStatus(name="HDMI-0", connected=False)]
+    mock_close.assert_called_once_with(5)
+
+
+def test_i2c_edid_ioctl_error_disconnected():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    fake_fcntl = MagicMock()
+    fake_fcntl.ioctl.side_effect = OSError(errno.EINVAL, "Invalid argument")
+    with patch("hardware.display.i2c_edid._fcntl", fake_fcntl), \
+         patch("hardware.display.i2c_edid.os.open", return_value=5), \
+         patch("hardware.display.i2c_edid.os.close") as mock_close:
+        probe = _i2c_probe(ports)
+        result = probe.probe_all()
+    assert result == [PortStatus(name="HDMI-0", connected=False)]
+    mock_close.assert_called_once_with(5)
+
+
+def test_i2c_edid_bus_missing_returns_none():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    fake_fcntl = MagicMock()
+    with patch("hardware.display.i2c_edid._fcntl", fake_fcntl), \
+         patch("hardware.display.i2c_edid.os.open",
+               side_effect=OSError(errno.ENOENT, "No such file or directory")):
+        probe = _i2c_probe(ports)
+        result = probe.probe_all()
+    assert result == [PortStatus(name="HDMI-0", connected=None)]
+
+
+def test_i2c_edid_returns_none_when_fcntl_unavailable():
+    """On platforms without fcntl (e.g. Windows) probe returns None."""
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    with patch("hardware.display.i2c_edid._fcntl", None):
+        probe = _i2c_probe(ports)
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=None)]
+
+
+def test_i2c_edid_attempts_modprobe_by_default():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    with patch("hardware.display.i2c_edid._try_load_i2c_dev") as mock_load:
+        I2cEdidDisplayProbe(ports)
+    mock_load.assert_called_once()
+
+
+def test_i2c_edid_skips_modprobe_when_disabled():
+    ports = [HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]
+    with patch("hardware.display.i2c_edid._try_load_i2c_dev") as mock_load:
+        I2cEdidDisplayProbe(ports, auto_load_module=False)
+    mock_load.assert_not_called()
+
+
+def test_i2c_edid_multiple_ports():
+    ports = [
+        HdmiPort("HDMI-0", "/dev/i2c-1", "HDMI-A-1"),
+        HdmiPort("HDMI-1", "/dev/i2c-10", "HDMI-A-2"),
+    ]
+
+    # Port 0 open returns fd=5 (connected), port 1 open raises ENOENT (bus missing).
+    open_calls = {"/dev/i2c-1": 5, "/dev/i2c-10": OSError(errno.ENOENT, "nope")}
+
+    def fake_open(path, flags):
+        value = open_calls[path]
+        if isinstance(value, OSError):
+            raise value
+        return value
+
+    fake_fcntl = MagicMock()
+    with patch("hardware.display.i2c_edid._fcntl", fake_fcntl), \
+         patch("hardware.display.i2c_edid.os.open", side_effect=fake_open), \
+         patch("hardware.display.i2c_edid.os.read", return_value=b"\x00"), \
+         patch("hardware.display.i2c_edid.os.close"):
+        probe = _i2c_probe(ports)
+        result = probe.probe_all()
+
+    assert result == [
+        PortStatus(name="HDMI-0", connected=True),
+        PortStatus(name="HDMI-1", connected=None),
+    ]
+
+
+# ── Cached factory lifecycle ────────────────────────────────────────
+
+
+def test_get_display_probe_caches_and_reset():
+    from hardware.display import factory as display_factory
+    display_factory.reset_cached_probe()
+    with patch.object(display_factory, "get_board", return_value=Board.UNKNOWN), \
+         patch.object(display_factory, "get_hdmi_ports",
+                      return_value=[HdmiPort("HDMI-0", "/dev/i2c-2", "HDMI-A-1")]):
+        probe1 = display_factory.get_display_probe()
+        probe2 = display_factory.get_display_probe()
+    assert probe1 is probe2
+    display_factory.reset_cached_probe()

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -34,8 +34,11 @@ def player():
         p._pending_error = None
         p._loops_completed = 0
         p._board = svc.Board.ZERO_2W
-        p._i2c_bus = "/dev/i2c-2"
         p._player_backend = "gstreamer"
+        # Display probe (#178): tests substitute their own via _mock_probe.
+        p._display_probe = MagicMock()
+        p._display_probe.probe_all.return_value = []
+        p._display_pending = {}
         yield p
 
 
@@ -1139,93 +1142,122 @@ class TestErrorBackoff:
 
 
 class TestDisplayDetection:
-    """Verify HDMI display detection via DDC/EDID I2C probe."""
+    """Verify HDMI display detection via the per-board :class:`DisplayProbe`."""
 
-    def test_display_connected_returns_true(self, player):
-        """Should return True when I2C read succeeds (display plugged in)."""
-        mock_fcntl = MagicMock()
-        with patch("player.service.os.open", return_value=3) as mock_open, \
-             patch.dict("sys.modules", {"fcntl": mock_fcntl}), \
-             patch("player.service.os.read", return_value=b"\x00") as mock_read, \
-             patch("player.service.os.close") as mock_close:
-            result = player._is_display_connected()
-            assert result is True
-            mock_open.assert_called_once_with("/dev/i2c-2", 2)  # O_RDWR = 2
-            mock_fcntl.ioctl.assert_called_once_with(3, 0x0703, 0x50)
-            mock_read.assert_called_once_with(3, 1)
-            mock_close.assert_called_once_with(3)
+    @staticmethod
+    def _mock_probe(player, ports):
+        """Make the player's display probe return a fixed port list."""
+        from hardware.display import PortStatus
 
-    def test_display_disconnected_returns_false(self, player):
-        """Should return False when I2C read fails with OSError (no display)."""
-        mock_fcntl = MagicMock()
-        with patch("player.service.os.open", return_value=3), \
-             patch.dict("sys.modules", {"fcntl": mock_fcntl}), \
-             patch("player.service.os.read", side_effect=OSError(5, "I/O error")), \
-             patch("player.service.os.close") as mock_close:
-            result = player._is_display_connected()
-            assert result is False
-            mock_close.assert_called_once_with(3)
+        def _probe_all():
+            return [PortStatus(name=n, connected=c) for n, c in ports]
 
-    def test_display_bus_unavailable_returns_none(self, player):
-        """Should return None when the I2C bus device cannot be opened."""
-        with patch("player.service.os.open", side_effect=OSError(2, "No such file")):
-            result = player._is_display_connected()
-            assert result is None
-
-    def test_display_ioctl_failure_returns_false(self, player):
-        """Should return False when ioctl fails (slave address rejected)."""
-        mock_fcntl = MagicMock()
-        mock_fcntl.ioctl.side_effect = OSError(22, "Invalid argument")
-        with patch("player.service.os.open", return_value=3), \
-             patch.dict("sys.modules", {"fcntl": mock_fcntl}), \
-             patch("player.service.os.close") as mock_close:
-            result = player._is_display_connected()
-            assert result is False
-            mock_close.assert_called_once_with(3)
+        player._display_probe = MagicMock()
+        player._display_probe.probe_all.side_effect = _probe_all
 
     def test_update_current_includes_display_connected(self, player, tmp_path):
-        """_update_current should include display_connected from the probe."""
+        """_update_current should set display_connected from port 0 of the probe."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", True)])
 
-        with patch.object(type(player), "_is_display_connected", return_value=True), \
-             patch.object(player, "_query_position_ms", return_value=0):
+        with patch.object(player, "_query_position_ms", return_value=0):
             player._update_current(mode=PlaybackMode.PLAY, asset="test.mp4")
 
         import json
         data = json.loads(state_file.read_text())
         assert data["display_connected"] is True
+        assert data["display_ports"] == [{"name": "HDMI-0", "connected": True}]
 
     def test_update_current_display_disconnected(self, player, tmp_path):
-        """_update_current should record display_connected=False when probe fails."""
+        """_update_current should record display_connected=False when probe reports no display."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", False)])
 
-        with patch.object(type(player), "_is_display_connected", return_value=False), \
-             patch.object(player, "_query_position_ms", return_value=0):
+        with patch.object(player, "_query_position_ms", return_value=0):
             player._update_current(mode=PlaybackMode.PLAY, asset="test.mp4")
 
         import json
         data = json.loads(state_file.read_text())
         assert data["display_connected"] is False
 
-    def test_update_position_probes_display(self, player, tmp_path):
-        """_update_position should update display_connected in current.json."""
+    def test_update_current_reports_all_ports(self, player, tmp_path):
+        """_update_current exposes every HDMI port in display_ports."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+        player.current_desired = DesiredState(
+            mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
+        )
+        self._mock_probe(
+            player, [("HDMI-0", False), ("HDMI-1", True)]
+        )
+
+        with patch.object(player, "_query_position_ms", return_value=0):
+            player._update_current(mode=PlaybackMode.PLAY, asset="test.mp4")
+
+        import json
+        data = json.loads(state_file.read_text())
+        assert data["display_connected"] is False  # primary = port 0
+        assert data["display_ports"] == [
+            {"name": "HDMI-0", "connected": False},
+            {"name": "HDMI-1", "connected": True},
+        ]
+
+    def test_update_position_probes_display_requires_two_flips(self, player, tmp_path):
+        """_update_position debounces True->False: one flipped probe is not enough."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
 
-        from shared.models import CurrentState
+        from shared.models import CurrentState, PortStatus as PortStatusModel
         from shared.state import write_state
         initial = CurrentState(
             mode=PlaybackMode.PLAY, asset="test.mp4",
             pipeline_state="PLAYING", playback_position_ms=1000,
             display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
+        )
+        write_state(state_file, initial)
+
+        player.pipeline = MagicMock()
+        player.current_desired = DesiredState(
+            mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
+        )
+        self._mock_probe(player, [("HDMI-0", False)])
+
+        with patch.object(player, "_query_position_ms", return_value=1000):
+            result = player._update_position()
+
+        assert result is True
+        import json
+        data = json.loads(state_file.read_text())
+        # First conflicting probe: stay "connected" while debouncing.
+        assert data["display_connected"] is True
+
+        # Second matching probe commits the flip.
+        with patch.object(player, "_query_position_ms", return_value=1000):
+            player._update_position()
+        data = json.loads(state_file.read_text())
+        assert data["display_connected"] is False
+
+    def test_update_position_debounce_reset_on_flap(self, player, tmp_path):
+        """A single contradicting reading clears the pending flip."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+
+        from shared.models import CurrentState, PortStatus as PortStatusModel
+        from shared.state import write_state
+        initial = CurrentState(
+            mode=PlaybackMode.PLAY, asset="test.mp4",
+            pipeline_state="PLAYING", playback_position_ms=1000,
+            display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
         )
         write_state(state_file, initial)
 
@@ -1234,26 +1266,35 @@ class TestDisplayDetection:
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
 
-        with patch.object(player, "_query_position_ms", return_value=1000), \
-             patch.object(type(player), "_is_display_connected", return_value=False):
-            result = player._update_position()
+        # Tick 1: False (candidate flip, not committed).
+        self._mock_probe(player, [("HDMI-0", False)])
+        with patch.object(player, "_query_position_ms", return_value=1000):
+            player._update_position()
+        # Tick 2: True again — matches current, so pending is cleared.
+        self._mock_probe(player, [("HDMI-0", True)])
+        with patch.object(player, "_query_position_ms", return_value=1000):
+            player._update_position()
+        # Tick 3: False again — should NOT commit yet (pending was reset).
+        self._mock_probe(player, [("HDMI-0", False)])
+        with patch.object(player, "_query_position_ms", return_value=1000):
+            player._update_position()
 
-        assert result is True
         import json
         data = json.loads(state_file.read_text())
-        assert data["display_connected"] is False
+        assert data["display_connected"] is True
 
     def test_update_position_no_write_when_unchanged(self, player, tmp_path):
-        """_update_position should not write when position and display are unchanged."""
+        """_update_position should not write when nothing changed."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
 
-        from shared.models import CurrentState
+        from shared.models import CurrentState, PortStatus as PortStatusModel
         from shared.state import write_state
         initial = CurrentState(
             mode=PlaybackMode.PLAY, asset="test.mp4",
             pipeline_state="PLAYING", playback_position_ms=1000,
             display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
         )
         write_state(state_file, initial)
         mtime_before = state_file.stat().st_mtime_ns
@@ -1262,9 +1303,9 @@ class TestDisplayDetection:
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", True)])
 
-        with patch.object(player, "_query_position_ms", return_value=1000), \
-             patch.object(type(player), "_is_display_connected", return_value=True):
+        with patch.object(player, "_query_position_ms", return_value=1000):
             result = player._update_position()
 
         assert result is True
@@ -1272,16 +1313,17 @@ class TestDisplayDetection:
         assert state_file.stat().st_mtime_ns == mtime_before
 
     def test_display_transition_logs_warning(self, player, tmp_path):
-        """Display state transition should log a warning."""
+        """Display True->False transition (after debounce) logs a warning."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
 
-        from shared.models import CurrentState
+        from shared.models import CurrentState, PortStatus as PortStatusModel
         from shared.state import write_state
         initial = CurrentState(
             mode=PlaybackMode.PLAY, asset="test.mp4",
             pipeline_state="PLAYING", playback_position_ms=1000,
             display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
         )
         write_state(state_file, initial)
 
@@ -1289,25 +1331,29 @@ class TestDisplayDetection:
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", False)])
 
-        import logging
         with patch.object(player, "_query_position_ms", return_value=1000), \
-             patch.object(type(player), "_is_display_connected", return_value=False), \
              patch("player.service.logger") as mock_logger:
+            # Tick 1: debouncing, should not log.
+            player._update_position()
+            mock_logger.warning.assert_not_called()
+            # Tick 2: commits the flip, should log.
             player._update_position()
             mock_logger.warning.assert_called_once_with("Display %s", "disconnected")
 
     def test_display_reconnect_logs_connected(self, player, tmp_path):
-        """Display reconnect should log 'connected'."""
+        """Display False->True transition logs 'connected' after debounce."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
 
-        from shared.models import CurrentState
+        from shared.models import CurrentState, PortStatus as PortStatusModel
         from shared.state import write_state
         initial = CurrentState(
             mode=PlaybackMode.PLAY, asset="test.mp4",
             pipeline_state="PLAYING", playback_position_ms=1000,
             display_connected=False,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=False)],
         )
         write_state(state_file, initial)
 
@@ -1315,16 +1361,16 @@ class TestDisplayDetection:
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", True)])
 
-        import logging
         with patch.object(player, "_query_position_ms", return_value=1000), \
-             patch.object(type(player), "_is_display_connected", return_value=True), \
              patch("player.service.logger") as mock_logger:
-            player._update_position()
+            player._update_position()  # tick 1 — debouncing
+            player._update_position()  # tick 2 — commits
             mock_logger.warning.assert_called_once_with("Display %s", "connected")
 
     def test_initial_probe_does_not_log(self, player, tmp_path):
-        """Transition from None to True/False should not log (initial probe)."""
+        """Transition from None to True/False commits immediately without warning."""
         state_file = tmp_path / "current.json"
         player.current_path = state_file
 
@@ -1333,7 +1379,8 @@ class TestDisplayDetection:
         initial = CurrentState(
             mode=PlaybackMode.PLAY, asset="test.mp4",
             pipeline_state="PLAYING", playback_position_ms=1000,
-            display_connected=None,  # initial state
+            display_connected=None,
+            display_ports=None,
         )
         write_state(state_file, initial)
 
@@ -1341,12 +1388,17 @@ class TestDisplayDetection:
         player.current_desired = DesiredState(
             mode=PlaybackMode.PLAY, asset="test.mp4", loop=True
         )
+        self._mock_probe(player, [("HDMI-0", True)])
 
         with patch.object(player, "_query_position_ms", return_value=1000), \
-             patch.object(type(player), "_is_display_connected", return_value=True), \
              patch("player.service.logger") as mock_logger:
             player._update_position()
             mock_logger.warning.assert_not_called()
+
+        import json
+        data = json.loads(state_file.read_text())
+        # None -> True commits immediately (no debounce for endpoint transitions).
+        assert data["display_connected"] is True
 
 
 # ── mpv command building ──


### PR DESCRIPTION
## Summary

Fixes #178 — HDMI display-connected detection is unreliable on VC4-HDMI boards (Pi Zero 2 W / Pi 3 / Pi 4) when `hdmi_force_hotplug=1` is set.

## Root cause (characterized on real hardware)

| Board | Behavior |
|---|---|
| Pi 5 / CM5 | `/sys/class/drm/card*-HDMI-A-*/status` is reliable (HPD IRQ through RP1) |
| Pi Zero 2 W / Pi 3 / Pi 4 | DRM sysfs lies — stays "connected" regardless of cable state when `hdmi_force_hotplug=1`. The I²C DDC EDID probe at `0x50` only ACKs when a real monitor is attached. |

## What changed

Per-board **`DisplayProbe` strategy pattern** under `agora/hardware/display/`:

- `DrmSysfsDisplayProbe` — Pi 5 / CM5
- `I2cEdidDisplayProbe` — VC4 boards (Pi Zero 2 W / Pi 3 / Pi 4)
- `NullDisplayProbe` — unknown / fallback
- `factory.build_probe(board, ports)` selects per board

Service-layer changes in `player/service.py`:

- Raw probe on every `_update_current`
- **Debounce** on `_update_position`: True↔False flips require 2 consecutive matching readings; None↔X commits immediately
- Emits new `display_ports: list[PortStatus]` field in `CurrentState` so **all HDMI ports are reported**, not just port 0 (unlocks future multi-monitor support)
- `display_connected` preserved as port-0 summary for wire-compat

CMS STATUS payload now includes `display_ports`.

Windows-portable: `fcntl` import is guarded for dev machines.

## Tests

- **`tests/test_hardware_display.py`** — 20 new tests covering all three probes + factory (including Windows `fcntl`-unavailable path)
- **`tests/test_player_service.py`** — `TestDisplayDetection` rewritten for the probe abstraction (9 tests: update paths, multi-port reporting, debounce flap reset, flip logging)
- **`tests/test_board.py`** — updated HdmiPort expectations for new `drm_connector` field

**166 passed** in the affected suites locally.

## Out of scope (follow-ups)

- Multi-monitor UI surfacing `display_ports` in CMS (new issue to file)
- Pi 4 verification on real hardware (assumed VC4 — matches existing code path)
- `/etc/modules-load.d/agora-i2c.conf` in pi-gen so `i2c-dev` loads at boot without runtime `modprobe`
- Small agora-cms PR to persist `display_ports` on status ingest

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
