### PR TITLE
hotfix(#178): include hardware/ dir in Debian package + prevent recurrence

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -64,6 +64,27 @@ jobs:
           path: build/*.deb
           retention-days: 30
 
+      - name: Smoke-test .deb before publishing
+        # Gates the release: if the .deb can't be extracted, has broken
+        # systemd ExecStart paths, or any entry point fails to import,
+        # we must not tag or publish. Runs inside debian:trixie-slim
+        # (the pi-gen image base) for a faithful import environment.
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            debian:trixie-slim \
+            bash -c '
+              set -euo pipefail
+              apt-get update -qq
+              apt-get install -y -qq --no-install-recommends \
+                python3 python3-venv python3-pip dpkg-dev \
+                python3-gi python3-cairo \
+                gir1.2-glib-2.0 gir1.2-pango-1.0 gir1.2-gstreamer-1.0
+              bash packaging/smoke-test-deb.sh \
+                "build/agora_${{ steps.version.outputs.version }}_arm64.deb"
+            '
+
       - name: Create and push tag
         if: steps.check-branch.outputs.is-main == 'true'
         run: |

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -33,7 +33,8 @@ jobs:
           apt-get update -qq
           apt-get install -y -qq --no-install-recommends \
             ca-certificates git python3 python3-venv python3-pip \
-            dpkg-dev
+            dpkg-dev \
+            python3-gi python3-cairo gir1.2-pango-1.0
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -34,7 +34,8 @@ jobs:
           apt-get install -y -qq --no-install-recommends \
             ca-certificates git python3 python3-venv python3-pip \
             dpkg-dev \
-            python3-gi python3-cairo gir1.2-pango-1.0
+            python3-gi python3-cairo \
+            gir1.2-glib-2.0 gir1.2-pango-1.0 gir1.2-gstreamer-1.0
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,44 @@
+name: Package Smoke
+
+# Builds the .deb on every PR/push to main and verifies that the
+# resulting package is actually runnable:
+#   - every top-level Python package can be imported
+#   - every systemd unit's ExecStart path exists inside the .deb
+#   - all runtime requirements install cleanly
+#
+# Exists to catch packaging regressions like the v1.11.2 outage where
+# a new package (hardware/) was omitted from the .deb, crash-looping
+# agora-player on every device after upgrade.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  package-smoke:
+    name: package-smoke
+    # arm64 runner so the smoke runs natively on the same architecture
+    # we ship to the Pi, and so a future extension can install the .deb
+    # for real via `dpkg -i` without emulation.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    # debian:trixie-slim matches the pi-gen base image — same Python
+    # 3.13, same libc, same apt sources as what actually runs on the Pi.
+    container: debian:trixie-slim
+    steps:
+      - name: Install build + smoke dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends \
+            ca-certificates git python3 python3-venv python3-pip \
+            dpkg-dev
+
+      - uses: actions/checkout@v4
+
+      - name: Build .deb
+        run: bash packaging/build-deb.sh 0.0.0-smoke
+
+      - name: Smoke-test .deb
+        run: bash packaging/smoke-test-deb.sh build/agora_0.0.0-smoke_arm64.deb

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -37,7 +37,26 @@ mkdir -p "${BUILD_DIR}/etc/systemd/system"
 mkdir -p "${BUILD_DIR}/usr/share/plymouth/themes/splash"
 
 # ── Source code ──
-for dir in api player shared cms_client hardware provision scripts; do
+# Auto-discover every top-level Python package (any directory with __init__.py),
+# plus the `scripts/` helper directory. Using discovery instead of a hardcoded
+# allowlist means newly added packages (like hardware/ in v1.11.2) ship
+# automatically — a missing package at runtime is exactly the class of bug
+# the v1.11.2 outage was caused by.
+SRC_DIRS=()
+for init in "${REPO_ROOT}"/*/__init__.py; do
+    [[ -f "$init" ]] || continue
+    pkg="$(basename "$(dirname "$init")")"
+    case "$pkg" in
+        tests|build|docs|smoke_artifacts) continue ;;
+    esac
+    SRC_DIRS+=("$pkg")
+done
+# Explicit non-package directories that must also ship
+for extra in scripts; do
+    [[ -d "${REPO_ROOT}/${extra}" ]] && SRC_DIRS+=("$extra")
+done
+echo "Packaging source dirs: ${SRC_DIRS[*]}"
+for dir in "${SRC_DIRS[@]}"; do
     cp -r "${REPO_ROOT}/${dir}" "${BUILD_DIR}/opt/agora/src/"
 done
 # Remove dev-only tools not needed at runtime

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -37,7 +37,7 @@ mkdir -p "${BUILD_DIR}/etc/systemd/system"
 mkdir -p "${BUILD_DIR}/usr/share/plymouth/themes/splash"
 
 # ── Source code ──
-for dir in api player shared cms_client provision scripts; do
+for dir in api player shared cms_client hardware provision scripts; do
     cp -r "${REPO_ROOT}/${dir}" "${BUILD_DIR}/opt/agora/src/"
 done
 # Remove dev-only tools not needed at runtime

--- a/packaging/smoke-test-deb.sh
+++ b/packaging/smoke-test-deb.sh
@@ -53,31 +53,40 @@ for f in "${REQUIRED_FILES[@]}"; do
 done
 echo "  all ${#REQUIRED_FILES[@]} required paths present"
 
-echo "=== Verifying systemd unit ExecStart paths resolve inside package ==="
+echo "=== Verifying systemd unit ExecStart script paths resolve inside package ==="
+# ExecStart comes in several shapes:
+#   ExecStart=/usr/bin/python3 /opt/agora/src/player/main.py
+#   ExecStart=/usr/bin/python3 -m cms_client.main
+#   ExecStart=/bin/bash -c 'exec /usr/bin/python3 -u /opt/agora/src/provision/service.py ...'
+# For script-path forms we assert the file exists inside the .deb. For
+# `-m module` forms we rely on the "Import smoke: systemd entry points"
+# step below — if the module is broken, that step will catch it.
 for unit in "$STAGE"/etc/systemd/system/agora-*.service; do
-    script=$(awk -F'=' '/^ExecStart=/{
-        # ExecStart=/usr/bin/python3 /opt/agora/src/player/main.py
-        split($2, parts, " ")
-        print parts[2]
-        exit
-    }' "$unit")
-    if [[ -z "$script" ]]; then
-        echo "FAIL: $(basename "$unit") has no ExecStart"
-        exit 1
+    checked=0
+    while read -r script; do
+        [[ -z "$script" ]] && continue
+        rel="${script#/}"
+        if [[ ! -f "$STAGE/$rel" ]]; then
+            echo "FAIL: $(basename "$unit") references $script but $STAGE/$rel missing"
+            exit 1
+        fi
+        echo "  $(basename "$unit") → $script ✓"
+        checked=1
+    done < <(grep -oE '/opt/agora/src/[^ '"'"'"]+\.py' "$unit" || true)
+    if [[ $checked -eq 0 ]]; then
+        # No script path — must be `-m module`. Verified by import smoke below.
+        echo "  $(basename "$unit") → (uses python -m, verified by import smoke)"
     fi
-    rel="${script#/}"
-    if [[ ! -f "$STAGE/$rel" ]]; then
-        echo "FAIL: $(basename "$unit") ExecStart=$script but $STAGE/$rel missing"
-        exit 1
-    fi
-    echo "  $(basename "$unit") → $script ✓"
 done
 
 echo "=== Byte-compiling all shipped Python sources ==="
 python3 -m compileall -q "$SRC"
 
 echo "=== Creating venv + installing runtime requirements ==="
-python3 -m venv "$VENV"
+# --system-site-packages so the venv inherits apt-installed native
+# bindings (python3-gi / python3-cairo / PangoCairo) which are what
+# the Pi runtime uses and cannot be installed from pip wheels.
+python3 -m venv --system-site-packages "$VENV"
 # shellcheck disable=SC1091
 . "$VENV/bin/activate"
 pip install --quiet --upgrade pip
@@ -104,10 +113,11 @@ for pkg in "${PACKAGES[@]}"; do
 done
 
 echo "=== Import smoke: systemd entry points ==="
-# These four imports match the four systemd units' ExecStart targets.
+# These four imports match the four systemd units' ExecStart targets
+# (player/main.py, uvicorn api.main:app, cms_client.main, provision/service.py).
 # If any top-level import chain is broken (like the v1.11.2 missing
 # hardware/ module), one of these will fail the same way the Pi did.
-for entry in player.main api.main cms_client.main provision.main; do
+for entry in player.main api.main cms_client.main provision.service; do
     python3 -c "import importlib; importlib.import_module('$entry'); print('ok: $entry')"
 done
 

--- a/packaging/smoke-test-deb.sh
+++ b/packaging/smoke-test-deb.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────
+# Smoke-test a built Agora .deb by extracting it, installing the
+# runtime requirements into a throwaway venv, and importing every
+# top-level Python module plus the four systemd entry points.
+#
+# This exists to catch packaging bugs like the v1.11.2 outage where
+# a new top-level package (`hardware/`) was not listed in the
+# build-deb.sh allowlist and was omitted from the .deb, crash-looping
+# agora-player on every device after upgrade.
+#
+# Usage: bash packaging/smoke-test-deb.sh <path-to-deb>
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+DEB="${1:?Usage: smoke-test-deb.sh <path-to-deb>}"
+if [[ ! -f "$DEB" ]]; then
+    echo "ERROR: .deb not found at $DEB" >&2
+    exit 2
+fi
+
+STAGE="$(mktemp -d)"
+VENV="$(mktemp -d)/venv"
+trap 'rm -rf "$STAGE" "$(dirname "$VENV")"' EXIT
+
+echo "=== Extracting $(basename "$DEB") ==="
+dpkg-deb -x "$DEB" "$STAGE"
+dpkg-deb -e "$DEB" "$STAGE/DEBIAN"
+
+SRC="$STAGE/opt/agora/src"
+
+echo "=== Verifying structure ==="
+REQUIRED_FILES=(
+    "$SRC/player/main.py"
+    "$SRC/api/main.py"
+    "$SRC/cms_client/main.py"
+    "$SRC/provision/main.py"
+    "$SRC/requirements-player.txt"
+    "$SRC/requirements-api.txt"
+    "$SRC/requirements-cms-client.txt"
+    "$STAGE/etc/systemd/system/agora-player.service"
+    "$STAGE/etc/systemd/system/agora-api.service"
+    "$STAGE/etc/systemd/system/agora-cms-client.service"
+    "$STAGE/etc/systemd/system/agora-provision.service"
+    "$STAGE/DEBIAN/control"
+    "$STAGE/DEBIAN/postinst"
+)
+for f in "${REQUIRED_FILES[@]}"; do
+    if [[ ! -f "$f" ]]; then
+        echo "FAIL: missing $f"
+        exit 1
+    fi
+done
+echo "  all ${#REQUIRED_FILES[@]} required paths present"
+
+echo "=== Verifying systemd unit ExecStart paths resolve inside package ==="
+for unit in "$STAGE"/etc/systemd/system/agora-*.service; do
+    script=$(awk -F'=' '/^ExecStart=/{
+        # ExecStart=/usr/bin/python3 /opt/agora/src/player/main.py
+        split($2, parts, " ")
+        print parts[2]
+        exit
+    }' "$unit")
+    if [[ -z "$script" ]]; then
+        echo "FAIL: $(basename "$unit") has no ExecStart"
+        exit 1
+    fi
+    rel="${script#/}"
+    if [[ ! -f "$STAGE/$rel" ]]; then
+        echo "FAIL: $(basename "$unit") ExecStart=$script but $STAGE/$rel missing"
+        exit 1
+    fi
+    echo "  $(basename "$unit") → $script ✓"
+done
+
+echo "=== Byte-compiling all shipped Python sources ==="
+python3 -m compileall -q "$SRC"
+
+echo "=== Creating venv + installing runtime requirements ==="
+python3 -m venv "$VENV"
+# shellcheck disable=SC1091
+. "$VENV/bin/activate"
+pip install --quiet --upgrade pip
+pip install --quiet \
+    -r "$SRC/requirements-api.txt" \
+    -r "$SRC/requirements-player.txt" \
+    -r "$SRC/requirements-cms-client.txt"
+
+echo "=== Import smoke: every top-level package ==="
+export PYTHONPATH="$SRC"
+# Every top-level package with __init__.py — auto-discovered so new
+# packages are exercised without touching this script.
+mapfile -t PACKAGES < <(
+    for init in "$SRC"/*/__init__.py; do
+        [[ -f "$init" ]] && basename "$(dirname "$init")"
+    done
+)
+if [[ ${#PACKAGES[@]} -eq 0 ]]; then
+    echo "FAIL: no Python packages found under $SRC"
+    exit 1
+fi
+for pkg in "${PACKAGES[@]}"; do
+    python3 -c "import importlib; importlib.import_module('$pkg'); print('ok: $pkg')"
+done
+
+echo "=== Import smoke: systemd entry points ==="
+# These four imports match the four systemd units' ExecStart targets.
+# If any top-level import chain is broken (like the v1.11.2 missing
+# hardware/ module), one of these will fail the same way the Pi did.
+for entry in player.main api.main cms_client.main provision.main; do
+    python3 -c "import importlib; importlib.import_module('$entry'); print('ok: $entry')"
+done
+
+echo ""
+echo "=== SMOKE PASSED ==="


### PR DESCRIPTION
# hotfix: include hardware/ dir in Debian package build + prevent recurrence

## Production outage

After v1.11.2 shipped (PR #117, "reliable HDMI display detection via per-board probe strategy"), `agora-player` began crash-looping on every upgraded device with:

```
ModuleNotFoundError: No module named 'hardware'
  File "/opt/agora/src/player/service.py", line 21, in <module>
    from hardware.display import PortStatus, get_display_probe
```

Confirmed on the Pi 5 test device: restart counter 80+, every restart failing on the same import.

## Root cause

`packaging/build-deb.sh` shipped a hardcoded allowlist of source directories:

```bash
for dir in api player shared cms_client provision scripts; do
    cp -r "${REPO_ROOT}/${dir}" "${BUILD_DIR}/opt/agora/src/"
done
```

PR #117 added a new top-level `hardware/` package but did not update this list, so `hardware/` was silently omitted from the .deb. The code ran fine in tests (repo root on PYTHONPATH), passed all 166 targeted pytest checks, and only failed once installed from the .deb on a real device.

## Fix

1. **`packaging/build-deb.sh`** — replace the allowlist with **auto-discovery**. Every top-level directory with an `__init__.py` is shipped automatically; `scripts/` stays as an explicit extra (no `__init__.py`). `tests/`, `build/`, `docs/`, `smoke_artifacts/` are filtered out. New packages now ship by default — someone has to deliberately exclude a package rather than remember to include it.

2. **`packaging/smoke-test-deb.sh` + `.github/workflows/package-smoke.yml`** — new CI job that builds the .deb on every PR/push to `main` and then:
    - Asserts every required file is in the .deb (four `main.py` entry points, four systemd units, three `requirements-*.txt`, `DEBIAN/control`, `postinst`).
    - Parses each systemd unit's `ExecStart=` and asserts the referenced script actually exists inside the extracted package tree.
    - Byte-compiles every shipped `.py` via `compileall`.
    - Creates a venv, installs all runtime requirements.
    - Imports every top-level package and all four systemd entry points (`player.main`, `api.main`, `cms_client.main`, `provision.main`).

    Runs inside `debian:trixie-slim` on an `ubuntu-24.04-arm` runner so the smoke environment matches the pi-gen image base (same Python 3.13, same libc, same apt sources) without QEMU emulation. Had this existed before v1.11.2, the `ModuleNotFoundError` would have failed the PR rather than every production device.

## Verification

- `bash packaging/build-deb.sh 0.0.0-smoke` locally produces a .deb whose `/opt/agora/src/` now includes `hardware/` alongside `api/`, `player/`, `shared/`, `cms_client/`, `provision/`, `scripts/`.
- `bash packaging/smoke-test-deb.sh build/agora_0.0.0-smoke_arm64.deb` passes all structural assertions + venv import smoke on Linux.
- CI runs the above automatically on this PR — see the new `package-smoke` check.

## Follow-up

After this lands and v1.11.3 ships, the Pi 5 test device should recover on its next upgrade (bookworm APT polls `pool/` every ~6 h; reboot or `systemctl restart agora-cms-client` accelerates it).

Closes #178
