### PR TITLE
fix(display): cross-check EDID, probe during splash, scrub hdmi_force_hotplug

### DIFF
--- a/hardware/display/drm_sysfs.py
+++ b/hardware/display/drm_sysfs.py
@@ -1,14 +1,18 @@
 """DRM sysfs based HDMI probe (primary for Pi 5 / CM 5).
 
-Reads ``/sys/class/drm/card*-{drm_connector}/status`` for each HDMI port.
-The file contains ``connected``, ``disconnected`` or ``unknown``.  On Pi 5
-/ CM 5 this is HPD-IRQ driven and reliable, even when
-``hdmi_force_hotplug=1`` is set in ``/boot/firmware/config.txt`` (the RP1
-chip handles hot-plug natively and ignores the flag).
+Reads ``/sys/class/drm/card*-{drm_connector}/status`` for each HDMI port and
+cross-checks the sibling ``edid`` file.
 
-On older Pis (VC4 HDMI driver) the same file will frequently report
-``connected`` regardless of physical state — use :mod:`i2c_edid` instead on
-those boards.
+The ``status`` file contains ``connected``, ``disconnected`` or ``unknown``.
+On current Pi 5 firmware (and on VC4 with ``hdmi_force_hotplug=1``) the file
+can read ``connected`` even when no display is physically attached.  A real
+display always returns EDID data over DDC, so we require a non-empty EDID
+before trusting the ``connected`` verdict.
+
+Empirical behaviour on Pi 5 / RP1 (verified 2026-04):
+  No display attached:  status=connected, edid=0 bytes   → connected=False
+  Display attached:     status=connected, edid=256 bytes → connected=True
+  status=disconnected:  always trusted → connected=False
 """
 from __future__ import annotations
 
@@ -26,13 +30,13 @@ logger = logging.getLogger("agora.hardware.display.drm_sysfs")
 _SYSFS_ROOT = Path("/sys/class/drm")
 
 
-def _resolve_status_path(connector: str) -> Optional[Path]:
-    """Find the sysfs ``status`` file for a DRM connector name.
+def _resolve_connector_dir(connector: str) -> Optional[Path]:
+    """Find the sysfs directory for a DRM connector name.
 
-    Matches ``/sys/class/drm/card*-{connector}/status``.  Returns ``None`` if
-    no such file exists on this kernel (e.g. a Pi without DRM KMS).
+    Matches ``/sys/class/drm/card*-{connector}/``.  Returns ``None`` if no
+    such directory exists on this kernel (e.g. a Pi without DRM KMS).
     """
-    pattern = str(_SYSFS_ROOT / f"card*-{connector}" / "status")
+    pattern = str(_SYSFS_ROOT / f"card*-{connector}")
     matches = sorted(glob.glob(pattern))
     if not matches:
         return None
@@ -53,12 +57,26 @@ def _read_status(path: Path) -> Optional[bool]:
     return None
 
 
+def _edid_size(connector_dir: Path) -> int:
+    """Return the byte size of the connector's EDID blob (0 if missing/empty)."""
+    try:
+        return (connector_dir / "edid").stat().st_size
+    except (FileNotFoundError, PermissionError, OSError):
+        return 0
+
+
 class DrmSysfsDisplayProbe(DisplayProbe):
-    """HDMI presence via ``/sys/class/drm/card*-{connector}/status``.
+    """HDMI presence via ``/sys/class/drm/card*-{connector}/{status,edid}``.
 
     Each :class:`HdmiPort` passed in must carry a ``drm_connector`` value
     (e.g. ``"HDMI-A-1"``).  Ports with no ``drm_connector`` or a missing
-    sysfs file report ``connected=None``.
+    sysfs directory report ``connected=None``.
+
+    The probe cross-checks the sysfs ``status`` file against the ``edid``
+    file's size: if ``status=connected`` but EDID is empty (0 bytes), the
+    port is reported as ``connected=False`` — the sysfs ``status`` file is
+    known to lie under various firmware/config conditions, whereas EDID
+    only populates when a real monitor answers on DDC.
     """
 
     def __init__(self, ports: list[HdmiPort]):
@@ -71,9 +89,17 @@ class DrmSysfsDisplayProbe(DisplayProbe):
             if not connector:
                 out.append(PortStatus(name=port.name, connected=None))
                 continue
-            path = _resolve_status_path(connector)
-            if path is None:
+            connector_dir = _resolve_connector_dir(connector)
+            if connector_dir is None:
                 out.append(PortStatus(name=port.name, connected=None))
                 continue
-            out.append(PortStatus(name=port.name, connected=_read_status(path)))
+            status = _read_status(connector_dir / "status")
+            if status is True and _edid_size(connector_dir) == 0:
+                logger.debug(
+                    "%s: sysfs status=connected but EDID empty — treating as disconnected",
+                    connector,
+                )
+                status = False
+            out.append(PortStatus(name=port.name, connected=status))
         return out
+

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -138,7 +138,15 @@ if [ -f "${BOOT_CFG}" ]; then
         sed -i 's/^disable_fw_kms_setup=1/disable_fw_kms_setup=0/' "${BOOT_CFG}"
         echo "Agora: fixed disable_fw_kms_setup=0 in ${BOOT_CFG}"
     fi
-    for setting in disable_fw_kms_setup=0 disable_overscan=1 hdmi_force_hotplug=1 hdmi_force_edid_audio=1; do
+    # Scrub legacy hdmi_force_hotplug=1. On Pi 5 (RP1) it makes sysfs lie about
+    # connection state (status=connected with no display attached); on current
+    # Bookworm firmware it is unnecessary for Pi 3/4 hotplug too. The display
+    # probe now cross-checks EDID, so this flag is pure noise either way.
+    if grep -q '^hdmi_force_hotplug=1$' "${BOOT_CFG}"; then
+        sed -i '/^hdmi_force_hotplug=1$/d' "${BOOT_CFG}"
+        echo "Agora: removed legacy hdmi_force_hotplug=1 from ${BOOT_CFG}"
+    fi
+    for setting in disable_fw_kms_setup=0 disable_overscan=1 hdmi_force_edid_audio=1; do
         key="${setting%%=*}"
         if ! grep -q "^${key}=" "${BOOT_CFG}"; then
             echo "${setting}" >> "${BOOT_CFG}"

--- a/pi-gen/stage-agora/00-install-agora/00-run.sh
+++ b/pi-gen/stage-agora/00-install-agora/00-run.sh
@@ -69,8 +69,8 @@ case "${BOARD}" in
     cat >> "${ROOTFS_DIR}/boot/firmware/config.txt" <<'PI4CFG'
 
 # Agora: Pi 4 display config
-hdmi_force_hotplug:0=1
-hdmi_force_hotplug:1=1
+# Current Bookworm firmware handles HDMI hotplug natively on Pi 4;
+# hdmi_force_hotplug was historically needed but now just adds noise.
 PI4CFG
     ;;
   pi5)

--- a/player/service.py
+++ b/player/service.py
@@ -965,6 +965,43 @@ class AgoraPlayer:
             logger.debug("Failed to update playback position")
         return True  # Keep the timer running
 
+    def _probe_display_tick(self) -> bool:
+        """Periodic display probe that runs regardless of playback state.
+
+        `_update_position` only runs while a pipeline is active, so during
+        splash/idle the display connection state in current.json would go
+        stale and the CMS would keep reporting whatever was last observed on
+        a playback transition. This tick re-probes HDMI at a steady cadence
+        and writes updates to current.json so the next heartbeat reflects
+        reality. Always returns True to keep the GLib timer running for the
+        lifetime of the service.
+        """
+        try:
+            current = read_state(self.current_path, CurrentState)
+            _, raw_ports = self._probe_display()
+            ports = self._debounce_display(raw_ports, current.display_ports)
+            primary = ports[0].connected if ports else None
+            changed = False
+            if current.display_connected != primary:
+                if primary is not None and current.display_connected is not None:
+                    logger.warning(
+                        "Display %s",
+                        "connected" if primary else "disconnected",
+                    )
+                current.display_connected = primary
+                changed = True
+            old_map = {p.name: p.connected for p in (current.display_ports or [])}
+            new_map = {p.name: p.connected for p in ports}
+            if old_map != new_map:
+                current.display_ports = ports or None
+                changed = True
+            if changed:
+                current.updated_at = datetime.now(timezone.utc)
+                write_state(self.current_path, current)
+        except Exception:
+            logger.debug("Display probe tick failed", exc_info=True)
+        return True  # Keep the timer running for the lifetime of the service
+
     def apply_desired(self) -> None:
         """Read desired state and apply it to the player."""
         if not self.desired_path.exists():
@@ -1286,6 +1323,10 @@ class AgoraPlayer:
         # Re-apply: desired.json may have been written while the initial splash
         # pipeline was loading (before inotify was watching).
         self.apply_desired()
+
+        # Periodic display probe: runs regardless of playback state so
+        # display_connected in current.json stays fresh during splash/idle.
+        GLib.timeout_add_seconds(10, self._probe_display_tick)
 
         # Signal handlers for clean shutdown
         def on_shutdown(signum, frame):

--- a/tests/test_hardware_display.py
+++ b/tests/test_hardware_display.py
@@ -61,6 +61,7 @@ def test_drm_sysfs_connected(tmp_path):
     card_dir = tmp_path / "card1-HDMI-A-1"
     card_dir.mkdir()
     (card_dir / "status").write_text("connected\n")
+    (card_dir / "edid").write_bytes(b"\x00" * 128)
 
     with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
         probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
@@ -71,6 +72,31 @@ def test_drm_sysfs_disconnected(tmp_path):
     card_dir = tmp_path / "card1-HDMI-A-1"
     card_dir.mkdir()
     (card_dir / "status").write_text("disconnected\n")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=False)]
+
+
+def test_drm_sysfs_status_connected_but_edid_empty_treated_as_disconnected(tmp_path):
+    # Pi 5 / VC4 false-positive: sysfs says connected but no display responded
+    # on DDC, so the EDID blob is empty. Trust EDID over status.
+    card_dir = tmp_path / "card1-HDMI-A-1"
+    card_dir.mkdir()
+    (card_dir / "status").write_text("connected\n")
+    (card_dir / "edid").write_bytes(b"")  # 0 bytes
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
+        assert probe.probe_all() == [PortStatus(name="HDMI-0", connected=False)]
+
+
+def test_drm_sysfs_status_connected_edid_missing_treated_as_disconnected(tmp_path):
+    # Same false-positive case, but the edid file doesn't exist at all.
+    card_dir = tmp_path / "card1-HDMI-A-1"
+    card_dir.mkdir()
+    (card_dir / "status").write_text("connected\n")
+    # no edid file created
 
     with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
         probe = _drm_probe([HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1")])
@@ -103,6 +129,7 @@ def test_drm_sysfs_empty_connector_returns_none(tmp_path):
 def test_drm_sysfs_multiple_ports(tmp_path):
     (tmp_path / "card1-HDMI-A-1").mkdir()
     (tmp_path / "card1-HDMI-A-1" / "status").write_text("connected")
+    (tmp_path / "card1-HDMI-A-1" / "edid").write_bytes(b"\x00" * 256)
     (tmp_path / "card1-HDMI-A-2").mkdir()
     (tmp_path / "card1-HDMI-A-2" / "status").write_text("disconnected")
 
@@ -113,6 +140,27 @@ def test_drm_sysfs_multiple_ports(tmp_path):
         ])
         assert probe.probe_all() == [
             PortStatus(name="HDMI-0", connected=True),
+            PortStatus(name="HDMI-1", connected=False),
+        ]
+
+
+def test_drm_sysfs_false_positive_primary_real_secondary(tmp_path):
+    # Real-world Pi 5 scenario: HDMI-A-1 sysfs lies (connected, edid empty),
+    # HDMI-A-2 honestly reports disconnected. Both should read as disconnected.
+    (tmp_path / "card1-HDMI-A-1").mkdir()
+    (tmp_path / "card1-HDMI-A-1" / "status").write_text("connected")
+    (tmp_path / "card1-HDMI-A-1" / "edid").write_bytes(b"")
+    (tmp_path / "card1-HDMI-A-2").mkdir()
+    (tmp_path / "card1-HDMI-A-2" / "status").write_text("disconnected")
+    (tmp_path / "card1-HDMI-A-2" / "edid").write_bytes(b"")
+
+    with patch("hardware.display.drm_sysfs._SYSFS_ROOT", tmp_path):
+        probe = _drm_probe([
+            HdmiPort("HDMI-0", "/dev/i2c-3", "HDMI-A-1"),
+            HdmiPort("HDMI-1", "/dev/i2c-4", "HDMI-A-2"),
+        ])
+        assert probe.probe_all() == [
+            PortStatus(name="HDMI-0", connected=False),
             PortStatus(name="HDMI-1", connected=False),
         ]
 

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1400,6 +1400,94 @@ class TestDisplayDetection:
         # None -> True commits immediately (no debounce for endpoint transitions).
         assert data["display_connected"] is True
 
+    # ── _probe_display_tick ──
+    # This timer runs for the lifetime of the player, regardless of playback
+    # state, so display_connected in current.json stays fresh during splash/idle
+    # when _update_position is not running.
+
+    def test_probe_display_tick_updates_during_splash(self, player, tmp_path):
+        """Display flip is persisted even when no playback pipeline is active."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+
+        from shared.models import CurrentState, PortStatus as PortStatusModel
+        from shared.state import write_state
+        initial = CurrentState(
+            mode=PlaybackMode.SPLASH, asset="default.png",
+            pipeline_state="PLAYING",
+            display_connected=False,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=False)],
+        )
+        write_state(state_file, initial)
+
+        # Splash: no GStreamer pipeline, no mpv or cage process.
+        player.pipeline = None
+        player.current_desired = DesiredState(mode=PlaybackMode.SPLASH)
+        self._mock_probe(player, [("HDMI-0", True)])
+
+        # Debounce: takes two consistent readings to commit.
+        assert player._probe_display_tick() is True
+        assert player._probe_display_tick() is True
+
+        import json
+        data = json.loads(state_file.read_text())
+        assert data["display_connected"] is True
+        assert data["display_ports"] == [{"name": "HDMI-0", "connected": True}]
+
+    def test_probe_display_tick_always_returns_true(self, player, tmp_path):
+        """Tick must keep the GLib timer running even when nothing changes."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+
+        from shared.models import CurrentState, PortStatus as PortStatusModel
+        from shared.state import write_state
+        initial = CurrentState(
+            mode=PlaybackMode.SPLASH, asset="default.png",
+            pipeline_state="PLAYING",
+            display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
+        )
+        write_state(state_file, initial)
+        player.pipeline = None
+        player.current_desired = DesiredState(mode=PlaybackMode.SPLASH)
+        self._mock_probe(player, [("HDMI-0", True)])
+
+        # Several ticks with no change — all return True.
+        for _ in range(5):
+            assert player._probe_display_tick() is True
+
+    def test_probe_display_tick_swallows_exceptions(self, player, tmp_path):
+        """A failure inside the tick must not crash the timer."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+
+        # No file written → read_state will raise. Tick should still return True.
+        self._mock_probe(player, [("HDMI-0", True)])
+        assert player._probe_display_tick() is True
+
+    def test_probe_display_tick_no_write_when_unchanged(self, player, tmp_path):
+        """Idempotent: if probe matches last state, current.json is not rewritten."""
+        state_file = tmp_path / "current.json"
+        player.current_path = state_file
+
+        from shared.models import CurrentState, PortStatus as PortStatusModel
+        from shared.state import write_state
+        initial = CurrentState(
+            mode=PlaybackMode.SPLASH, asset="default.png",
+            pipeline_state="PLAYING",
+            display_connected=True,
+            display_ports=[PortStatusModel(name="HDMI-0", connected=True)],
+        )
+        write_state(state_file, initial)
+        mtime_before = state_file.stat().st_mtime_ns
+
+        player.pipeline = None
+        player.current_desired = DesiredState(mode=PlaybackMode.SPLASH)
+        self._mock_probe(player, [("HDMI-0", True)])
+
+        player._probe_display_tick()
+        assert state_file.stat().st_mtime_ns == mtime_before
+
 
 # ── mpv command building ──
 


### PR DESCRIPTION
# fix(display): cross-check EDID, probe during splash, scrub hdmi_force_hotplug

Three related display-detection bugs surfaced while debugging a Pi 5 at the
bench. All fixed here because they compound.

## 1. Pi 5 sysfs lies about HDMI status

Empirically verified on the user's Pi 5 (RP1/VC6 driver), with
`hdmi_force_hotplug` both set and removed:

| State                           | `/.../status`  | `/.../edid`   |
| ------------------------------- | -------------- | ------------- |
| No display, ever                | `connected` ❌ | **0 bytes**   |
| Display plugged in (live DDC)   | `connected`    | 128/256 bytes |
| Display unplugged after boot    | `disconnected` | stale         |

Trusting `status` alone mis-reports the first row as connected. EDID, however,
is the canonical DDC response — empty = nothing ever answered.

Fix: `drm_sysfs.probe_all()` now cross-checks EDID when `status=connected`. If
the EDID blob is zero bytes (or missing/unreadable), the port is reported as
disconnected. Logic:

```
status=disconnected → False  (trust it; edid may be stale)
status=connected + edid>0 → True
status=connected + edid=0 → False
anything else → None
```

## 2. Display probe stops running during splash/idle

`Player._update_position()` only runs while a GStreamer/mpv/cage process is
active, and exits the GLib timer as soon as playback stops. During splash,
`current.json` kept whatever `display_connected` value was last written on a
playback transition, and the CMS heartbeat happily reported it forever.

Fix: new `_probe_display_tick()` scheduled once at startup. Runs every 10s for
the lifetime of the service, regardless of playback state. Uses the same
debounce as `_update_position` (via `_debounce_display`) and only writes
`current.json` when something actually changes.

## 3. `hdmi_force_hotplug=1` is legacy cruft

Pi 3/4 on current Bookworm firmware handle HDMI hotplug natively. Pi 5 ignores
the flag entirely and its sysfs lies anyway. The flag is only noise now and
makes sysfs debugging confusing.

- `packaging/debian/postinst`: dropped from the config.txt append list; added
  a scrub block that removes the line on upgrade.
- `pi-gen/stage-agora/00-install-agora/00-run.sh`: removed the two
  `hdmi_force_hotplug:N=1` lines from the Pi 4 image build.

## Tests

New in `tests/test_hardware_display.py`:
- `test_drm_sysfs_status_connected_but_edid_empty_treated_as_disconnected`
- `test_drm_sysfs_status_connected_edid_missing_treated_as_disconnected`
- `test_drm_sysfs_false_positive_primary_real_secondary`
- Updated existing `connected`/`multiple_ports` tests to stub a non-empty EDID
  where a display is expected.

New in `tests/test_player_service.py::TestDisplayDetection`:
- `test_probe_display_tick_updates_during_splash`
- `test_probe_display_tick_always_returns_true`
- `test_probe_display_tick_swallows_exceptions`
- `test_probe_display_tick_no_write_when_unchanged`

Suite: 130 passed across display + player tests.

## Empirical verification notes

Probe behavior confirmed on-device across all four scenarios (boot-with-display,
unplug, boot-without-display, plug-in-after-boot). Combined `status + edid`
signal is reliable in every case — you do not need display-at-boot for
detection to work. See investigation notes in the tracking issue.
