### PR TITLE
ci: auto-release on merge + daily cleanup at midnight PDT

### DIFF
--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -7,9 +7,12 @@ name: Cleanup Old Releases
 # Runs weekly (Monday 09:00 UTC) and can be triggered manually with a
 # custom `keep` value or a dry-run.
 
+# Runs daily at 07:00 UTC (midnight PDT / 23:00 PST — cron doesn't
+# observe DST, so the local wall time drifts by an hour across the
+# DST boundary; that's fine for a cleanup job).
 on:
   schedule:
-    - cron: "0 9 * * 1"
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       keep:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,6 +2,14 @@ name: Build & Release
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/**'
+      - 'tests/**'
+      - '.gitleaks.toml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Auto-release on merge + daily retention cleanup

Two small CI tweaks now that retention cleanup is in place:

### 1. `create-release.yml` — auto-release on merge to `main`

Adds a `push` trigger alongside the existing `workflow_dispatch`, with a `paths-ignore` so docs/CI/tests-only merges don't cut a release:

```yaml
on:
  workflow_dispatch:
  push:
    branches: [main]
    paths-ignore:
      - '**/*.md'
      - 'docs/**'
      - '.github/**'
      - 'tests/**'
      - '.gitleaks.toml'
```

- A PR that touches code → merge → `.deb` + GitHub Release automatically.
- A docs-only or workflow-only PR → merge → nothing (as intended).
- A mixed PR (code + docs) → release (any non-ignored path triggers).
- The `bump-main` commit writes `[skip ci]`, so the auto-bump doesn't recursively re-trigger the workflow.
- `workflow_dispatch` still works for manual re-cuts and feature-branch builds.

### 2. `cleanup-releases.yml` — daily at midnight PDT

Per-merge releases will accumulate faster than weekly pruning can keep up, so run the cleanup nightly:

```yaml
on:
  schedule:
    - cron: "0 7 * * *"   # 00:00 PDT / 23:00 PST — DST drift is fine for cleanup
  workflow_dispatch:
```

Still keeps the newest 15 releases; still dry-run-capable via dispatch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
