### PR TITLE
fix(player): apply Chromium memory-saver flags on low-mem boards

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -292,6 +292,45 @@ class AgoraPlayer:
 
     # ── Cage+Chromium (webpage rendering) ──
 
+    # Boards where aggressive Chromium memory-saver flags are applied.
+    # These boards either have ≤1 GB RAM (Zero 2 W) or are memory-constrained
+    # variants in the supported line (Pi 4 — the 1 GB model is still in use).
+    # Pi 5 is excluded: it has ≥4 GB and hardware-accelerated compositing.
+    # UNKNOWN is included defensively (same rationale as gstreamer fallback).
+    _LOWMEM_BOARDS = frozenset({Board.ZERO_2W, Board.PI_4, Board.UNKNOWN})
+
+    @staticmethod
+    def _chromium_lowmem_flags() -> list[str]:
+        """Chromium flags that reduce RAM footprint on memory-constrained boards.
+
+        Empirically validated on a Pi Zero 2 W (416 MB usable RAM) rendering
+        wikipedia, google, bbc and similar pages without swap thrash. Full
+        rationale and test results are in the PR that introduced this helper.
+        """
+        return [
+            # Bypass the Raspberry Pi OS chromium wrapper's low-RAM zenity
+            # dialog that blocks launch on boards with MemTotal ≤ 512 MB.
+            "--no-memcheck",
+            # Collapse all same-site frames into one renderer and cap it at 1.
+            "--disable-features=site-per-process,IsolateOrigins,SpareRendererForSitePerProcess",
+            "--process-per-site",
+            "--renderer-process-limit=1",
+            # Skip disk cache writes (slow SD, small wins, bloats dirty pages).
+            "--disk-cache-size=1", "--media-cache-size=1",
+            # Don't proactively free memory on pressure events; we're always
+            # under pressure, and the discards cause visible redraw churn.
+            "--memory-pressure-off",
+            # Chromium auto-disables GPU rasterization below 512 MB anyway,
+            # but explicit flags also free upfront EGL/GBM surface allocations
+            # and skip the GPU process, which measurably reduces RSS.
+            "--disable-gpu", "--disable-gpu-compositing", "--disable-accelerated-2d-canvas",
+            # Background chatter that's pointless for signage.
+            "--disable-background-networking", "--disable-sync", "--disable-default-apps",
+            "--disable-component-update", "--disable-domain-reliability",
+            # Cap V8 heap so JS-heavy sites don't eat all RAM before GC.
+            "--js-flags=--max-old-space-size=96 --max-semi-space-size=2",
+        ]
+
     def _start_cage(self, url: str) -> None:
         """Launch Cage + Chromium in kiosk mode to render a URL."""
         self._stop_cage()
@@ -306,9 +345,13 @@ class AgoraPlayer:
             "chromium", "--no-sandbox", "--kiosk", "--noerrdialogs",
             "--disable-translate", "--disable-infobars", "--incognito",
             "--hide-scrollbars", "--autoplay-policy=no-user-gesture-required",
+        ]
+        if get_board() in self._LOWMEM_BOARDS:
+            cmd.extend(self._chromium_lowmem_flags())
+        cmd.extend([
             "--load-extension=/opt/agora/src/player/extensions/hide-cursor",
             url,
-        ]
+        ])
 
         logger.info("Starting Cage+Chromium for URL: %s", url)
         try:

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -2428,3 +2428,76 @@ class TestFindSplash:
         assert mpv_player._resolve_asset("img.png") is not None
         assert mpv_player._resolve_asset("spl.png") is not None
         assert mpv_player._resolve_asset("missing.png") is None
+
+
+class TestChromiumLowMemFlags:
+    """Verify low-memory Chromium flag set is applied only on supported boards."""
+
+    @pytest.fixture
+    def svc_module(self):
+        with patch.dict("sys.modules", {
+            "gi": MagicMock(),
+            "gi.repository": MagicMock(),
+        }):
+            import importlib
+            import player.service as svc
+            importlib.reload(svc)
+            yield svc
+
+    def test_lowmem_boards_set(self, svc_module):
+        """Zero 2 W, Pi 4 and UNKNOWN get low-mem flags; Pi 5 does not."""
+        p = svc_module.AgoraPlayer
+        assert svc_module.Board.ZERO_2W in p._LOWMEM_BOARDS
+        assert svc_module.Board.PI_4 in p._LOWMEM_BOARDS
+        assert svc_module.Board.UNKNOWN in p._LOWMEM_BOARDS
+        assert svc_module.Board.PI_5 not in p._LOWMEM_BOARDS
+
+    def test_lowmem_flags_contents(self, svc_module):
+        """Flag list contains the empirically-validated memory-saver switches."""
+        flags = svc_module.AgoraPlayer._chromium_lowmem_flags()
+        assert "--no-memcheck" in flags
+        assert "--process-per-site" in flags
+        assert "--renderer-process-limit=1" in flags
+        assert "--memory-pressure-off" in flags
+        assert "--disable-gpu" in flags
+        assert "--disable-gpu-compositing" in flags
+        assert "--disable-accelerated-2d-canvas" in flags
+        assert any(f.startswith("--js-flags=") and "max-old-space-size" in f for f in flags)
+        assert any(f.startswith("--disable-features=") and "site-per-process" in f for f in flags)
+
+    def test_start_cage_applies_flags_on_zero2w(self, player, svc_module):
+        """On Zero 2 W the low-mem flag set is injected into the cage command."""
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.ZERO_2W), \
+             patch.object(player, "_stop_cage"), \
+             patch.object(player, "_teardown"), \
+             patch.object(player, "_update_current"), \
+             patch("player.service.subprocess.Popen") as mock_popen, \
+             patch("player.service.os.makedirs"):
+            mock_popen.return_value = MagicMock()
+            player._start_cage("https://example.com")
+
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        assert "--no-memcheck" in cmd
+        assert "--process-per-site" in cmd
+        assert "--disable-gpu" in cmd
+
+    def test_start_cage_omits_flags_on_pi5(self, mpv_player, svc_module):
+        """On Pi 5 the low-mem flag set is NOT applied."""
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_cage"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch("player.service.subprocess.Popen") as mock_popen, \
+             patch("player.service.os.makedirs"):
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_cage("https://example.com")
+
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        assert "--no-memcheck" not in cmd
+        assert "--process-per-site" not in cmd
+        assert "--disable-gpu" not in cmd
+        # Baseline flags still present
+        assert "--kiosk" in cmd
+        assert "https://example.com" in cmd


### PR DESCRIPTION
# fix(player): apply Chromium memory-saver flags on low-mem boards for webpage assets

## Problem

When scheduling a webpage asset on a Pi Zero 2 W (and by extension any
low-memory Pi board), Cage+Chromium would either refuse to launch
(Raspberry Pi OS low-RAM wrapper dialog) or swap-thrash itself into a
hang because Chromium's default multi-process/GPU/cache layout doesn't
fit in ≤1 GB of RAM.

The CMS currently gates webpage assets to Pi 5 only so this doesn't
surface in production, but the gate is a policy, not a hard limit — a
follow-up change may relax it, and the player should be ready.

## Change

Added a board-gated low-memory flag set to `_start_cage`:

- `--no-memcheck` — bypass the Raspberry Pi OS chromium wrapper's
  low-RAM zenity dialog.
- `--disable-features=site-per-process,IsolateOrigins,SpareRendererForSitePerProcess`
  + `--process-per-site` + `--renderer-process-limit=1` — collapse all
  same-site frames into a single renderer.
- `--disk-cache-size=1 --media-cache-size=1` — no disk caching.
- `--memory-pressure-off` — avoid redraw churn from eager discards.
- `--disable-gpu --disable-gpu-compositing --disable-accelerated-2d-canvas`
  — skip GPU process and EGL/GBM surface allocations (rasterization is
  auto-disabled below 512 MB anyway, but the surfaces aren't).
- `--disable-background-networking --disable-sync --disable-default-apps
  --disable-component-update --disable-domain-reliability` — no
  background chatter.
- `--js-flags=--max-old-space-size=96 --max-semi-space-size=2` — cap V8
  heap so JS-heavy sites don't eat all RAM before GC.

Flags are applied only on `Board.ZERO_2W`, `Board.PI_4` and
`Board.UNKNOWN` (the defensive fallback). Pi 5 is unaffected: it has
≥4 GB and hardware compositing, and the flag set would regress perf
there.

## Validation

Empirically tested on a Pi Zero 2 W (416 MB usable RAM) against:

| Site | Result |
| --- | --- |
| example.com | rendered ~15 s, 0 MB swap |
| google.com | rendered ~100 s |
| wikipedia.org homepage | rendered |
| en.wikipedia.org/wiki/Raspberry_Pi | rendered, article + images |
| bbc.com | main content rendered; ad iframes dropped (memory-starved) |
| time.is | loaded but seconds update infrequently (JS heap > working set) |

The Zero 2 W can load and display modest static-ish pages. It **cannot
sustain live/animated JS content** — that's a hardware limit, not a
flag-tuning problem. Boards with ≥1 GB RAM (Pi 4, Pi 5) are expected
to handle all of the above comfortably; this PR only removes the
launch/load-time gotchas on the small box.

Also re-enabled GPU as a control test: swap usage jumped from 0 MB to
>215 MB just loading example.com and the page never fully painted.
Confirmed `--disable-gpu` is the right default for this class.

## Tests

Added `TestChromiumLowMemFlags` in `tests/test_player_service.py`:

- Boards in/out of `_LOWMEM_BOARDS`.
- Flag list contains all expected switches.
- `_start_cage` injects flags on Zero 2 W.
- `_start_cage` omits flags on Pi 5 (baseline `--kiosk` / URL still present).

All 111 player tests pass.

## Out of scope

- The CMS Pi-5-only gate for webpage assets stays in place. Relaxing
  it (e.g. to allow Pi 4) is a CMS-side decision and a separate PR.
- No changes to splash / device-side webpage rendering beyond the
  Chromium command line.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
