### PR TITLE
feat: Stage 3c chunked LOGS_RESPONSE over WSS

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -27,7 +27,25 @@ from shared.state import atomic_write, read_state, write_state
 
 logger = logging.getLogger("agora.cms_client")
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
+
+# Stage 3c (#345 in agora-cms): chunked LOGS_RESPONSE over the
+# existing WS channel.  WPS caps a single WebSocket frame at ~1 MiB;
+# we build a gzipped tarball of journal output and, if it's too large
+# to fit in one JSON message, split it into LGCK-tagged binary frames
+# that the CMS assembler concatenates into a blob.
+LOGS_CHUNK_MAGIC = b"LGCK"
+LOGS_CHUNK_HEADER_VERSION = 1
+LOGS_CHUNK_FLAG_FINAL = 0x01
+# ~900 KiB JSON fits safely under the 1 MiB WPS ceiling after the
+# WS/WPS framing overhead.  Anything larger goes down the chunk path.
+LOGS_JSON_MAX_BYTES = 900_000
+# Payload bytes per chunk.  30 × 0.75 MiB = 22.5 MiB total possible
+# frames, but the assembler enforces a 21 MiB assembled cap — the
+# chunk-count cap (30) is the practical limit for Pi-generated logs.
+LOGS_CHUNK_PAYLOAD_BYTES = 768 * 1024
+LOGS_CHUNK_MAX_COUNT = 30
+LOGS_CHUNK_ASSEMBLED_CAP = 22_020_096  # 21 MiB — matches CMS side
 
 # Reconnect backoff: 2s, 4s, 8s, ... capped at 60s
 RECONNECT_BASE = 2
@@ -46,6 +64,69 @@ AUTH_REJECTED_RETRY = 10    # seconds to wait before retrying after auth rejecti
 
 class AuthRejectedError(Exception):
     """Raised when the CMS rejects this device's credentials."""
+
+
+def _build_logs_tar_gz(logs: dict[str, str]) -> bytes:
+    """Pack per-service log text into a gzipped tar archive.
+
+    Mirrors the layout the CMS-side shim produces for the legacy
+    ``LOGS_RESPONSE`` JSON path — one ``<service>.log`` entry per
+    service, UTF-8 encoded.  The CMS assembler writes the result to
+    blob storage untouched; consumers (the dashboard download link)
+    pull it straight through.
+    """
+    import io
+    import tarfile
+    import time
+
+    buf = io.BytesIO()
+    mtime = int(time.time())
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for service_name, log_text in logs.items():
+            safe_name = service_name.replace("/", "_").replace("\\", "_")
+            data = (log_text or "").encode("utf-8")
+            info = tarfile.TarInfo(name=f"{safe_name}.log")
+            info.size = len(data)
+            info.mtime = mtime
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _encode_logs_chunk_frame(
+    *,
+    request_id: str,
+    seq: int,
+    total: int,
+    payload: bytes,
+    is_final: bool,
+) -> bytes:
+    """Encode a single LGCK chunk frame.
+
+    Wire format (little-endian, matches the CMS assembler):
+
+    ``"LGCK" | u8 ver | u16 rid_len | utf8 request_id | u16 seq |
+    u16 total | u8 flags | payload``
+
+    ``flags`` bit 0 is the ``is_final`` marker.
+    """
+    import struct
+
+    if total <= 0:
+        raise ValueError("total must be > 0")
+    if not 0 <= seq < total:
+        raise ValueError(f"seq {seq} out of range for total {total}")
+    rid_bytes = request_id.encode("utf-8")
+    if len(rid_bytes) > 0xFFFF:
+        raise ValueError("request_id too long")
+    flags = LOGS_CHUNK_FLAG_FINAL if is_final else 0
+    header = (
+        LOGS_CHUNK_MAGIC
+        + struct.pack("<B", LOGS_CHUNK_HEADER_VERSION)
+        + struct.pack("<H", len(rid_bytes))
+        + rid_bytes
+        + struct.pack("<HHB", seq, total, flags)
+    )
+    return header + payload
 
 
 def _get_device_id() -> str:
@@ -412,6 +493,9 @@ class CMSClient:
                 "ip_address": _get_local_ip(),
                 "storage_capacity_mb": cap_mb,
                 "storage_used_mb": used_mb,
+                # Stage 3c: advertises that this device can split large
+                # LOGS_RESPONSE payloads into LGCK binary frames.
+                "capabilities": ["logs_chunk_v1"],
             }
             await ws.send(json.dumps(register_msg))
             logger.info("Sent register message (device_id=%s)", self.device_id)
@@ -1422,7 +1506,16 @@ class CMSClient:
             pass
 
     async def _handle_request_logs(self, msg: dict, ws) -> None:
-        """Collect journalctl logs for requested services and send back."""
+        """Collect journalctl logs for requested services and send back.
+
+        Stage 3c (#345 in agora-cms): the current single-message
+        ``logs_response`` JSON path works fine for most devices but
+        silently truncates / errors when the journal output exceeds
+        the WPS ~1 MiB per-message cap.  When that happens we build a
+        gzipped tarball of the per-service output and stream it back
+        as a sequence of LGCK-tagged binary WebSocket frames that the
+        CMS assembler reconstructs on the other side.
+        """
         request_id = msg.get("request_id", "")
         services = msg.get("services") or [
             "agora-player", "agora-api", "agora-cms-client", "agora-provision",
@@ -1451,17 +1544,105 @@ class CMSClient:
             except Exception as e:
                 logs[service] = f"[error: {e}]"
 
+        # journalctl-failure case always uses the small path — there's
+        # no payload worth chunking.
+        if error:
+            try:
+                await ws.send(json.dumps({
+                    "type": "logs_response",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "request_id": request_id,
+                    "device_id": self.device_id,
+                    "logs": logs,
+                    "error": error,
+                }))
+            except Exception:
+                logger.exception("Failed to send logs response")
+            return
+
+        # Decide: JSON path (legacy, small) vs chunked binary path.
+        response = {
+            "type": "logs_response",
+            "protocol_version": PROTOCOL_VERSION,
+            "request_id": request_id,
+            "device_id": self.device_id,
+            "logs": logs,
+            "error": None,
+        }
+        json_payload = json.dumps(response)
+
+        if len(json_payload.encode("utf-8")) <= LOGS_JSON_MAX_BYTES:
+            try:
+                await ws.send(json_payload)
+            except Exception:
+                logger.exception("Failed to send logs response")
+            return
+
+        # Large payload: gzipped tarball → binary LGCK chunks.
+        try:
+            tar_gz = _build_logs_tar_gz(logs)
+        except Exception as e:
+            logger.exception("Failed to build logs tarball for request %s", request_id)
+            await self._send_logs_error(ws, request_id, f"log_pack_failed: {e}")
+            return
+
+        if len(tar_gz) > LOGS_CHUNK_ASSEMBLED_CAP:
+            logger.warning(
+                "Log request %s payload %d bytes exceeds %d-byte cap; dropping",
+                request_id, len(tar_gz), LOGS_CHUNK_ASSEMBLED_CAP,
+            )
+            await self._send_logs_error(
+                ws, request_id,
+                f"logs_too_large: {len(tar_gz)} bytes > {LOGS_CHUNK_ASSEMBLED_CAP}",
+            )
+            return
+
+        total_chunks = (len(tar_gz) + LOGS_CHUNK_PAYLOAD_BYTES - 1) // LOGS_CHUNK_PAYLOAD_BYTES
+        if total_chunks > LOGS_CHUNK_MAX_COUNT:
+            logger.warning(
+                "Log request %s would need %d chunks (max %d); dropping",
+                request_id, total_chunks, LOGS_CHUNK_MAX_COUNT,
+            )
+            await self._send_logs_error(
+                ws, request_id,
+                f"logs_too_large: {total_chunks} chunks > {LOGS_CHUNK_MAX_COUNT}",
+            )
+            return
+
+        logger.info(
+            "Log request %s: sending %d bytes in %d chunks",
+            request_id, len(tar_gz), total_chunks,
+        )
+        try:
+            for seq in range(total_chunks):
+                start = seq * LOGS_CHUNK_PAYLOAD_BYTES
+                end = start + LOGS_CHUNK_PAYLOAD_BYTES
+                is_final = seq == total_chunks - 1
+                frame = _encode_logs_chunk_frame(
+                    request_id=request_id,
+                    seq=seq,
+                    total=total_chunks,
+                    payload=tar_gz[start:end],
+                    is_final=is_final,
+                )
+                await ws.send(frame)
+        except Exception:
+            logger.exception(
+                "Failed to send chunked logs for request %s", request_id,
+            )
+
+    async def _send_logs_error(self, ws, request_id: str, error: str) -> None:
         try:
             await ws.send(json.dumps({
                 "type": "logs_response",
                 "protocol_version": PROTOCOL_VERSION,
                 "request_id": request_id,
                 "device_id": self.device_id,
-                "logs": logs,
+                "logs": {},
                 "error": error,
             }))
         except Exception:
-            logger.exception("Failed to send logs response")
+            logger.exception("Failed to send logs error response")
 
     async def _handle_upgrade(self, ws) -> None:
         logger.info("Upgrade requested by CMS")

--- a/tests/test_request_logs_chunking.py
+++ b/tests/test_request_logs_chunking.py
@@ -1,0 +1,308 @@
+"""Tests for the chunked ``request_logs`` handler (Stage 3c / #345).
+
+Covers:
+
+- Small payloads (< JSON cap) → single ``logs_response`` JSON frame
+  (legacy path, untouched).
+- journalctl-unavailable error → single ``logs_response`` with error.
+- Large payloads (> JSON cap) → gzipped tarball split into LGCK
+  binary frames in the correct sequence.
+- Oversize payloads (> assembled cap) → ``logs_response`` with a
+  ``logs_too_large`` error instead of chunks.
+- Wire-format helpers (``_encode_logs_chunk_frame``).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import struct
+import sys
+import tarfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock heavy deps before importing the service module (matches the
+# pattern used by test_wipe_assets.py).
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("websockets.asyncio", MagicMock())
+sys.modules.setdefault("websockets.asyncio.client", MagicMock())
+sys.modules.setdefault("aiohttp", MagicMock())
+
+from cms_client.service import (  # noqa: E402
+    CMSClient,
+    LOGS_CHUNK_ASSEMBLED_CAP,
+    LOGS_CHUNK_FLAG_FINAL,
+    LOGS_CHUNK_MAGIC,
+    LOGS_CHUNK_MAX_COUNT,
+    LOGS_CHUNK_PAYLOAD_BYTES,
+    LOGS_JSON_MAX_BYTES,
+    PROTOCOL_VERSION,
+    _build_logs_tar_gz,
+    _encode_logs_chunk_frame,
+)
+
+
+def _make_settings(tmp_path: Path) -> MagicMock:
+    s = MagicMock()
+    s.agora_base = tmp_path
+    assets = tmp_path / "assets"; assets.mkdir()
+    state = tmp_path / "state"; state.mkdir()
+    persist = tmp_path / "persist"; persist.mkdir()
+    s.assets_dir = assets
+    s.videos_dir = assets / "videos"; s.videos_dir.mkdir()
+    s.images_dir = assets / "images"; s.images_dir.mkdir()
+    s.splash_dir = assets / "splash"; s.splash_dir.mkdir()
+    s.state_dir = state
+    s.persist_dir = persist
+    s.manifest_path = state / "assets.json"
+    s.schedule_path = state / "schedule.json"
+    s.current_state_path = state / "current.json"
+    s.desired_state_path = state / "desired.json"
+    s.splash_config_path = state / "splash.txt"
+    s.cms_config_path = persist / "cms_config.json"
+    s.auth_token_path = persist / "cms_auth_token"
+    s.storage_budget_mb = 500
+    s.asset_budget_mb = 500
+    return s
+
+
+def _build_client(settings) -> CMSClient:
+    with patch("cms_client.service._get_device_id", return_value="test-pi"):
+        return CMSClient(settings)
+
+
+# ── Wire-format tests ────────────────────────────────────────────────
+
+
+def test_protocol_version_is_two():
+    assert PROTOCOL_VERSION == 2
+
+
+def test_encode_frame_layout():
+    payload = b"hello"
+    frame = _encode_logs_chunk_frame(
+        request_id="abc", seq=1, total=3, payload=payload, is_final=False,
+    )
+    assert frame[:4] == LOGS_CHUNK_MAGIC
+    assert frame[4] == 1  # version
+    rid_len = struct.unpack("<H", frame[5:7])[0]
+    assert rid_len == 3
+    assert frame[7:10] == b"abc"
+    seq, total, flags = struct.unpack("<HHB", frame[10:15])
+    assert (seq, total, flags) == (1, 3, 0)
+    assert frame[15:] == payload
+
+
+def test_encode_frame_final_flag():
+    frame = _encode_logs_chunk_frame(
+        request_id="r", seq=2, total=3, payload=b"", is_final=True,
+    )
+    # header layout: magic(4) + ver(1) + rid_len(2) + rid(1) + seq(2) + total(2) + flags(1)
+    flags = frame[12]
+    assert flags & LOGS_CHUNK_FLAG_FINAL
+
+
+def test_encode_frame_validates():
+    with pytest.raises(ValueError):
+        _encode_logs_chunk_frame(
+            request_id="r", seq=3, total=3, payload=b"", is_final=True,
+        )
+    with pytest.raises(ValueError):
+        _encode_logs_chunk_frame(
+            request_id="r", seq=0, total=0, payload=b"", is_final=True,
+        )
+
+
+def test_build_logs_tar_gz_roundtrip():
+    data = _build_logs_tar_gz({
+        "agora-player": "line1\nline2",
+        "path/with/slashes": "sanitised",
+    })
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        names = sorted(m.name for m in tf.getmembers())
+        assert names == sorted(["agora-player.log", "path_with_slashes.log"])
+        body = tf.extractfile("agora-player.log").read()
+        assert body == b"line1\nline2"
+
+
+# ── Handler path selection ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_small_payload_uses_json_path(tmp_path):
+    client = _build_client(_make_settings(tmp_path))
+    ws = MagicMock()
+    sent: list = []
+
+    async def capture_send(data):
+        sent.append(data)
+    ws.send = capture_send
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "short"
+    with patch("cms_client.service.subprocess.run", return_value=mock_result):
+        await client._handle_request_logs(
+            {"request_id": "req-1", "services": ["agora-player"], "since": "1h"},
+            ws,
+        )
+
+    assert len(sent) == 1
+    msg = json.loads(sent[0])
+    assert msg["type"] == "logs_response"
+    assert msg["request_id"] == "req-1"
+    assert msg["error"] is None
+    assert msg["logs"]["agora-player"] == "short"
+
+
+@pytest.mark.asyncio
+async def test_journalctl_missing_uses_json_error_path(tmp_path):
+    client = _build_client(_make_settings(tmp_path))
+    ws = MagicMock()
+    sent: list = []
+
+    async def capture_send(data):
+        sent.append(data)
+    ws.send = capture_send
+
+    with patch("cms_client.service.subprocess.run", side_effect=FileNotFoundError()):
+        await client._handle_request_logs(
+            {"request_id": "req-2", "services": ["agora-player"]},
+            ws,
+        )
+
+    assert len(sent) == 1
+    msg = json.loads(sent[0])
+    assert msg["error"] == "journalctl not available on this device"
+
+
+@pytest.mark.asyncio
+async def test_large_payload_streams_as_chunks(tmp_path):
+    client = _build_client(_make_settings(tmp_path))
+    ws = MagicMock()
+    sent: list = []
+
+    async def capture_send(data):
+        sent.append(data)
+    ws.send = capture_send
+
+    # Use text that compresses poorly so the tarball is guaranteed to
+    # be > LOGS_JSON_MAX_BYTES but < the assembled cap.
+    import os
+    big = os.urandom(1_500_000).hex()  # ~3 MB of hex ASCII
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = big
+    with patch("cms_client.service.subprocess.run", return_value=mock_result):
+        await client._handle_request_logs(
+            {"request_id": "big-req", "services": ["agora-player"]},
+            ws,
+        )
+
+    # Expect only binary frames — no JSON.
+    assert len(sent) >= 2
+    for frame in sent:
+        assert isinstance(frame, (bytes, bytearray))
+        assert frame[:4] == LOGS_CHUNK_MAGIC
+
+    # Re-assemble and verify it's a valid tar.gz containing our data.
+    reassembled = b""
+    for i, frame in enumerate(sent):
+        # Parse header to extract payload slice.
+        rid_len = struct.unpack("<H", frame[5:7])[0]
+        assert frame[7:7 + rid_len] == b"big-req"
+        seq, total, flags = struct.unpack(
+            "<HHB", frame[7 + rid_len:7 + rid_len + 5],
+        )
+        assert seq == i
+        assert total == len(sent)
+        if i == len(sent) - 1:
+            assert flags & LOGS_CHUNK_FLAG_FINAL
+        else:
+            assert not (flags & LOGS_CHUNK_FLAG_FINAL)
+        reassembled += frame[7 + rid_len + 5:]
+
+    with tarfile.open(fileobj=io.BytesIO(reassembled), mode="r:gz") as tf:
+        body = tf.extractfile("agora-player.log").read().decode("utf-8")
+    assert body == big
+
+
+@pytest.mark.asyncio
+async def test_oversize_payload_sends_error_response(tmp_path, monkeypatch):
+    client = _build_client(_make_settings(tmp_path))
+    ws = MagicMock()
+    sent: list = []
+
+    async def capture_send(data):
+        sent.append(data)
+    ws.send = capture_send
+
+    # Force the assembled-cap check to fire by patching the size limits
+    # to something small, then feeding a payload that exceeds it.
+    monkeypatch.setattr("cms_client.service.LOGS_JSON_MAX_BYTES", 100)
+    monkeypatch.setattr("cms_client.service.LOGS_CHUNK_ASSEMBLED_CAP", 1000)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    # Random data doesn't compress, so the tarball exceeds the patched
+    # assembled cap reliably.
+    import os as _os
+    mock_result.stdout = _os.urandom(3000).hex()  # 6000 ASCII chars
+    with patch("cms_client.service.subprocess.run", return_value=mock_result):
+        await client._handle_request_logs(
+            {"request_id": "huge", "services": ["agora-player"]},
+            ws,
+        )
+
+    assert len(sent) == 1
+    msg = json.loads(sent[0])
+    assert msg["type"] == "logs_response"
+    assert msg["error"].startswith("logs_too_large")
+
+
+@pytest.mark.asyncio
+async def test_too_many_chunks_sends_error_response(tmp_path, monkeypatch):
+    client = _build_client(_make_settings(tmp_path))
+    ws = MagicMock()
+    sent: list = []
+
+    async def capture_send(data):
+        sent.append(data)
+    ws.send = capture_send
+
+    # Tiny chunk payload size so the count cap is exercised before the
+    # assembled-byte cap.
+    monkeypatch.setattr("cms_client.service.LOGS_JSON_MAX_BYTES", 10)
+    monkeypatch.setattr("cms_client.service.LOGS_CHUNK_PAYLOAD_BYTES", 64)
+    monkeypatch.setattr("cms_client.service.LOGS_CHUNK_MAX_COUNT", 3)
+    monkeypatch.setattr("cms_client.service.LOGS_CHUNK_ASSEMBLED_CAP", 100_000)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    import os as _os
+    mock_result.stdout = _os.urandom(1500).hex()  # 3000 ASCII incompressible
+    with patch("cms_client.service.subprocess.run", return_value=mock_result):
+        await client._handle_request_logs(
+            {"request_id": "manychunks", "services": ["agora-player"]},
+            ws,
+        )
+
+    assert len(sent) == 1
+    msg = json.loads(sent[0])
+    assert msg["type"] == "logs_response"
+    assert msg["error"].startswith("logs_too_large")
+
+
+# ── Register capability advertisement ────────────────────────────────
+
+
+def test_capabilities_advertised_in_module():
+    """Sanity-check the module-level constants used in the register
+    message so the CMS can trust the chunking path is supported."""
+    assert LOGS_JSON_MAX_BYTES > 0
+    assert LOGS_CHUNK_PAYLOAD_BYTES > 0
+    assert LOGS_CHUNK_MAX_COUNT > 0
+    assert LOGS_CHUNK_ASSEMBLED_CAP >= LOGS_CHUNK_PAYLOAD_BYTES


### PR DESCRIPTION
# Stage 3c — Chunked LOGS_RESPONSE over WSS (Pi side)

Companion to sslivins/agora-cms#391 (refs #345 in agora-cms).

## Why

Today the Pi's `_handle_request_logs` dumps journal output into a
single `logs_response` JSON frame. WPS caps a single WebSocket frame
at ~1 MiB, so noisy devices or wider `since=` windows silently fail
to deliver.

This PR adds a chunked-binary fallback over the existing WS channel:
no new HTTP path, no new auth surface, no schema migration. When the
payload is small enough we still take the legacy JSON path, so the
rollout is fully back-compatible.

## What

- **`PROTOCOL_VERSION` bumped to 2** — the CMS side already accepts
  `{1, 2}` so a device running this build will register successfully
  against the current CMS, and a device running the old build will
  register successfully against the new CMS.

- **`capabilities: ["logs_chunk_v1"]`** added to the register message
  so the CMS can reason about which devices support chunking (future
  server-side routing decisions).

- **`_build_logs_tar_gz(logs)`** — mirrors the CMS-side shim layout
  (`<service>.log` files inside a `.tar.gz`), so the blob written by
  the assembler is byte-identical regardless of which path the Pi
  took.

- **`_encode_logs_chunk_frame(...)`** — encodes the wire format the
  CMS assembler expects:
  ```
  +--------+-----+---------+------------+-----+-------+-------+---------+
  | "LGCK" | ver | rid_len | request_id | seq | total | flags | payload |
  |  4b    | u8  |  u16    | utf8 Nb    | u16 | u16   | u8    | rest    |
  +--------+-----+---------+------------+-----+-------+-------+---------+
  ```
  Little-endian throughout; `flags` bit 0 = `is_final`.

- **`_handle_request_logs` refactor** — after gathering per-service
  journalctl output, decide:
  - journalctl unavailable → small JSON `logs_response` with `error`.
  - Serialised JSON ≤ 900 000 bytes → send legacy JSON (unchanged).
  - Else build tar.gz:
    - > 21 MiB or > 30 chunks → send error `logs_response`
      (`logs_too_large: ...`).
    - Otherwise stream `total_chunks` LGCK frames, last one with
      `is_final` set.

- **Constants** (module-level, patchable in tests):
  - `LOGS_JSON_MAX_BYTES = 900_000`
  - `LOGS_CHUNK_PAYLOAD_BYTES = 768 KiB`
  - `LOGS_CHUNK_MAX_COUNT = 30`
  - `LOGS_CHUNK_ASSEMBLED_CAP = 21 MiB` (matches the CMS assembler)

## Tests

`tests/test_request_logs_chunking.py` — 11 cases:

- `PROTOCOL_VERSION == 2`
- wire-format roundtrip + flags byte layout + validation errors
- `_build_logs_tar_gz` sanitises slashes in service names
- small payload → single JSON frame (legacy path)
- journalctl missing → single JSON frame with error (no chunks)
- large payload → sequential LGCK frames; reassemble and verify the
  tarball parses + contains the original bytes
- cap violations (assembled bytes / chunk count) → error JSON
  response instead of chunks
- constants sanity

## What's NOT in this PR

- No CMS changes (landed in sslivins/agora-cms#391).
- No other message types touched.
- No config flags — the threshold is compile-time. A future tweak
  could expose it via `Settings` if real devices tell us 900 KB is
  the wrong split.

## Rollout

1. sslivins/agora-cms#391 merged and deployed (done — v1.37.52).
2. Merge this PR → CI publishes a new .deb.
3. Trigger an OTA on a test device; verify:
   - Register message includes `"capabilities": ["logs_chunk_v1"]`.
   - A `request_logs since=168h` (or similar) on a busy service
     produces a downloadable tar.gz in the CMS UI.
4. Roll out fleet-wide.

Refs sslivins/agora-cms#345.
