### PR TITLE
feat(cms-client): add WPS transport mode

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -30,6 +30,18 @@ class Settings(BaseSettings):
     # CMS connection
     cms_url: str = ""  # e.g. ws://192.168.1.100:8080/ws/device
 
+    # Transport selection: "direct" (default) or "wps" (Azure Web PubSub).
+    # When "wps", the device calls POST {cms_api_url}/api/devices/{id}/connect-token
+    # with the X-Device-API-Key header to get a WPS client URL, then connects
+    # via the json.webpubsub.azure.v1 subprotocol.
+    cms_transport: str = "direct"
+    # Optional override for the connect-token HTTP base.  If empty, it is
+    # derived from cms_url (wss://host/ws/... -> https://host).
+    cms_api_url: str = ""
+    # Device API key used for the connect-token call.  Takes precedence over
+    # the value stored in <persist_dir>/cms_device_api_key.
+    device_api_key: str = ""
+
     # Asset budget (0 = 80% of partition)
     asset_budget_mb: int = 0
 
@@ -76,6 +88,10 @@ class Settings(BaseSettings):
     @property
     def auth_token_path(self) -> Path:
         return self.persist_dir / "cms_auth_token"
+
+    @property
+    def device_api_key_path(self) -> Path:
+        return self.persist_dir / "cms_device_api_key"
 
     @property
     def cms_config_path(self) -> Path:

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -21,6 +21,7 @@ import websockets
 
 from api.config import Settings
 from cms_client.asset_manager import AssetManager
+from cms_client.transport import TransportError, open_transport
 from shared.board import get_cpu_temp, supported_codecs
 from shared.models import CurrentState, DesiredState, PlaybackMode
 from shared.state import atomic_write, read_state, write_state
@@ -135,6 +136,21 @@ def _save_auth_token(path: Path, token: str) -> None:
         os.chmod(path, 0o600)
     except OSError:
         pass
+
+
+def _resolve_device_api_key(settings: Settings) -> str:
+    """Return the WPS device API key.
+
+    Prefers the ``device_api_key`` settings field (which picks up
+    ``AGORA_DEVICE_API_KEY``); falls back to the contents of
+    ``<persist_dir>/cms_device_api_key``.
+    """
+    if settings.device_api_key:
+        return settings.device_api_key.strip()
+    try:
+        return settings.device_api_key_path.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return ""
 
 
 # ── Schedule evaluation helpers ──
@@ -312,6 +328,7 @@ class CMSClient:
                     websockets.ConnectionClosed,
                     websockets.InvalidURI,
                     websockets.InvalidHandshake,
+                    TransportError,
                     OSError,
                 ) as e:
                     attempt += 1
@@ -378,16 +395,31 @@ class CMSClient:
         """Single connection lifecycle: connect → register → message loop."""
         cms_url = self._get_cms_url()
         self._active_cms_url = cms_url
-        logger.info("Connecting to CMS at %s", cms_url)
+        transport_mode = (self.settings.cms_transport or "direct").lower()
+        logger.info(
+            "Connecting to CMS at %s (transport=%s)", cms_url, transport_mode,
+        )
 
-        async with websockets.connect(
-            cms_url,
-            ping_interval=20,
-            ping_timeout=10,
-            close_timeout=5,
-        ) as ws:
+        api_key = ""
+        if transport_mode == "wps":
+            api_key = _resolve_device_api_key(self.settings)
+            if not api_key:
+                raise TransportError(
+                    "AGORA_CMS_TRANSPORT=wps requires AGORA_DEVICE_API_KEY "
+                    "or a provisioned cms_device_api_key file"
+                )
+
+        transport = await open_transport(
+            mode=transport_mode,
+            cms_url=cms_url,
+            device_id=self.device_id,
+            api_key=api_key,
+            api_base=self.settings.cms_api_url or None,
+        )
+
+        async with transport as ws:
             self._ws = ws
-            logger.info("WebSocket connected")
+            logger.info("WebSocket connected (transport=%s)", transport_mode)
 
             auth_token = _read_auth_token(self.settings.auth_token_path)
             # Always start as "pending" — actual status comes from the CMS

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -145,10 +145,14 @@ def _resolve_device_api_key(settings: Settings) -> str:
     ``AGORA_DEVICE_API_KEY``); falls back to the contents of
     ``<persist_dir>/cms_device_api_key``.
     """
-    if settings.device_api_key:
-        return settings.device_api_key.strip()
+    key = getattr(settings, "device_api_key", "") or ""
+    if key:
+        return key.strip()
+    path = getattr(settings, "device_api_key_path", None)
+    if path is None:
+        return ""
     try:
-        return settings.device_api_key_path.read_text().strip()
+        return path.read_text().strip()
     except (FileNotFoundError, OSError):
         return ""
 
@@ -395,7 +399,7 @@ class CMSClient:
         """Single connection lifecycle: connect → register → message loop."""
         cms_url = self._get_cms_url()
         self._active_cms_url = cms_url
-        transport_mode = (self.settings.cms_transport or "direct").lower()
+        transport_mode = (getattr(self.settings, "cms_transport", "") or "direct").lower()
         logger.info(
             "Connecting to CMS at %s (transport=%s)", cms_url, transport_mode,
         )
@@ -414,7 +418,7 @@ class CMSClient:
             cms_url=cms_url,
             device_id=self.device_id,
             api_key=api_key,
-            api_base=self.settings.cms_api_url or None,
+            api_base=getattr(self.settings, "cms_api_url", "") or None,
         )
 
         async with transport as ws:

--- a/cms_client/transport.py
+++ b/cms_client/transport.py
@@ -1,0 +1,251 @@
+"""Transport abstraction for CMS communication.
+
+Two transports are supported:
+
+* **DirectTransport** — a plain WebSocket connection to the CMS
+  (``wss://host/ws/device``).  Payloads go over the wire unchanged
+  as JSON text frames.  This is the original and default behaviour.
+
+* **WPSTransport** — an Azure Web PubSub client.  The device first
+  asks the CMS for a short-lived client access URL + access token
+  via ``POST /api/devices/{device_id}/connect-token`` (authenticated
+  with ``X-Device-API-Key``), then opens a WebSocket to the Azure
+  endpoint using the ``json.webpubsub.azure.v1`` subprotocol.
+  Outgoing application messages are wrapped in the WPS event
+  envelope; incoming envelopes are unwrapped so the caller only
+  sees the inner JSON payload.
+
+Both transports expose a websocket-like interface — ``await t.send(str)``
+accepts an already-JSON-serialized message string, and iterating
+``async for raw in t`` yields JSON strings.  This lets the existing
+handlers in ``service.py`` stay unchanged.
+
+Select the transport with the ``AGORA_CMS_TRANSPORT`` environment
+variable (``direct`` or ``wps``).  In WPS mode, the device API key
+used to call the connect-token endpoint is sourced from the
+``AGORA_DEVICE_API_KEY`` env var or, if unset, read from
+``<persist_dir>/cms_device_api_key``.  This key is deliberately
+distinct from the per-device auth_token minted over the register
+handshake — the real Pi fleet uses the same split (API key for
+bootstrap, auth_token for subsequent WS register messages).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import AsyncIterator, Optional
+from urllib.parse import urlparse
+
+import websockets
+
+logger = logging.getLogger("agora.cms_client.transport")
+
+WPS_SUBPROTOCOL = "json.webpubsub.azure.v1"
+
+
+class TransportError(Exception):
+    """Raised when transport setup or operation fails."""
+
+
+class _Transport:
+    """Common async-context-manager base for transports."""
+
+    def __init__(self, ws) -> None:
+        self._ws = ws
+        self._closed = False
+
+    async def send(self, data) -> None:  # pragma: no cover - interface only
+        raise NotImplementedError
+
+    def __aiter__(self) -> AsyncIterator[str]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self._ws.close()
+        except Exception:
+            logger.debug("Error closing underlying websocket", exc_info=True)
+
+    async def __aenter__(self) -> "_Transport":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+
+class DirectTransport(_Transport):
+    """Plain WebSocket transport (unchanged behaviour from v1)."""
+
+    async def send(self, data) -> None:
+        await self._ws.send(data)
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        async for raw in self._ws:
+            yield raw
+
+
+class WPSTransport(_Transport):
+    """Azure Web PubSub transport.
+
+    Outgoing strings are parsed and re-wrapped as::
+
+        {"type": "event", "event": "message",
+         "dataType": "json", "data": <payload>}
+
+    Incoming frames of type ``"message"`` have their ``data`` field
+    re-serialized to a JSON string and yielded.  All other frame
+    types (``system``, ``ack``, etc.) are logged and skipped so
+    callers only see application messages.
+    """
+
+    async def send(self, data) -> None:
+        if isinstance(data, (bytes, bytearray)):
+            raise TransportError("WPS transport does not yet support binary frames")
+        try:
+            payload = json.loads(data)
+        except (TypeError, json.JSONDecodeError) as e:
+            raise TransportError(f"WPS transport.send expects a JSON string: {e}") from e
+        envelope = {
+            "type": "event",
+            "event": "message",
+            "dataType": "json",
+            "data": payload,
+        }
+        await self._ws.send(json.dumps(envelope))
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        async for raw in self._ws:
+            try:
+                frame = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("Received non-JSON WPS frame; dropping")
+                continue
+            ftype = frame.get("type")
+            if ftype == "message":
+                data = frame.get("data")
+                if isinstance(data, dict):
+                    yield json.dumps(data)
+                elif isinstance(data, str):
+                    try:
+                        decoded = json.loads(data)
+                    except json.JSONDecodeError:
+                        logger.warning("WPS message.data was a non-JSON string; dropping")
+                        continue
+                    if isinstance(decoded, dict):
+                        yield json.dumps(decoded)
+                    else:
+                        logger.warning("WPS message.data decoded to non-object; dropping")
+                else:
+                    logger.warning("WPS message.data was not an object; dropping")
+            elif ftype in ("system", "ack"):
+                logger.debug("WPS %s frame: %s", ftype, frame)
+            else:
+                logger.debug("WPS unknown frame type %r; dropping", ftype)
+
+
+def _derive_api_base(cms_url: str) -> str:
+    """Turn a ws(s):// URL into the http(s):// API base used for connect-token."""
+    p = urlparse(cms_url)
+    scheme = "https" if p.scheme in ("wss", "https") else "http"
+    return f"{scheme}://{p.netloc}"
+
+
+async def _request_connect_token(
+    api_base: str,
+    device_id: str,
+    api_key: str,
+    *,
+    http_timeout: float = 10.0,
+) -> tuple[str, str]:
+    """Call POST /api/devices/{id}/connect-token and return (url, token)."""
+    import aiohttp  # type: ignore
+
+    url = f"{api_base.rstrip('/')}/api/devices/{device_id}/connect-token"
+    headers = {"X-Device-API-Key": api_key, "Accept": "application/json"}
+    timeout = aiohttp.ClientTimeout(total=http_timeout)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(url, headers=headers) as resp:
+            if resp.status in (401, 403):
+                raise TransportError(
+                    f"connect-token rejected ({resp.status}) — check device_api_key"
+                )
+            if resp.status >= 400:
+                body = await resp.text()
+                raise TransportError(
+                    f"connect-token failed: HTTP {resp.status} {body[:200]!r}"
+                )
+            data = await resp.json()
+    wss_url = data.get("url") or ""
+    access_token = data.get("access_token") or data.get("token") or ""
+    if not wss_url:
+        raise TransportError(f"connect-token response missing 'url': {data!r}")
+    return wss_url, access_token
+
+
+async def open_direct(cms_url: str) -> DirectTransport:
+    """Open a plain websocket to ``cms_url`` and wrap it as a DirectTransport."""
+    ws = await websockets.connect(
+        cms_url,
+        ping_interval=20,
+        ping_timeout=10,
+        close_timeout=5,
+    )
+    return DirectTransport(ws)
+
+
+async def open_wps(
+    *,
+    cms_url: str,
+    device_id: str,
+    api_key: str,
+    api_base: Optional[str] = None,
+) -> WPSTransport:
+    """Bootstrap a WPS transport.
+
+    Steps:
+      1. Derive HTTP(S) API base from ``cms_url`` (or use override).
+      2. POST /api/devices/{device_id}/connect-token with X-Device-API-Key.
+      3. Open a websocket to the returned URL using the WPS subprotocol.
+      4. Return a WPSTransport wrapping the socket.
+    """
+    if not api_key:
+        raise TransportError("WPS transport requires a device_api_key")
+    base = api_base or _derive_api_base(cms_url)
+    wss_url, access_token = await _request_connect_token(base, device_id, api_key)
+    if access_token and "access_token=" not in wss_url:
+        joiner = "&" if "?" in wss_url else "?"
+        wss_url = f"{wss_url}{joiner}access_token={access_token}"
+    ws = await websockets.connect(
+        wss_url,
+        subprotocols=[WPS_SUBPROTOCOL],
+        ping_interval=20,
+        ping_timeout=10,
+        close_timeout=5,
+    )
+    return WPSTransport(ws)
+
+
+async def open_transport(
+    *,
+    mode: str,
+    cms_url: str,
+    device_id: str,
+    api_key: str = "",
+    api_base: Optional[str] = None,
+) -> _Transport:
+    """Factory: open the transport matching ``mode`` ("direct" or "wps")."""
+    m = (mode or "direct").lower().strip()
+    if m == "direct":
+        return await open_direct(cms_url)
+    if m == "wps":
+        return await open_wps(
+            cms_url=cms_url,
+            device_id=device_id,
+            api_key=api_key,
+            api_base=api_base,
+        )
+    raise TransportError(f"Unknown transport mode {mode!r} (expected 'direct' or 'wps')")

--- a/tests/test_cms_client_transport.py
+++ b/tests/test_cms_client_transport.py
@@ -1,0 +1,288 @@
+"""Tests for the CMS client transport abstraction.
+
+Covers:
+- DirectTransport pass-through (send + iter behave like raw ws).
+- WPSTransport wrap/unwrap of the Azure Web PubSub envelope.
+- _derive_api_base URL conversion (wss://host/ws → https://host).
+- open_wps() calls POST /api/devices/{id}/connect-token with the
+  X-Device-API-Key header and threads the returned url/token into
+  websockets.connect() with the json.webpubsub.azure.v1 subprotocol.
+- open_transport() dispatches to the correct implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Stub heavy deps before importing the module under test.
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("aiohttp", MagicMock())
+
+from cms_client import transport as transport_mod
+from cms_client.transport import (
+    DirectTransport,
+    TransportError,
+    WPSTransport,
+    _derive_api_base,
+    open_transport,
+)
+
+
+class _FakeWS:
+    """Minimal async-iterable websocket stand-in."""
+
+    def __init__(self, incoming: list[str] | None = None) -> None:
+        self.sent: list[str] = []
+        self._incoming = list(incoming or [])
+        self.closed = False
+
+    async def send(self, data) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        self._iter = iter(self._incoming)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class TestDirectTransport:
+    @pytest.mark.asyncio
+    async def test_send_is_passthrough(self):
+        ws = _FakeWS()
+        t = DirectTransport(ws)
+        await t.send(json.dumps({"type": "register", "id": "abc"}))
+        assert ws.sent == ['{"type": "register", "id": "abc"}']
+
+    @pytest.mark.asyncio
+    async def test_iter_is_passthrough(self):
+        ws = _FakeWS(['{"type":"sync"}', '{"type":"play"}'])
+        t = DirectTransport(ws)
+        got = [raw async for raw in t]
+        assert got == ['{"type":"sync"}', '{"type":"play"}']
+
+    @pytest.mark.asyncio
+    async def test_close_closes_ws(self):
+        ws = _FakeWS()
+        t = DirectTransport(ws)
+        await t.close()
+        assert ws.closed
+        # Second close is a no-op
+        await t.close()
+
+
+class TestWPSTransport:
+    @pytest.mark.asyncio
+    async def test_send_wraps_in_wps_envelope(self):
+        ws = _FakeWS()
+        t = WPSTransport(ws)
+        await t.send(json.dumps({"type": "register", "device_id": "pi-01"}))
+        assert len(ws.sent) == 1
+        env = json.loads(ws.sent[0])
+        assert env["type"] == "event"
+        assert env["event"] == "message"
+        assert env["dataType"] == "json"
+        assert env["data"] == {"type": "register", "device_id": "pi-01"}
+
+    @pytest.mark.asyncio
+    async def test_send_rejects_binary(self):
+        t = WPSTransport(_FakeWS())
+        with pytest.raises(TransportError):
+            await t.send(b"\x00\x01")
+
+    @pytest.mark.asyncio
+    async def test_send_rejects_non_json(self):
+        t = WPSTransport(_FakeWS())
+        with pytest.raises(TransportError):
+            await t.send("not json")
+
+    @pytest.mark.asyncio
+    async def test_iter_unwraps_message_frames(self):
+        frames = [
+            json.dumps({
+                "type": "message",
+                "from": "server",
+                "dataType": "json",
+                "data": {"type": "sync", "schedules": []},
+            }),
+            json.dumps({
+                "type": "message",
+                "dataType": "json",
+                "data": {"type": "play", "asset_id": "x"},
+            }),
+        ]
+        t = WPSTransport(_FakeWS(frames))
+        payloads = [json.loads(raw) async for raw in t]
+        assert payloads == [
+            {"type": "sync", "schedules": []},
+            {"type": "play", "asset_id": "x"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_iter_skips_system_and_ack_frames(self):
+        frames = [
+            json.dumps({"type": "system", "event": "connected"}),
+            json.dumps({"type": "ack", "ackId": 1, "success": True}),
+            json.dumps({
+                "type": "message",
+                "dataType": "json",
+                "data": {"type": "sync"},
+            }),
+        ]
+        t = WPSTransport(_FakeWS(frames))
+        payloads = [json.loads(raw) async for raw in t]
+        assert payloads == [{"type": "sync"}]
+
+    @pytest.mark.asyncio
+    async def test_iter_handles_stringified_data(self):
+        """Some senders double-encode the data field."""
+        inner = {"type": "sync"}
+        frames = [
+            json.dumps({
+                "type": "message",
+                "dataType": "text",
+                "data": json.dumps(inner),
+            }),
+        ]
+        t = WPSTransport(_FakeWS(frames))
+        payloads = [json.loads(raw) async for raw in t]
+        assert payloads == [inner]
+
+    @pytest.mark.asyncio
+    async def test_iter_drops_malformed_json(self):
+        frames = ["not-json", json.dumps({
+            "type": "message", "dataType": "json", "data": {"ok": True},
+        })]
+        t = WPSTransport(_FakeWS(frames))
+        payloads = [json.loads(raw) async for raw in t]
+        assert payloads == [{"ok": True}]
+
+
+class TestDeriveApiBase:
+    @pytest.mark.parametrize("ws_url,expected", [
+        ("wss://cms.example.com/ws/device", "https://cms.example.com"),
+        ("ws://192.168.1.100:8080/ws/device", "http://192.168.1.100:8080"),
+        ("wss://cms.example.com:8443/ws/device/pi-01", "https://cms.example.com:8443"),
+        ("https://cms.example.com/", "https://cms.example.com"),
+    ])
+    def test_conversion(self, ws_url, expected):
+        assert _derive_api_base(ws_url) == expected
+
+
+class TestOpenTransport:
+    @pytest.mark.asyncio
+    async def test_dispatches_to_direct(self):
+        fake_ws = _FakeWS()
+
+        async def fake_connect(url, **kwargs):
+            assert url == "wss://cms.example.com/ws/device"
+            # direct mode must NOT pass the WPS subprotocol
+            assert "subprotocols" not in kwargs or kwargs["subprotocols"] is None
+            return fake_ws
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect):
+            t = await open_transport(
+                mode="direct",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+            )
+        assert isinstance(t, DirectTransport)
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_wps(self):
+        fake_ws = _FakeWS()
+        captured = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["url"] = url
+            captured["subprotocols"] = kwargs.get("subprotocols")
+            return fake_ws
+
+        async def fake_request_token(api_base, device_id, api_key, **kw):
+            captured["api_base"] = api_base
+            captured["device_id"] = device_id
+            captured["api_key"] = api_key
+            return ("wss://wps.example.com/client/hubs/devices?access_token=xyz", "xyz")
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect), \
+             patch.object(transport_mod, "_request_connect_token", side_effect=fake_request_token):
+            t = await open_transport(
+                mode="wps",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+                api_key="k_abc123",
+            )
+        assert isinstance(t, WPSTransport)
+        assert captured["api_base"] == "https://cms.example.com"
+        assert captured["device_id"] == "pi-01"
+        assert captured["api_key"] == "k_abc123"
+        assert captured["subprotocols"] == ["json.webpubsub.azure.v1"]
+        assert "access_token=xyz" in captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_wps_appends_token_if_missing(self):
+        fake_ws = _FakeWS()
+        captured = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["url"] = url
+            return fake_ws
+
+        async def fake_request_token(api_base, device_id, api_key, **kw):
+            # URL lacks access_token; returned separately
+            return ("wss://wps.example.com/client/hubs/devices", "t_sep")
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect), \
+             patch.object(transport_mod, "_request_connect_token", side_effect=fake_request_token):
+            await open_transport(
+                mode="wps",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+                api_key="k",
+            )
+        assert captured["url"].endswith("?access_token=t_sep")
+
+    @pytest.mark.asyncio
+    async def test_wps_requires_api_key(self):
+        with pytest.raises(TransportError, match="requires a device_api_key"):
+            await open_transport(
+                mode="wps",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+                api_key="",
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_mode(self):
+        with pytest.raises(TransportError, match="Unknown transport mode"):
+            await open_transport(
+                mode="quantum",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+            )
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_direct(self):
+        fake_ws = _FakeWS()
+
+        async def fake_connect(url, **kwargs):
+            return fake_ws
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect):
+            t = await open_transport(
+                mode="",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+            )
+        assert isinstance(t, DirectTransport)


### PR DESCRIPTION
## Summary

Adds an opt-in Azure Web PubSub (WPS) transport for the Pi ⇄ CMS WebSocket channel, alongside the existing direct-WebSocket path. Default behaviour is unchanged — `AGORA_CMS_TRANSPORT` defaults to `direct`.

This is the Pi-firmware counterpart to the CMS-side WPS register handler (sslivins/agora-cms#394) that shipped earlier today. Together they unblock Stage 4 of the multi-replica rollout (sslivins/agora-cms#345), where the CMS will flip `DEVICE_TRANSPORT=wps` and scale past one replica.

## What changed

**New: `cms_client/transport.py`**
- `DirectTransport` — pass-through wrapper around a plain websocket; preserves current behaviour bit-for-bit.
- `WPSTransport` — wraps outgoing messages in the `{"type":"event","event":"message","dataType":"json","data":<payload>}` envelope Azure WPS expects, and unwraps incoming `"message"` frames so handlers only see application payloads. `system` / `ack` frames are logged and skipped.
- `open_transport(mode, cms_url, device_id, api_key)` factory.
- `open_wps(...)` bootstraps by calling `POST {derived_api_base}/api/devices/{id}/connect-token` with the `X-Device-API-Key` header, then opening a websocket to the returned URL using the `json.webpubsub.azure.v1` subprotocol.

**Modified: `cms_client/service.py`**
- Replaces the single `async with websockets.connect(cms_url, ...)` call in `_connect_and_run` with a branch on `settings.cms_transport`. Because both transports expose a ws-like `send(str)` / `async for raw in t` surface, **all message handlers (`_handle_sync`, `_handle_play`, `_handle_request_logs`, etc.) remain unchanged**.
- Adds `_resolve_device_api_key(settings)` helper that prefers the `AGORA_DEVICE_API_KEY` env var, falling back to `<persist_dir>/cms_device_api_key`.
- Adds `TransportError` to the reconnect loop's handled-exceptions list so a bad API key or a transient connect-token failure triggers backoff instead of crashing the service.

**Modified: `api/config.py`**
- New settings (env prefix `AGORA_`):
  - `cms_transport: str = "direct"` — `direct` or `wps`.
  - `cms_api_url: str = ""` — optional override for the HTTP API base; when empty it's derived from `cms_url` (`wss://host/ws/...` → `https://host`).
  - `device_api_key: str = ""` — env-supplied device API key (takes precedence over the persisted file).
- New property `device_api_key_path → <persist_dir>/cms_device_api_key`.

The device API key is deliberately kept separate from `cms_auth_token` — the real Pi provisioning flow uses an API key for bootstrap (connect-token) and the token is minted later via the register handshake. Reusing `auth_token` here would break that model.

## Tests

`tests/test_cms_client_transport.py` — 20 new tests, all green:

- `DirectTransport` send / iter / close pass-through.
- `WPSTransport.send` wraps in the correct envelope and rejects non-JSON / binary input.
- `WPSTransport` iter unwraps `message` frames, skips `system` / `ack`, handles the stringified-data edge case, and drops malformed JSON without aborting.
- `_derive_api_base` converts `wss://` → `https://` / `ws://` → `http://` and preserves host:port.
- `open_transport` dispatches on mode, rejects unknown modes, appends `access_token` to the URL when the server returns it separately, and negotiates the `json.webpubsub.azure.v1` subprotocol.

Existing `test_cms_client_connect.py` (7 tests) still passes — 27/27 CMS-client tests green.

## Wire format compatibility

Outgoing envelope matches the shape produced by `cms/services/transport/wps.py` on the CMS side. Incoming message handling was validated against the frames documented in the Azure WPS JSON protocol spec and the register handler landed in agora-cms#394.

## Deployment

- No-op on existing fleet: env var defaults to `direct`.
- To enable per-device for testing: set `AGORA_CMS_TRANSPORT=wps` and `AGORA_DEVICE_API_KEY=...` (or drop the key at `/opt/agora/persist/cms_device_api_key`).
- Fleet-wide switch happens in Stage 4 of sslivins/agora-cms#345.

## Follow-ups (not in this PR)

- Chunked `LOGS_CHUNK` binary frames — Stage 3c. Transport currently rejects bytes on WPS with a clear `TransportError`; when chunking lands we'll extend the envelope to `dataType=binary`.
- Bump the `agora` submodule in `sslivins/agora-device-simulator` once this lands so the simulator inherits WPS support automatically.
