### PR TITLE
fix(cms-client): read api_key from canonical persist path in WPS mode

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     # derived from cms_url (wss://host/ws/... -> https://host).
     cms_api_url: str = ""
     # Device API key used for the connect-token call.  Takes precedence over
-    # the value stored in <persist_dir>/cms_device_api_key.
+    # the value stored in <persist_dir>/api_key.
     device_api_key: str = ""
 
     # Asset budget (0 = 80% of partition)
@@ -88,10 +88,6 @@ class Settings(BaseSettings):
     @property
     def auth_token_path(self) -> Path:
         return self.persist_dir / "cms_auth_token"
-
-    @property
-    def device_api_key_path(self) -> Path:
-        return self.persist_dir / "cms_device_api_key"
 
     @property
     def cms_config_path(self) -> Path:

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -220,20 +220,19 @@ def _save_auth_token(path: Path, token: str) -> None:
 
 
 def _resolve_device_api_key(settings: Settings) -> str:
-    """Return the WPS device API key.
+    """Return the device API key used for WPS transport auth.
 
-    Prefers the ``device_api_key`` settings field (which picks up
-    ``AGORA_DEVICE_API_KEY``); falls back to the contents of
-    ``<persist_dir>/cms_device_api_key``.
+    Prefers ``AGORA_DEVICE_API_KEY`` (dev/test override);
+    otherwise reads ``<persist_dir>/api_key`` — the same file CMS
+    rotates into via the config message and that direct-mode
+    transport uses for asset downloads.
     """
     key = getattr(settings, "device_api_key", "") or ""
     if key:
         return key.strip()
-    path = getattr(settings, "device_api_key_path", None)
-    if path is None:
-        return ""
+    key_path = settings.persist_dir / "api_key"
     try:
-        return path.read_text().strip()
+        return key_path.read_text().strip()
     except (FileNotFoundError, OSError):
         return ""
 
@@ -491,7 +490,7 @@ class CMSClient:
             if not api_key:
                 raise TransportError(
                     "AGORA_CMS_TRANSPORT=wps requires AGORA_DEVICE_API_KEY "
-                    "or a provisioned cms_device_api_key file"
+                    "or a populated <persist_dir>/api_key file"
                 )
 
         transport = await open_transport(

--- a/cms_client/transport.py
+++ b/cms_client/transport.py
@@ -24,10 +24,11 @@ Select the transport with the ``AGORA_CMS_TRANSPORT`` environment
 variable (``direct`` or ``wps``).  In WPS mode, the device API key
 used to call the connect-token endpoint is sourced from the
 ``AGORA_DEVICE_API_KEY`` env var or, if unset, read from
-``<persist_dir>/cms_device_api_key``.  This key is deliberately
-distinct from the per-device auth_token minted over the register
-handshake — the real Pi fleet uses the same split (API key for
-bootstrap, auth_token for subsequent WS register messages).
+``<persist_dir>/api_key`` — the same file CMS rotates into via the
+config message and that direct-mode transport uses for asset
+downloads.  This key is distinct from the per-device auth_token
+minted over the register handshake (API key for bootstrap,
+auth_token for subsequent WS register messages).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

In WPS transport mode, the CMS client reads the device API key from `<persist_dir>/cms_device_api_key`. **Nothing writes to that file** — not firmware, not install scripts, not CMS config messages. The canonical live key lives at `<persist_dir>/api_key`: CMS rotates into it via the config message (`agora-cms service.py:1391`), direct-mode uses it for asset downloads, and the web UI override reads it.

Result: fresh Pis that flip to `AGORA_CMS_TRANSPORT=wps` fail auth until someone manually `cp`s `api_key` → `cms_device_api_key`. (Observed on the test Pi at 192.168.1.53 — required a manual copy to get WPS working.)

## Fix

Point `_resolve_device_api_key()` at the canonical `<persist_dir>/api_key` file instead of the dead `cms_device_api_key` path. No CMS-side change needed — this is a one-sided firmware fix.

## Changes

- `cms_client/service.py` — `_resolve_device_api_key()` now falls back to `settings.persist_dir / "api_key"`. Also updated the `TransportError` message that referenced the old filename.
- `api/config.py` — removed the unused `device_api_key_path` property (not read anywhere after this change) and updated the `device_api_key` field comment.
- `cms_client/transport.py` — module docstring updated to match.

## Out of scope

- Splitting the web-UI API key and CMS device API key into distinct files (separate latent bug — leaving for later).
- No change to `agora-cms` or `agora-device-simulator`.

## Test Pi

Test Pi at 192.168.1.53 has both files populated with the same key today, so there's no rollback concern — it will keep working with either the old or new code path.

## Tests

Existing relevant tests (`test_cms_client_transport.py`, `test_cms_client_connect.py`, `test_config.py`) all pass locally (34 passed). No fixtures referenced the old path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
