### PR TITLE
feat(bootstrap): device-side crypto + secret-file primitives (stage B.1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           pip install -r requirements-api.txt
           pip install pytest pytest-asyncio httpx
           pip install pytest-playwright
+          pip install "cryptography>=44,<46"
           playwright install --with-deps chromium
 
       - name: Run tests

--- a/requirements-cms-client.txt
+++ b/requirements-cms-client.txt
@@ -2,3 +2,4 @@ websockets>=14.0,<15.0
 aiohttp>=3.11,<4.0
 pydantic>=2.10,<3.0
 pydantic-settings>=2.7,<3.0
+cryptography>=44,<46

--- a/shared/bootstrap_identity.py
+++ b/shared/bootstrap_identity.py
@@ -1,0 +1,470 @@
+"""Device-side crypto + secret-file primitives for the HTTPS bootstrap flow.
+
+This is the firmware complement to ``cms.services.device_identity`` in the
+CMS repo (umbrella issue #420).  All functions here are pure or touch only
+the two on-disk secret files (``device_key`` and ``pairing_secret``); HTTP
+wiring lives in ``cms_client.bootstrap_client`` (stage B.2) and service
+orchestration lives in ``cms_client.service`` (stage B.3).
+
+Wire-format invariants that MUST stay in lockstep with CMS:
+
+- Device identity is a raw 32-byte Ed25519 **seed** (not PKCS8, not the
+  expanded 64-byte form).  CMS ``_ed25519_priv_to_x25519`` and the firmware
+  here both take the seed directly.
+- Public key on the wire is standard base64 (``+/`` alphabet, ``=`` padding)
+  of the 32-byte Ed25519 public key.
+- ``/connect-token`` signing input is ``f"{device_id}|{timestamp}|{nonce}"``
+  UTF-8; ``timestamp`` stringified via ``str(int(timestamp))`` so device
+  and CMS produce bit-identical bytes regardless of JSON int vs str shape.
+- Fleet-HMAC input is ``"register|{device_id}|{pubkey_b64}|{pairing_secret_hash}|{fleet_id}|{timestamp}|{nonce}"``
+  UTF-8, HMAC-SHA256 under the fleet secret, hex-encoded.
+- ECIES wire format is base64 of
+  ``eph_x25519_pubkey(32) || aesgcm_nonce(12) || ciphertext || tag(16)``,
+  HKDF-SHA256 with salt=None and info=``agora-bootstrap-ecies-v1``.
+- Pairing secret is 26 chars of RFC-4648 base32 (uppercase, no padding),
+  hashed as ``sha256(secret.encode("utf-8")).hexdigest()`` — the admin in
+  CMS types/pastes that exact string into the adopt modal.
+
+File-system contract (both files):
+
+- Parent dir must be a directory owned by the current uid, not group- or
+  world-writable.  Perms are repaired to ``0o700`` if same owner + too
+  permissive; mismatched owner is a hard error.
+- Secret file is a regular file (no symlinks, FIFOs, devices) opened with
+  ``O_NOFOLLOW``; must be owned by the current uid; perms repaired to
+  ``0o400`` if same owner + too permissive; mismatched owner is a hard error.
+- **Malformed contents never trigger silent regeneration.**  That would
+  strand an already-adopted device whose seed briefly looked corrupt.  The
+  caller sees ``BootstrapKeyFileError`` / ``BootstrapSecretFileError`` and
+  has to intervene (delete the file explicitly, or factory-reset).
+- Writes are fd-based with ``O_CREAT | O_EXCL | O_NOFOLLOW``, fsynced, then
+  the parent directory is fsynced — power-loss-safe on first boot.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+
+# ---------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------
+
+PAIRING_SECRET_LEN_BYTES = 16  # 128 bits of entropy
+PAIRING_SECRET_TEXT_LEN = 26  # base32(16 bytes) unpadded
+
+_SEED_LEN = 32
+_FILE_MODE = 0o400
+_DIR_MODE = 0o700
+_ECIES_HKDF_INFO = b"agora-bootstrap-ecies-v1"
+
+# Base32 alphabet we expect the secret to use (RFC-4648 uppercase, no "=").
+_B32_ALPHA = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+
+
+# ---------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------
+
+
+class BootstrapKeyFileError(Exception):
+    """Raised when the device-key file fails invariants."""
+
+
+class BootstrapSecretFileError(Exception):
+    """Raised when the pairing-secret file fails invariants."""
+
+
+# ---------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeviceIdentity:
+    """Output of :func:`load_or_create_device_identity`.
+
+    ``seed`` is the raw 32-byte Ed25519 seed (keep secret).
+    ``pubkey_b64`` is standard-base64 of the 32-byte public key.
+    """
+
+    seed: bytes
+    pubkey_b64: str
+
+
+# ---------------------------------------------------------------------
+# File-system helpers (fd-based, TOCTOU-safe)
+# ---------------------------------------------------------------------
+
+
+def _check_parent_dir(path: Path, exc_cls: type[Exception]) -> None:
+    """Validate and, where safe, repair the parent directory of ``path``.
+
+    Rules:
+    - must exist and be a directory
+    - must be owned by the current uid
+    - must not be group- or world-writable
+    - same-owner over-permissive mode is repaired to ``0o700``
+    """
+    parent = path.parent
+    if not parent.exists():
+        parent.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        return
+    st = os.stat(parent, follow_symlinks=False)
+    if not stat.S_ISDIR(st.st_mode):
+        raise exc_cls(f"{parent} is not a directory")
+    uid = os.getuid() if hasattr(os, "getuid") else st.st_uid
+    if st.st_uid != uid:
+        raise exc_cls(
+            f"{parent} is owned by uid={st.st_uid}, expected {uid}; "
+            f"fix ownership or choose a different path"
+        )
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        try:
+            os.chmod(parent, _DIR_MODE)
+        except OSError as e:
+            raise exc_cls(
+                f"{parent} is group/world-writable and chmod failed: {e}"
+            ) from e
+
+
+def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
+    """Open ``path`` with ``O_NOFOLLOW`` and validate via ``fstat``.
+
+    Returns an open file descriptor in read-only mode.  Caller must close it.
+    Raises ``exc_cls`` if the file is a symlink, not a regular file, owned
+    by a different uid, or (repairably) has loose permissions.
+
+    Same-owner over-permissive mode is repaired to ``0o400`` via ``fchmod``.
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as e:
+        # ELOOP means a symlink was followed; distinguish for the caller.
+        if getattr(e, "errno", None) in (40,):  # ELOOP on Linux
+            raise exc_cls(f"{path} is a symlink; refusing to follow") from e
+        raise exc_cls(f"open({path}) failed: {e}") from e
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise exc_cls(f"{path} is not a regular file")
+        uid = os.getuid() if hasattr(os, "getuid") else st.st_uid
+        if st.st_uid != uid:
+            raise exc_cls(
+                f"{path} is owned by uid={st.st_uid}, expected {uid}; "
+                f"refusing to load a secret from a file owned by another user"
+            )
+        perm = st.st_mode & 0o777
+        if perm != _FILE_MODE:
+            # Same owner and loose perms → repair via fd.
+            try:
+                os.fchmod(fd, _FILE_MODE)
+            except OSError as e:
+                raise exc_cls(
+                    f"{path} has mode {perm:o} and fchmod failed: {e}"
+                ) from e
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _atomic_write_secret(path: Path, data: bytes, exc_cls: type[Exception]) -> None:
+    """Write ``data`` to ``path`` atomically with mode ``0o400``.
+
+    Power-loss-safe: tmp file is fsynced, renamed into place, and the parent
+    directory is fsynced before we return.  Uses ``O_EXCL | O_NOFOLLOW`` on
+    the tmp file to make sure we don't race with an attacker planting a
+    symlink under a predictable name.
+    """
+    parent = path.parent
+    # secrets.token_hex picks a random tmp suffix so parallel boots or a
+    # previous crash don't cause O_EXCL to bail.
+    tmp = parent / f".{path.name}.tmp.{secrets.token_hex(4)}"
+    fd = os.open(
+        tmp,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        _FILE_MODE,
+    )
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    try:
+        os.replace(tmp, path)
+    except OSError as e:
+        # Best-effort cleanup of the tmp file.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise exc_cls(f"rename into {path} failed: {e}") from e
+    # Fsync the parent directory so the rename itself is durable.
+    try:
+        dir_fd = os.open(parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+# ---------------------------------------------------------------------
+# Device identity (Ed25519 seed on disk)
+# ---------------------------------------------------------------------
+
+
+def _derive_pubkey_b64(seed: bytes) -> str:
+    if len(seed) != _SEED_LEN:
+        raise BootstrapKeyFileError(
+            f"ed25519 seed must be {_SEED_LEN} bytes, got {len(seed)}"
+        )
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    pub_bytes = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return base64.b64encode(pub_bytes).decode("ascii")
+
+
+def load_or_create_device_identity(key_path: Path) -> DeviceIdentity:
+    """Load the device's Ed25519 seed from ``key_path`` or create it.
+
+    Never regenerates a malformed existing file — raises instead so an
+    already-adopted device isn't silently re-issued a new identity.
+    """
+    _check_parent_dir(key_path, BootstrapKeyFileError)
+    if key_path.exists() or key_path.is_symlink():
+        fd = _open_existing_regular_file(key_path, BootstrapKeyFileError)
+        try:
+            blob = os.read(fd, _SEED_LEN + 1)
+        finally:
+            os.close(fd)
+        if len(blob) != _SEED_LEN:
+            raise BootstrapKeyFileError(
+                f"{key_path} is {len(blob)} bytes; expected {_SEED_LEN}. "
+                f"Refusing to silently regenerate (would strand the adopted "
+                f"device); delete the file manually to factory-reset identity."
+            )
+        return DeviceIdentity(seed=blob, pubkey_b64=_derive_pubkey_b64(blob))
+    seed = os.urandom(_SEED_LEN)
+    _atomic_write_secret(key_path, seed, BootstrapKeyFileError)
+    return DeviceIdentity(seed=seed, pubkey_b64=_derive_pubkey_b64(seed))
+
+
+# ---------------------------------------------------------------------
+# Pairing secret
+# ---------------------------------------------------------------------
+
+
+def _generate_pairing_secret() -> str:
+    raw = os.urandom(PAIRING_SECRET_LEN_BYTES)
+    # b32encode pads to multiple of 8; strip "=" so QR content stays minimal.
+    text = base64.b32encode(raw).decode("ascii").rstrip("=")
+    assert len(text) == PAIRING_SECRET_TEXT_LEN, (
+        f"base32 length drift: got {len(text)}"
+    )
+    return text
+
+
+def load_or_create_pairing_secret(secret_path: Path) -> str:
+    """Load the pairing secret from ``secret_path`` or create it.
+
+    Shares the same file-system contract as
+    :func:`load_or_create_device_identity`.  Returns the 26-char base32
+    text form the admin will type into the CMS adopt modal.
+    """
+    _check_parent_dir(secret_path, BootstrapSecretFileError)
+    if secret_path.exists() or secret_path.is_symlink():
+        fd = _open_existing_regular_file(secret_path, BootstrapSecretFileError)
+        try:
+            blob = os.read(fd, PAIRING_SECRET_TEXT_LEN + 2)
+        finally:
+            os.close(fd)
+        text = blob.decode("ascii", errors="replace").strip()
+        if len(text) != PAIRING_SECRET_TEXT_LEN or not set(text).issubset(_B32_ALPHA):
+            raise BootstrapSecretFileError(
+                f"{secret_path} contents are not a {PAIRING_SECRET_TEXT_LEN}-char "
+                f"RFC-4648 base32 string; refusing to silently regenerate. "
+                f"Delete the file manually to generate a fresh secret."
+            )
+        return text
+    text = _generate_pairing_secret()
+    _atomic_write_secret(secret_path, text.encode("ascii"), BootstrapSecretFileError)
+    return text
+
+
+def pairing_secret_hash_hex(secret: str) -> str:
+    """sha256 hex of UTF-8 bytes.  Matches the CMS adopt-lookup convention."""
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------
+# Signing
+# ---------------------------------------------------------------------
+
+
+def connect_token_canonical_bytes(device_id: str, timestamp: int, nonce: str) -> bytes:
+    """Bit-identical canonicalisation of a ``/connect-token`` request.
+
+    CMS uses ``str(req.timestamp)`` before canonicalising; we match by
+    calling ``str(int(timestamp))`` so a JSON int and a JSON str round-trip
+    to the same bytes here.
+    """
+    return f"{device_id}|{int(timestamp)}|{nonce}".encode("utf-8")
+
+
+def sign_connect_token_request(
+    seed: bytes, device_id: str, timestamp: int, nonce: str,
+) -> str:
+    """Ed25519-sign the canonical bytes and return a standard-base64 signature."""
+    if len(seed) != _SEED_LEN:
+        raise ValueError(f"ed25519 seed must be {_SEED_LEN} bytes")
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    sig = priv.sign(connect_token_canonical_bytes(device_id, timestamp, nonce))
+    return base64.b64encode(sig).decode("ascii")
+
+
+# ---------------------------------------------------------------------
+# ECIES decrypt (mirror of CMS encrypt_for_device)
+# ---------------------------------------------------------------------
+
+
+def _ed25519_priv_to_x25519(seed: bytes) -> X25519PrivateKey:
+    """Derive the X25519 private key from a raw Ed25519 seed.
+
+    Implementation matches the CMS side byte-for-byte (RFC 8032 §5.1.5):
+    SHA-512 the seed, take the low 32 bytes, apply RFC 7748 clamping.
+    """
+    if len(seed) != _SEED_LEN:
+        raise ValueError("ed25519 seed must be 32 bytes")
+    h = hashlib.sha512(seed).digest()[:32]
+    scalar = bytearray(h)
+    scalar[0] &= 248
+    scalar[31] &= 127
+    scalar[31] |= 64
+    return X25519PrivateKey.from_private_bytes(bytes(scalar))
+
+
+def decrypt_adopt_payload(seed: bytes, ciphertext_b64: str) -> bytes:
+    """Inverse of CMS ``encrypt_for_device``.
+
+    Raises ``ValueError`` on malformed base64, a too-short blob, a derived
+    nonce/prefix mismatch, or AES-GCM authentication failure (propagates
+    ``InvalidTag`` as ``ValueError``).
+    """
+    try:
+        blob = base64.b64decode(ciphertext_b64, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise ValueError("invalid base64 ciphertext") from e
+    if len(blob) < 32 + 12 + 16:
+        raise ValueError("ciphertext too short")
+    eph_pub, nonce, ct = blob[:32], blob[32:44], blob[44:]
+    x_priv = _ed25519_priv_to_x25519(seed)
+    shared = x_priv.exchange(X25519PublicKey.from_public_bytes(eph_pub))
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32 + 12,
+        salt=None,
+        info=_ECIES_HKDF_INFO,
+    ).derive(shared)
+    key, derived_nonce = key_material[:32], key_material[32:]
+    if derived_nonce != nonce:
+        # CMS's encrypt_for_device uses the HKDF-derived nonce as the
+        # on-wire nonce, so a mismatch means the blob was tampered with
+        # before the AEAD check could catch it.
+        raise ValueError("nonce mismatch")
+    try:
+        return AESGCM(key).decrypt(nonce, ct, associated_data=None)
+    except Exception as e:
+        raise ValueError("AES-GCM authentication failed") from e
+
+
+# ---------------------------------------------------------------------
+# Fleet HMAC (register gate)
+# ---------------------------------------------------------------------
+
+
+def fleet_hmac_input(
+    *,
+    device_id: str,
+    pubkey_b64: str,
+    pairing_secret_hash: str,
+    fleet_id: str,
+    timestamp: int,
+    nonce: str,
+) -> bytes:
+    """Canonical MAC input for ``POST /api/devices/register``.  Mirrors CMS."""
+    parts = [
+        "register",
+        device_id,
+        pubkey_b64,
+        pairing_secret_hash,
+        fleet_id,
+        str(int(timestamp)),
+        nonce,
+    ]
+    return "|".join(parts).encode("utf-8")
+
+
+def compute_fleet_hmac_hex(
+    secret: bytes,
+    *,
+    device_id: str,
+    pubkey_b64: str,
+    pairing_secret_hash: str,
+    fleet_id: str,
+    timestamp: int,
+    nonce: str,
+) -> str:
+    """HMAC-SHA256, hex-encoded, over :func:`fleet_hmac_input`."""
+    message = fleet_hmac_input(
+        device_id=device_id,
+        pubkey_b64=pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash,
+        fleet_id=fleet_id,
+        timestamp=timestamp,
+        nonce=nonce,
+    )
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+
+
+__all__ = [
+    "BootstrapKeyFileError",
+    "BootstrapSecretFileError",
+    "DeviceIdentity",
+    "PAIRING_SECRET_LEN_BYTES",
+    "PAIRING_SECRET_TEXT_LEN",
+    "compute_fleet_hmac_hex",
+    "connect_token_canonical_bytes",
+    "decrypt_adopt_payload",
+    "fleet_hmac_input",
+    "load_or_create_device_identity",
+    "load_or_create_pairing_secret",
+    "pairing_secret_hash_hex",
+    "sign_connect_token_request",
+]

--- a/tests/test_bootstrap_identity.py
+++ b/tests/test_bootstrap_identity.py
@@ -1,0 +1,373 @@
+"""Unit tests for ``shared.bootstrap_identity``.
+
+Stage B.1 of the bootstrap redesign (issue #420).  The module is pure
+library code (crypto + secret-file primitives); these tests avoid any
+cross-repo imports and instead mirror the CMS ``encrypt_for_device``
+wire format inline when needed, so the suite pins the wire format on
+the device side independently.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from shared.bootstrap_identity import (
+    BootstrapKeyFileError,
+    BootstrapSecretFileError,
+    DeviceIdentity,
+    PAIRING_SECRET_TEXT_LEN,
+    compute_fleet_hmac_hex,
+    connect_token_canonical_bytes,
+    decrypt_adopt_payload,
+    fleet_hmac_input,
+    load_or_create_device_identity,
+    load_or_create_pairing_secret,
+    pairing_secret_hash_hex,
+    sign_connect_token_request,
+)
+
+_POSIX = sys.platform != "win32"
+posix_only = pytest.mark.skipif(
+    not _POSIX, reason="fd-based fs invariants are POSIX-only"
+)
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def _ed25519_pub_to_x25519(pub_bytes: bytes) -> X25519PublicKey:
+    """Mirror of CMS ``_ed25519_pub_to_x25519`` — derive X25519 pub from Ed25519 pub.
+
+    Uses the standard Montgomery-from-Edwards u = (1+y)/(1-y) mapping.  We
+    only need this for the self-contained ECIES fixture below; the library
+    under test does *not* exercise this branch.
+    """
+    # We can avoid re-implementing y→u by doing the encrypt against a
+    # recipient whose identity we already own: derive X25519 priv from
+    # the seed and use its public key as the recipient.  That's what
+    # ``_encrypt_for_device_seed`` does instead.
+    raise NotImplementedError  # pragma: no cover
+
+
+def _x25519_priv_from_ed25519_seed(seed: bytes) -> X25519PrivateKey:
+    h = hashlib.sha512(seed).digest()[:32]
+    scalar = bytearray(h)
+    scalar[0] &= 248
+    scalar[31] &= 127
+    scalar[31] |= 64
+    return X25519PrivateKey.from_private_bytes(bytes(scalar))
+
+
+def _encrypt_for_device_seed(seed: bytes, plaintext: bytes) -> str:
+    """Produce a bootstrap-ECIES ciphertext addressed to ``seed``'s identity.
+
+    Byte-for-byte match with CMS ``encrypt_for_device``.  We encrypt
+    against the X25519 pub derived from the same seed the decrypt path
+    will use, sidestepping the Ed25519-pub → X25519-pub conversion
+    (not under test here).
+    """
+    recip_x_pub = _x25519_priv_from_ed25519_seed(seed).public_key()
+
+    eph_priv = X25519PrivateKey.generate()
+    eph_pub_bytes = eph_priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    shared = eph_priv.exchange(recip_x_pub)
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32 + 12,
+        salt=None,
+        info=b"agora-bootstrap-ecies-v1",
+    ).derive(shared)
+    key, nonce = key_material[:32], key_material[32:]
+    ct = AESGCM(key).encrypt(nonce, plaintext, associated_data=None)
+    return base64.b64encode(eph_pub_bytes + nonce + ct).decode("ascii")
+
+
+# ---------------------------------------------------------------------
+# Device identity
+# ---------------------------------------------------------------------
+
+
+@posix_only
+def test_load_or_create_device_identity_roundtrip(tmp_path: Path) -> None:
+    # Parent must be 0o700 + owned by us — tmp_path satisfies this.
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+
+    ident1 = load_or_create_device_identity(key_path)
+    assert isinstance(ident1, DeviceIdentity)
+    assert len(ident1.seed) == 32
+    # Pubkey must match what Ed25519PrivateKey derives from the seed.
+    priv = Ed25519PrivateKey.from_private_bytes(ident1.seed)
+    pub = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    assert base64.b64decode(ident1.pubkey_b64) == pub
+
+    # On-disk file should be the raw 32-byte seed.
+    assert key_path.read_bytes() == ident1.seed
+    assert stat.S_IMODE(os.stat(key_path).st_mode) == 0o400
+
+    # Reload returns the same identity.
+    ident2 = load_or_create_device_identity(key_path)
+    assert ident2.seed == ident1.seed
+    assert ident2.pubkey_b64 == ident1.pubkey_b64
+
+
+@posix_only
+def test_loose_perms_repaired_when_same_owner(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+    load_or_create_device_identity(key_path)
+
+    # Admin fat-fingered mode 0o644 after-the-fact; same owner, we repair.
+    os.chmod(key_path, 0o644)
+    ident = load_or_create_device_identity(key_path)
+    assert stat.S_IMODE(os.stat(key_path).st_mode) == 0o400
+    assert len(ident.seed) == 32
+
+
+@posix_only
+def test_different_owner_is_hard_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+    load_or_create_device_identity(key_path)
+
+    # Simulate "file owned by someone else" by faking the effective uid.
+    real_uid = os.getuid()
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+    with pytest.raises(BootstrapKeyFileError, match="owned by uid"):
+        load_or_create_device_identity(key_path)
+
+
+@posix_only
+def test_malformed_seed_never_regenerates(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+    # Write a 31-byte file (one short) with permissive perms then tight.
+    key_path.write_bytes(b"\x00" * 31)
+    os.chmod(key_path, 0o400)
+
+    with pytest.raises(BootstrapKeyFileError, match="bytes; expected 32"):
+        load_or_create_device_identity(key_path)
+
+    # Crucially the file is untouched — admin must intervene explicitly.
+    assert key_path.read_bytes() == b"\x00" * 31
+
+
+@posix_only
+def test_symlink_target_refused(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    real = tmp_path / "real_key"
+    real.write_bytes(os.urandom(32))
+    os.chmod(real, 0o400)
+
+    key_path = tmp_path / "device_key"
+    os.symlink(real, key_path)
+    with pytest.raises(BootstrapKeyFileError, match="symlink"):
+        load_or_create_device_identity(key_path)
+
+
+@posix_only
+def test_parent_dir_group_writable_repaired(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o770)  # group-writable; same owner, should repair
+    key_path = tmp_path / "device_key"
+    load_or_create_device_identity(key_path)
+    # _DIR_MODE == 0o700 after repair
+    assert stat.S_IMODE(os.stat(tmp_path).st_mode) == 0o700
+
+
+@posix_only
+def test_parent_not_a_directory(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    # Plant a regular file where the parent directory should be.
+    bogus_parent = tmp_path / "bogus"
+    bogus_parent.write_bytes(b"not a dir")
+    key_path = bogus_parent / "device_key"
+    with pytest.raises(BootstrapKeyFileError, match="not a directory"):
+        load_or_create_device_identity(key_path)
+
+
+@posix_only
+def test_existing_path_is_directory_not_file(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+    key_path.mkdir(mode=0o700)
+    with pytest.raises(BootstrapKeyFileError, match="not a regular file"):
+        load_or_create_device_identity(key_path)
+
+
+# ---------------------------------------------------------------------
+# Pairing secret
+# ---------------------------------------------------------------------
+
+
+@posix_only
+def test_pairing_secret_roundtrip(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    secret_path = tmp_path / "pairing_secret"
+    text1 = load_or_create_pairing_secret(secret_path)
+    assert len(text1) == PAIRING_SECRET_TEXT_LEN
+    assert text1 == text1.upper()  # uppercase base32
+    assert set(text1).issubset(set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"))
+    assert stat.S_IMODE(os.stat(secret_path).st_mode) == 0o400
+
+    text2 = load_or_create_pairing_secret(secret_path)
+    assert text2 == text1
+
+
+@posix_only
+def test_pairing_secret_malformed_never_regenerates(tmp_path: Path) -> None:
+    os.chmod(tmp_path, 0o700)
+    secret_path = tmp_path / "pairing_secret"
+    # Wrong length + non-base32 chars.
+    secret_path.write_text("shortsecret")
+    os.chmod(secret_path, 0o400)
+    with pytest.raises(BootstrapSecretFileError, match="refusing to silently"):
+        load_or_create_pairing_secret(secret_path)
+    assert secret_path.read_text() == "shortsecret"
+
+
+def test_pairing_secret_hash_hex_frozen() -> None:
+    # Pin the hash contract with a frozen input → expected SHA-256 hex.
+    digest = pairing_secret_hash_hex("MFRGG2DFMZTWQ2LKNNWG23TV")
+    expected = hashlib.sha256(
+        "MFRGG2DFMZTWQ2LKNNWG23TV".encode("utf-8")
+    ).hexdigest()
+    assert digest == expected
+
+
+# ---------------------------------------------------------------------
+# Signing
+# ---------------------------------------------------------------------
+
+
+def test_connect_token_canonical_bytes_stable() -> None:
+    # Timestamps may arrive as int or str off the wire — both must produce
+    # the exact same canonical bytes once coerced.
+    a = connect_token_canonical_bytes("dev-1", 1700000000, "nonce-xyz")
+    b = connect_token_canonical_bytes("dev-1", int("1700000000"), "nonce-xyz")
+    assert a == b == b"dev-1|1700000000|nonce-xyz"
+
+
+def test_sign_connect_token_roundtrip() -> None:
+    seed = os.urandom(32)
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    pub = priv.public_key()
+    sig_b64 = sign_connect_token_request(
+        seed, device_id="dev-1", timestamp=1700000000, nonce="n"
+    )
+    sig = base64.b64decode(sig_b64)
+    pub.verify(sig, b"dev-1|1700000000|n")  # raises on failure
+
+
+def test_sign_connect_token_rejects_wrong_seed_length() -> None:
+    with pytest.raises(ValueError, match="32 bytes"):
+        sign_connect_token_request(b"\x00" * 31, "d", 1, "n")
+
+
+# ---------------------------------------------------------------------
+# ECIES decrypt
+# ---------------------------------------------------------------------
+
+
+def test_decrypt_adopt_payload_roundtrip() -> None:
+    seed = os.urandom(32)
+    plaintext = b'{"device_id":"abc","api_key":"k"}'
+    ct_b64 = _encrypt_for_device_seed(seed, plaintext)
+    assert decrypt_adopt_payload(seed, ct_b64) == plaintext
+
+
+def test_decrypt_adopt_payload_tamper_triggers_auth_failure() -> None:
+    seed = os.urandom(32)
+    ct_b64 = _encrypt_for_device_seed(seed, b"hello world")
+    raw = bytearray(base64.b64decode(ct_b64))
+    # Flip one bit deep in the ciphertext region (past the 32+12 prefix).
+    raw[50] ^= 0x01
+    tampered = base64.b64encode(bytes(raw)).decode("ascii")
+    with pytest.raises(ValueError, match="AES-GCM authentication failed"):
+        decrypt_adopt_payload(seed, tampered)
+
+
+def test_decrypt_adopt_payload_nonce_mismatch() -> None:
+    seed = os.urandom(32)
+    ct_b64 = _encrypt_for_device_seed(seed, b"hello world")
+    raw = bytearray(base64.b64decode(ct_b64))
+    # Flip the first byte of the on-wire nonce; HKDF-derived nonce won't
+    # match and we short-circuit before AEAD.
+    raw[32] ^= 0x01
+    tampered = base64.b64encode(bytes(raw)).decode("ascii")
+    with pytest.raises(ValueError, match="nonce mismatch"):
+        decrypt_adopt_payload(seed, tampered)
+
+
+def test_decrypt_adopt_payload_too_short() -> None:
+    with pytest.raises(ValueError, match="too short"):
+        decrypt_adopt_payload(os.urandom(32), base64.b64encode(b"x" * 10).decode())
+
+
+def test_decrypt_adopt_payload_bad_base64() -> None:
+    with pytest.raises(ValueError, match="invalid base64"):
+        decrypt_adopt_payload(os.urandom(32), "!!!not base64!!!")
+
+
+# ---------------------------------------------------------------------
+# Fleet HMAC
+# ---------------------------------------------------------------------
+
+
+def test_fleet_hmac_input_canonical() -> None:
+    buf = fleet_hmac_input(
+        device_id="dev-1",
+        pubkey_b64="PUB",
+        pairing_secret_hash="HASH",
+        fleet_id="fleet-A",
+        timestamp=1700000000,
+        nonce="n",
+    )
+    assert buf == b"register|dev-1|PUB|HASH|fleet-A|1700000000|n"
+
+
+def test_compute_fleet_hmac_hex_matches_stdlib() -> None:
+    secret = b"fleet-secret-bytes"
+    got = compute_fleet_hmac_hex(
+        secret,
+        device_id="dev-1",
+        pubkey_b64="PUB",
+        pairing_secret_hash="HASH",
+        fleet_id="fleet-A",
+        timestamp=1700000000,
+        nonce="n",
+    )
+    expected = hmac.new(
+        secret,
+        b"register|dev-1|PUB|HASH|fleet-A|1700000000|n",
+        hashlib.sha256,
+    ).hexdigest()
+    assert got == expected


### PR DESCRIPTION
### Stage B.1 — device-side bootstrap crypto + secret-file primitives

First slice of the firmware half of the bootstrap redesign
([agora-cms#420](https://github.com/sslivins/agora-cms/issues/420)).
Pure library: no HTTP, no service wiring.  Gets us a reviewable unit
before B.2 (HTTP client) and B.3 (cms_client service integration).

#### What's here

New module `shared/bootstrap_identity.py`:

- **`load_or_create_device_identity(path)`** — 32-byte Ed25519 seed on
  disk.  Returns `DeviceIdentity(seed, pubkey_b64)`.
- **`load_or_create_pairing_secret(path)`** — 26-char RFC-4648 base32
  secret.  (Scope note: UI will adopt-by-pending-id without the admin
  typing it, but we still emit it on the wire as an idempotent
  re-registration lookup key; A.5 follow-up will hide it from the UI.)
- **`pairing_secret_hash_hex`**, **`sign_connect_token_request`**,
  **`decrypt_adopt_payload`**, **`compute_fleet_hmac_hex`** — wire-format
  complements to the CMS `device_identity` module.

Every wire-format invariant is documented at the top of the module and
pinned byte-for-byte with CMS:

| thing                       | format                                                                |
|-----------------------------|-----------------------------------------------------------------------|
| device identity on disk     | raw 32-byte Ed25519 seed                                              |
| public key on the wire      | std-base64 of 32B Ed25519 pub                                         |
| `/connect-token` signing    | `f"{device_id}\|{int(ts)}\|{nonce}"` UTF-8, Ed25519                   |
| fleet HMAC                  | `register\|device_id\|pubkey_b64\|pairing_secret_hash\|fleet_id\|ts\|nonce`, HMAC-SHA256 hex |
| ECIES                       | b64(`eph_x25519_pub(32) \|\| aesgcm_nonce(12) \|\| ct \|\| tag(16)`), HKDF-SHA256 salt=None info=`agora-bootstrap-ecies-v1` |
| pairing secret              | 26 chars RFC-4648 base32 uppercase unpadded                           |
| Ed25519 seed → X25519       | RFC-8032 §5.1.5 / RFC-7748 clamp                                      |

#### File-system contract

Both secret files follow the same rules (rubber-duck caught a handful
of real issues I'd missed originally — this version incorporates all of
them):

- `O_NOFOLLOW` on every open; symlink → hard error (`ELOOP`).
- `fstat` validates: regular file, owned by current uid, perms `0o400`.
  Same-owner loose perms → repaired via `fchmod`; different-owner →
  `BootstrapKeyFileError` / `BootstrapSecretFileError`.
- Parent dir: must be a directory, owned by current uid, not
  group/world-writable; same-owner loose → repaired to `0o700`.
- **Malformed contents never trigger silent regeneration** — that would
  strand an already-adopted device whose seed looked momentarily wrong.
  Admin intervenes (delete the file explicitly to factory-reset).
- Writes: tmp → `O_CREAT | O_EXCL | O_NOFOLLOW` + random suffix → `fsync(fd)`
  → `os.replace` → `fsync(parent dir)`.  Power-loss-safe on first boot.

#### Tests

`tests/test_bootstrap_identity.py` — 21 tests, no cross-repo import.
Self-contained ECIES encrypt helper inline so we pin the device-side
wire format independently of CMS.

| section              | tests                                                                                |
|----------------------|--------------------------------------------------------------------------------------|
| device identity      | roundtrip, perm repair, owner mismatch hard-error, malformed untouched, symlink refused, parent repair, parent-not-dir, path-is-dir |
| pairing secret       | roundtrip + charset, malformed untouched, hash frozen                                |
| signing              | canonical bytes stable across int/str, Ed25519 verify roundtrip, wrong seed length   |
| ECIES                | roundtrip, AEAD tamper, nonce-mismatch short-circuit, too-short, bad base64          |
| fleet HMAC           | canonical input string, stdlib-matching digest                                       |

11 platform-agnostic tests pass on Windows + Linux; 10 POSIX-only tests
are gated on `sys.platform != "win32"` (fd-based permission checks don't
map cleanly to NTFS ACLs).

#### CI / deps

- `requirements-cms-client.txt` gains `cryptography>=44,<46` (runtime).
- `.github/workflows/tests.yml` explicitly installs the same pin so CI
  sees the new module's only extra dep.

#### What's intentionally NOT here

- B.2: HTTP client (`bootstrap_client.py` with `register`,
  `get_bootstrap_status_once`, `connect_token`).  One-shot methods only;
  retry/backoff belongs to B.3 orchestration.
- B.3: `cms_client/service.py` wiring — detect missing `api_key` at
  boot, run bootstrap loop, persist adopt payload, transition to WPS
  connect-token auth.  Also solves API-key continuity for asset
  downloads + log upload.
- QR rendering: dropped.  A.5 adds pending-devices list to CMS UI so
  admin clicks Adopt directly, no pairing-secret typing.

#### Rubber-duck findings incorporated

- fd-based I/O with `O_NOFOLLOW` + `fchmod` instead of path-based chmod
  (TOCTOU-safe).
- Parent-dir ownership/mode checks, not just the file.
- `fsync(parent dir)` after `os.replace` for power-loss safety.
- `timestamp: int` in the public API (not `str`), matching CMS's
  `str(req.timestamp)` canonicalization internally.
- `compute_fleet_hmac_hex` (not `_header`); `load_or_create_device_identity`
  (not `_keypair`) — the file only holds the seed.
- Never regenerate malformed files — `BootstrapKeyFileError` /
  `BootstrapSecretFileError` forces operator intervention.
- No auto-wipe on a single failure — that policy will live in B.3.
