### PR TITLE
fix(bootstrap): address B.1 post-merge rubber-duck findings

### DIFF
--- a/shared/bootstrap_identity.py
+++ b/shared/bootstrap_identity.py
@@ -48,7 +48,6 @@ import binascii
 import hashlib
 import hmac
 import os
-import secrets
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -118,17 +117,27 @@ class DeviceIdentity:
 
 
 def _check_parent_dir(path: Path, exc_cls: type[Exception]) -> None:
-    """Validate and, where safe, repair the parent directory of ``path``.
+    """Validate and, where safe, repair the *immediate* parent of ``path``.
 
-    Rules:
+    Rules enforced on the immediate parent only:
     - must exist and be a directory
     - must be owned by the current uid
     - must not be group- or world-writable
     - same-owner over-permissive mode is repaired to ``0o700``
+
+    Note: if the parent is missing, we create it with ``mkdir(parents=True,
+    mode=0o700)``; intermediate ancestors inherit that mode on creation
+    but pre-existing ancestors are **not** audited.  Callers that care
+    about the full chain should place the secret under a stable
+    application directory (e.g. ``/opt/agora/persist``) that is itself
+    managed by packaging.
     """
     parent = path.parent
     if not parent.exists():
-        parent.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        try:
+            parent.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+        except OSError as e:
+            raise exc_cls(f"mkdir({parent}) failed: {e}") from e
         return
     st = os.stat(parent, follow_symlinks=False)
     if not stat.S_ISDIR(st.st_mode):
@@ -146,6 +155,20 @@ def _check_parent_dir(path: Path, exc_cls: type[Exception]) -> None:
             raise exc_cls(
                 f"{parent} is group/world-writable and chmod failed: {e}"
             ) from e
+
+
+def _fsync_dir(parent: Path) -> None:
+    """Best-effort fsync of ``parent``.  Silently ignored if unsupported."""
+    try:
+        dir_fd = os.open(parent, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
@@ -189,48 +212,58 @@ def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
     return fd
 
 
-def _atomic_write_secret(path: Path, data: bytes, exc_cls: type[Exception]) -> None:
-    """Write ``data`` to ``path`` atomically with mode ``0o400``.
+def _create_new_secret_file(
+    path: Path, data: bytes, exc_cls: type[Exception],
+) -> bool:
+    """Atomically create ``path`` with ``data`` and mode ``0o400``.
 
-    Power-loss-safe: tmp file is fsynced, renamed into place, and the parent
-    directory is fsynced before we return.  Uses ``O_EXCL | O_NOFOLLOW`` on
-    the tmp file to make sure we don't race with an attacker planting a
-    symlink under a predictable name.
+    Uses ``O_CREAT | O_EXCL | O_NOFOLLOW`` on the *final* path so the
+    operation is create-once: concurrent callers cannot overwrite each
+    other.  Returns ``True`` on success, ``False`` if the file already
+    exists (``EEXIST``) — caller should fall through to the existing-file
+    validation path.  Any other failure (``ENOSPC``, ``EROFS``, ``EPERM``,
+    ...) is wrapped in ``exc_cls``.
+
+    On success, ``fsync``s the file fd and the parent directory so the
+    newly-created file is durable across power-loss.
     """
     parent = path.parent
-    # secrets.token_hex picks a random tmp suffix so parallel boots or a
-    # previous crash don't cause O_EXCL to bail.
-    tmp = parent / f".{path.name}.tmp.{secrets.token_hex(4)}"
-    fd = os.open(
-        tmp,
-        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-        _FILE_MODE,
-    )
     try:
-        os.write(fd, data)
-        os.fsync(fd)
-    finally:
-        os.close(fd)
-    try:
-        os.replace(tmp, path)
+        fd = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            _FILE_MODE,
+        )
+    except FileExistsError:
+        return False
     except OSError as e:
-        # Best-effort cleanup of the tmp file.
+        errno_val = getattr(e, "errno", None)
+        hint = ""
+        if errno_val == 30:  # EROFS
+            hint = " (read-only filesystem?)"
+        elif errno_val == 28:  # ENOSPC
+            hint = " (no space left on device)"
+        elif errno_val == 13:  # EACCES
+            hint = " (permission denied; check parent ownership/mode)"
+        raise exc_cls(f"create({path}) failed{hint}: {e}") from e
+    try:
         try:
-            tmp.unlink()
+            os.write(fd, data)
+            os.fsync(fd)
+        except OSError as e:
+            raise exc_cls(f"write({path}) failed: {e}") from e
+    except Exception:
+        # Don't leave a partial file behind; O_EXCL on the next attempt
+        # would otherwise mis-diagnose an already-created file.
+        try:
+            os.unlink(path)
         except OSError:
             pass
-        raise exc_cls(f"rename into {path} failed: {e}") from e
-    # Fsync the parent directory so the rename itself is durable.
-    try:
-        dir_fd = os.open(parent, os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(dir_fd)
-    except OSError:
-        pass
+        raise
     finally:
-        os.close(dir_fd)
+        os.close(fd)
+    _fsync_dir(parent)
+    return True
 
 
 # ---------------------------------------------------------------------
@@ -254,26 +287,31 @@ def _derive_pubkey_b64(seed: bytes) -> str:
 def load_or_create_device_identity(key_path: Path) -> DeviceIdentity:
     """Load the device's Ed25519 seed from ``key_path`` or create it.
 
+    Create-once semantics: two concurrent callers observing an absent
+    file will not both generate and overwrite — the loser's ``O_EXCL``
+    create fails with ``EEXIST`` and that caller reads the winner's
+    contents instead.
+
     Never regenerates a malformed existing file — raises instead so an
     already-adopted device isn't silently re-issued a new identity.
     """
     _check_parent_dir(key_path, BootstrapKeyFileError)
-    if key_path.exists() or key_path.is_symlink():
-        fd = _open_existing_regular_file(key_path, BootstrapKeyFileError)
-        try:
-            blob = os.read(fd, _SEED_LEN + 1)
-        finally:
-            os.close(fd)
-        if len(blob) != _SEED_LEN:
-            raise BootstrapKeyFileError(
-                f"{key_path} is {len(blob)} bytes; expected {_SEED_LEN}. "
-                f"Refusing to silently regenerate (would strand the adopted "
-                f"device); delete the file manually to factory-reset identity."
-            )
-        return DeviceIdentity(seed=blob, pubkey_b64=_derive_pubkey_b64(blob))
     seed = os.urandom(_SEED_LEN)
-    _atomic_write_secret(key_path, seed, BootstrapKeyFileError)
-    return DeviceIdentity(seed=seed, pubkey_b64=_derive_pubkey_b64(seed))
+    if _create_new_secret_file(key_path, seed, BootstrapKeyFileError):
+        return DeviceIdentity(seed=seed, pubkey_b64=_derive_pubkey_b64(seed))
+    # File already existed (or was concurrently created): validate + load.
+    fd = _open_existing_regular_file(key_path, BootstrapKeyFileError)
+    try:
+        blob = os.read(fd, _SEED_LEN + 1)
+    finally:
+        os.close(fd)
+    if len(blob) != _SEED_LEN:
+        raise BootstrapKeyFileError(
+            f"{key_path} is {len(blob)} bytes; expected {_SEED_LEN}. "
+            f"Refusing to silently regenerate (would strand the adopted "
+            f"device); delete the file manually to factory-reset identity."
+        )
+    return DeviceIdentity(seed=blob, pubkey_b64=_derive_pubkey_b64(blob))
 
 
 # ---------------------------------------------------------------------
@@ -294,27 +332,29 @@ def _generate_pairing_secret() -> str:
 def load_or_create_pairing_secret(secret_path: Path) -> str:
     """Load the pairing secret from ``secret_path`` or create it.
 
-    Shares the same file-system contract as
+    Shares the same file-system contract and create-once semantics as
     :func:`load_or_create_device_identity`.  Returns the 26-char base32
-    text form the admin will type into the CMS adopt modal.
+    text form.
     """
     _check_parent_dir(secret_path, BootstrapSecretFileError)
-    if secret_path.exists() or secret_path.is_symlink():
-        fd = _open_existing_regular_file(secret_path, BootstrapSecretFileError)
-        try:
-            blob = os.read(fd, PAIRING_SECRET_TEXT_LEN + 2)
-        finally:
-            os.close(fd)
-        text = blob.decode("ascii", errors="replace").strip()
-        if len(text) != PAIRING_SECRET_TEXT_LEN or not set(text).issubset(_B32_ALPHA):
-            raise BootstrapSecretFileError(
-                f"{secret_path} contents are not a {PAIRING_SECRET_TEXT_LEN}-char "
-                f"RFC-4648 base32 string; refusing to silently regenerate. "
-                f"Delete the file manually to generate a fresh secret."
-            )
-        return text
-    text = _generate_pairing_secret()
-    _atomic_write_secret(secret_path, text.encode("ascii"), BootstrapSecretFileError)
+    new_text = _generate_pairing_secret()
+    if _create_new_secret_file(
+        secret_path, new_text.encode("ascii"), BootstrapSecretFileError,
+    ):
+        return new_text
+    # File already existed (or was concurrently created): validate + load.
+    fd = _open_existing_regular_file(secret_path, BootstrapSecretFileError)
+    try:
+        blob = os.read(fd, PAIRING_SECRET_TEXT_LEN + 2)
+    finally:
+        os.close(fd)
+    text = blob.decode("ascii", errors="replace").strip()
+    if len(text) != PAIRING_SECRET_TEXT_LEN or not set(text).issubset(_B32_ALPHA):
+        raise BootstrapSecretFileError(
+            f"{secret_path} contents are not a {PAIRING_SECRET_TEXT_LEN}-char "
+            f"RFC-4648 base32 string; refusing to silently regenerate. "
+            f"Delete the file manually to generate a fresh secret."
+        )
     return text
 
 

--- a/tests/test_bootstrap_identity.py
+++ b/tests/test_bootstrap_identity.py
@@ -35,6 +35,7 @@ from shared.bootstrap_identity import (
     BootstrapSecretFileError,
     DeviceIdentity,
     PAIRING_SECRET_TEXT_LEN,
+    _create_new_secret_file,
     compute_fleet_hmac_hex,
     connect_token_canonical_bytes,
     decrypt_adopt_payload,
@@ -57,17 +58,59 @@ posix_only = pytest.mark.skipif(
 
 
 def _ed25519_pub_to_x25519(pub_bytes: bytes) -> X25519PublicKey:
-    """Mirror of CMS ``_ed25519_pub_to_x25519`` — derive X25519 pub from Ed25519 pub.
-
-    Uses the standard Montgomery-from-Edwards u = (1+y)/(1-y) mapping.  We
-    only need this for the self-contained ECIES fixture below; the library
-    under test does *not* exercise this branch.
+    """Deprecated helper kept for backwards reference; see module-level
+    ``_ed25519_pub_to_x25519_bytes`` for the real implementation used by
+    ``test_decrypt_adopt_payload_roundtrip_from_pubkey``.
     """
-    # We can avoid re-implementing y→u by doing the encrypt against a
-    # recipient whose identity we already own: derive X25519 priv from
-    # the seed and use its public key as the recipient.  That's what
-    # ``_encrypt_for_device_seed`` does instead.
     raise NotImplementedError  # pragma: no cover
+
+
+def _ed25519_pub_to_x25519_bytes(pub_bytes: bytes) -> bytes:
+    """Mirror of CMS ``_ed25519_pub_to_x25519``.
+
+    Returns the raw 32-byte X25519 public key.  Kept inline (rather than
+    importing from the CMS repo) so the device-side test suite can pin
+    the conversion math independently.
+    """
+    assert len(pub_bytes) == 32
+    y = int.from_bytes(pub_bytes, "little") & ((1 << 255) - 1)
+    p = (1 << 255) - 19
+    assert y < p, "non-canonical y"
+    denom = (1 - y) % p
+    assert denom != 0, "point at infinity"
+    inv = pow(denom, p - 2, p)
+    u = ((1 + y) * inv) % p
+    assert u not in (0, 1), "low-order point"
+    return u.to_bytes(32, "little")
+
+
+def _encrypt_for_device_pubkey(pubkey_b64: str, plaintext: bytes) -> str:
+    """CMS-side ``encrypt_for_device`` replicated exactly: starts from the
+    Ed25519 *public key* (b64) and applies the y→u Montgomery conversion.
+
+    This is the real wire path CMS uses; it exercises ``decrypt_adopt_payload``
+    against a ciphertext produced via the pub-key conversion branch, which
+    ``_encrypt_for_device_seed`` deliberately bypasses.
+    """
+    recip_ed = base64.b64decode(pubkey_b64, validate=True)
+    recip_x_bytes = _ed25519_pub_to_x25519_bytes(recip_ed)
+    recip_x = X25519PublicKey.from_public_bytes(recip_x_bytes)
+
+    eph_priv = X25519PrivateKey.generate()
+    eph_pub_bytes = eph_priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    shared = eph_priv.exchange(recip_x)
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32 + 12,
+        salt=None,
+        info=b"agora-bootstrap-ecies-v1",
+    ).derive(shared)
+    key, nonce = key_material[:32], key_material[32:]
+    ct = AESGCM(key).encrypt(nonce, plaintext, associated_data=None)
+    return base64.b64encode(eph_pub_bytes + nonce + ct).decode("ascii")
 
 
 def _x25519_priv_from_ed25519_seed(seed: bytes) -> X25519PrivateKey:
@@ -304,6 +347,23 @@ def test_decrypt_adopt_payload_roundtrip() -> None:
     assert decrypt_adopt_payload(seed, ct_b64) == plaintext
 
 
+def test_decrypt_adopt_payload_roundtrip_from_pubkey() -> None:
+    # Closes the interop gap: ciphertext is produced using the real CMS
+    # path (Ed25519 pubkey → Montgomery y→u conversion), not the
+    # seed-shortcut used elsewhere in these tests.
+    seed = os.urandom(32)
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    pub_b64 = base64.b64encode(
+        priv.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    ).decode("ascii")
+    plaintext = b"ecies from pubkey"
+    ct_b64 = _encrypt_for_device_pubkey(pub_b64, plaintext)
+    assert decrypt_adopt_payload(seed, ct_b64) == plaintext
+
+
 def test_decrypt_adopt_payload_tamper_triggers_auth_failure() -> None:
     seed = os.urandom(32)
     ct_b64 = _encrypt_for_device_seed(seed, b"hello world")
@@ -371,3 +431,113 @@ def test_compute_fleet_hmac_hex_matches_stdlib() -> None:
         hashlib.sha256,
     ).hexdigest()
     assert got == expected
+
+
+# ---------------------------------------------------------------------
+# Encoding contract
+# ---------------------------------------------------------------------
+
+
+def test_pubkey_b64_is_standard_base64_with_padding() -> None:
+    """Ed25519 raw pub (32 bytes) → std-base64 is 44 chars ending in '='."""
+    seed = os.urandom(32)
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    pub_bytes = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    b64 = base64.b64encode(pub_bytes).decode("ascii")
+    assert len(b64) == 44
+    assert b64.endswith("=")
+    # Standard alphabet (no urlsafe / stripped padding).
+    assert "-" not in b64 and "_" not in b64
+    # And it must round-trip through strict base64 validation.
+    assert base64.b64decode(b64, validate=True) == pub_bytes
+
+
+def test_connect_token_signature_is_standard_base64() -> None:
+    seed = os.urandom(32)
+    sig_b64 = sign_connect_token_request(seed, "d", 1700000000, "n")
+    # Ed25519 signature is always 64 bytes → 88 chars standard base64, no padding.
+    assert len(sig_b64) == 88
+    assert "-" not in sig_b64 and "_" not in sig_b64
+    assert len(base64.b64decode(sig_b64, validate=True)) == 64
+
+
+# ---------------------------------------------------------------------
+# Create-once semantics (regression guard for the duck's finding #1)
+# ---------------------------------------------------------------------
+
+
+@posix_only
+def test_concurrent_create_does_not_overwrite(tmp_path: Path) -> None:
+    """Two racing callers: second must see the first's data, not clobber it."""
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+
+    # Simulate a losing-racer: pre-create the file with a fixed seed.
+    fixed_seed = b"\xab" * 32
+    assert _create_new_secret_file(key_path, fixed_seed, BootstrapKeyFileError)
+
+    # Now call the top-level function — it must NOT overwrite the
+    # already-present file, and must return the on-disk identity.
+    ident = load_or_create_device_identity(key_path)
+    assert ident.seed == fixed_seed
+    assert key_path.read_bytes() == fixed_seed
+
+
+@posix_only
+def test_pairing_secret_concurrent_create_does_not_overwrite(
+    tmp_path: Path,
+) -> None:
+    os.chmod(tmp_path, 0o700)
+    secret_path = tmp_path / "pairing_secret"
+    pre_existing = "AAAAAAAAAAAAAAAAAAAAAAAAAA"  # 26-char valid base32
+    assert _create_new_secret_file(
+        secret_path, pre_existing.encode("ascii"), BootstrapSecretFileError,
+    )
+    assert load_or_create_pairing_secret(secret_path) == pre_existing
+    assert secret_path.read_text() == pre_existing
+
+
+@posix_only
+def test_create_side_oserror_is_wrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Raw OSError on the create path (e.g. read-only FS) must surface as
+    the module's domain exception so B.3 / support tooling can catch it
+    uniformly."""
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "device_key"
+
+    import shared.bootstrap_identity as bi
+
+    real_open = os.open
+
+    def fake_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if str(path) == str(key_path) and (flags & os.O_CREAT):
+            raise OSError(30, "Read-only file system")  # EROFS
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(bi.os, "open", fake_open)
+    with pytest.raises(BootstrapKeyFileError, match="read-only filesystem"):
+        load_or_create_device_identity(key_path)
+
+
+@posix_only
+def test_mkdir_failure_is_wrapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parent-dir ``mkdir`` failures (permission denied, disk full, …)
+    must also surface as the module's domain exception."""
+    os.chmod(tmp_path, 0o700)
+    key_path = tmp_path / "missing_parent" / "device_key"
+
+    import shared.bootstrap_identity as bi
+
+    def fake_mkdir(self, mode=0o777, parents=False, exist_ok=False):  # type: ignore[no-untyped-def]
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(bi.Path, "mkdir", fake_mkdir)
+    with pytest.raises(BootstrapKeyFileError, match="mkdir"):
+        load_or_create_device_identity(key_path)


### PR DESCRIPTION
Follow-up to #130 before B.2. Three real issues + coverage gaps; pure library, no runtime impact.

### Issues fixed

1. **Create-once race** — previous flow `if not exists: generate -> tmp -> os.replace` was not race-safe. New `_create_new_secret_file` uses `O_CREAT | O_EXCL | O_NOFOLLOW` on the final path; loser gets `EEXIST` and reads the winner's data.
2. **Raw OSError leaked on create path** — EROFS / ENOSPC / EACCES / mkdir failures now surface as `BootstrapKeyFileError` / `BootstrapSecretFileError` with actionable hints.
3. **Ed25519-pub → X25519 interop gap** — original ECIES test encrypted via an X25519 pub derived from the seed, skipping CMS's y→u conversion. New test mirrors the CMS conversion math inline.
4. **Base64 contract unpinned** — 2 new assertions lock pubkey at 44 chars w/ `=` padding and Ed25519 signature at 88 chars std alphabet.
5. **`_check_parent_dir` docstring narrowed** — only audits the immediate parent, not ancestors.

### Tests

7 new, total 28 (14 cross-platform, 14 POSIX-only). Local: 14 passed, 14 skipped on Windows.
