### PR TITLE
feat(bootstrap): device-side HTTP bootstrap client (stage B.2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-api.txt
+          pip install -r requirements-cms-client.txt
           pip install pytest pytest-asyncio httpx
           pip install pytest-playwright
           pip install "cryptography>=44,<46"

--- a/cms_client/bootstrap_client.py
+++ b/cms_client/bootstrap_client.py
@@ -1,0 +1,447 @@
+"""Device-side HTTPS client for the CMS bootstrap endpoints (issue #420).
+
+Wraps the three anonymous bootstrap HTTP endpoints on the CMS:
+
+* ``POST /api/devices/register``         — fleet-HMAC gated, announce to CMS.
+* ``GET  /api/devices/bootstrap-status``  — poll until the operator adopts.
+* ``POST /api/devices/connect-token``     — ed25519-signed, mint fresh WPS JWT.
+
+Stage B.2 of the bootstrap redesign.  This is a **pure library**: it has no
+dependency on :mod:`api.config`, touches no disk state, and does NOT drive
+the service lifecycle.  Callers (Stage B.3, ``cms_client.service``) own
+timing / retry / persistence policy.
+
+Crypto primitives (fleet HMAC, ed25519 signing, ECIES wire format) live in
+:mod:`shared.bootstrap_identity`; this module only marshals arguments and
+encodes them onto the wire.  In particular, this module does NOT decrypt
+the bootstrap payload — the caller holds the ed25519 seed and is the only
+party that can safely do that.
+
+Design notes:
+
+* Errors are typed.  Callers can catch :class:`FleetHmacRejectedError` vs
+  :class:`PubkeyMismatchError` vs :class:`CapacityExceededError` vs the
+  catch-all :class:`BootstrapServerError` and choose different policies
+  (retry with fresh nonce, refuse to re-register, back off hard).
+* ``timestamp`` and ``nonce`` are injectable on every signed call so tests
+  can pin canonical bytes deterministically.
+* No argument is ever logged at INFO or above.  Seeds, fleet secrets,
+  HMACs, signatures, JWTs, and ECIES payloads never appear in logs.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import aiohttp
+
+from shared.bootstrap_identity import (
+    compute_fleet_hmac_hex,
+    sign_connect_token_request,
+)
+
+logger = logging.getLogger("agora.cms_client.bootstrap")
+
+# ---------------------------------------------------------------------
+# Default timeouts.  Callers can override by passing a pre-configured
+# ``aiohttp.ClientSession`` with its own timeout, or by supplying
+# ``request_timeout`` explicitly.
+# ---------------------------------------------------------------------
+
+DEFAULT_REQUEST_TIMEOUT_S = 30.0
+
+
+# ---------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------
+
+
+class BootstrapClientError(Exception):
+    """Base class for every error raised by this module."""
+
+
+class BootstrapTransportError(BootstrapClientError):
+    """Network/transport-layer failure (connection reset, DNS, TLS, etc.)."""
+
+
+class BootstrapServerError(BootstrapClientError):
+    """CMS returned a non-success HTTP status.
+
+    ``status`` is the HTTP status code.  ``detail`` is the server's
+    ``detail`` field from the standard FastAPI error JSON, or ``None``
+    if the body was missing/unparseable.  Use the typed subclasses for
+    the specific failure modes the caller is expected to act on.
+    """
+
+    def __init__(self, status: int, detail: Optional[str] = None) -> None:
+        self.status = int(status)
+        self.detail = detail
+        super().__init__(f"bootstrap server returned {self.status} ({detail!r})")
+
+
+class FleetHmacRejectedError(BootstrapServerError):
+    """``POST /register`` returned 401 (fleet HMAC missing / bad / stale / replay).
+
+    Callers should treat this as a **configuration problem** (bad fleet
+    secret, clock skew > 300s, or nonce reuse) and NOT retry in a tight
+    loop.  The ``detail`` field distinguishes the subcases:
+    ``fleet_hmac_missing``, ``fleet_hmac_bad_timestamp``,
+    ``fleet_hmac_stale``, ``fleet_hmac_bad``, ``fleet_hmac_replay``.
+    """
+
+
+class PubkeyMismatchError(BootstrapServerError):
+    """``POST /register`` returned 409 ``pubkey_mismatch``.
+
+    Another device has already registered under the same ``device_id``
+    with a different pubkey.  The caller MUST NOT overwrite its key;
+    the operator has to reset state on the CMS side or the device has
+    to mint a fresh ``device_id``.
+    """
+
+
+class CapacityExceededError(BootstrapServerError):
+    """``POST /register`` returned 503 ``registration_capacity_exceeded``.
+
+    CMS is in back-pressure; back off and retry later.
+    """
+
+
+class RateLimitedError(BootstrapServerError):
+    """Any endpoint returned 429 ``rate_limited``.  Back off and retry."""
+
+
+class PendingNotFoundError(BootstrapServerError):
+    """``GET /bootstrap-status`` returned 404 ``not_found``.
+
+    Either the device has not yet called ``/register`` for this pubkey,
+    or the pending row has been reaped/reset.  The caller's policy
+    decides whether to re-register or fail hard.
+    """
+
+
+class ConnectTokenRejectedError(BootstrapServerError):
+    """``POST /connect-token`` returned 401 (signature/adoption check failed).
+
+    Subcases surface via the ``detail`` field (``unauthorized`` — the
+    CMS intentionally does NOT distinguish further so that a probe
+    can't tell valid-device-wrong-signature from non-adopted-device).
+    """
+
+
+# ---------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BootstrapStatus:
+    """Raw result of ``GET /bootstrap-status``.
+
+    Does NOT decrypt the payload — callers own the ed25519 seed and
+    pass it into :func:`shared.bootstrap_identity.decrypt_adopt_payload`
+    themselves.
+    """
+
+    status: str  # "pending" or "adopted"
+    payload_b64: Optional[str]  # base64 ECIES ciphertext when adopted; else None
+
+    @property
+    def is_adopted(self) -> bool:
+        return self.status == "adopted" and bool(self.payload_b64)
+
+
+@dataclass(frozen=True)
+class ConnectTokenResult:
+    """Successful response from ``POST /connect-token``."""
+
+    wps_jwt: str
+    wps_url: str
+    expires_at: str  # RFC3339 UTC string; parsing is the caller's job
+
+
+# ---------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------
+
+
+async def register_once(
+    session: aiohttp.ClientSession,
+    api_base: str,
+    *,
+    device_id: str,
+    pubkey_b64: str,
+    pairing_secret_hash: str,
+    fleet_id: str,
+    fleet_secret: bytes,
+    metadata: Optional[Mapping[str, Any]] = None,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> None:
+    """POST to ``/api/devices/register``.
+
+    On success (CMS returns 202 ``{"status":"pending"}`` unconditionally
+    so probes can't distinguish valid from invalid MACs), this function
+    returns ``None``.
+
+    :param session: pre-built ``aiohttp.ClientSession`` (caller-owned).
+    :param api_base: CMS root URL, e.g. ``"https://cms.example.com"``.
+        Trailing slash optional.
+    :param device_id: advisory device_id the CMS will pin the pending
+        row to.  The CMS key is ``(pubkey, pairing_secret_hash)`` — this
+        field lets the operator see a familiar ID in the adopt UI.
+    :param pubkey_b64: standard-base64 of the raw 32-byte ed25519 pubkey.
+    :param pairing_secret_hash: 64-char hex SHA-256 of the raw pairing
+        secret the device shows in its QR code.  Use
+        :func:`shared.bootstrap_identity.pairing_secret_hash_hex`.
+    :param fleet_id: fleet identifier (goes in the ``X-Fleet-Id`` header
+        and the HMAC canonical input).
+    :param fleet_secret: raw bytes of the fleet HMAC key (NOT base64).
+    :param metadata: optional advisory metadata dict (model / serial /
+        firmware version etc.).  The CMS stores but does not trust it.
+    :param timestamp: unix seconds.  Defaults to ``int(time.time())``.
+        Injectable for deterministic tests.
+    :param nonce: 32+ hex chars.  Defaults to ``secrets.token_hex(16)``.
+        Injectable for deterministic tests.
+    :param request_timeout: per-request timeout in seconds.
+
+    :raises FleetHmacRejectedError: 401 (any ``fleet_hmac_*`` detail).
+    :raises PubkeyMismatchError: 409 ``pubkey_mismatch``.
+    :raises CapacityExceededError: 503 ``registration_capacity_exceeded``.
+    :raises RateLimitedError: 429.
+    :raises BootstrapServerError: any other non-2xx.
+    :raises BootstrapTransportError: network-layer failure.
+    """
+    ts = int(timestamp) if timestamp is not None else int(time.time())
+    n = nonce if nonce is not None else secrets.token_hex(16)
+
+    mac_hex = compute_fleet_hmac_hex(
+        fleet_secret,
+        device_id=device_id,
+        pubkey_b64=pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash,
+        fleet_id=fleet_id,
+        timestamp=ts,
+        nonce=n,
+    )
+
+    url = _join(api_base, "/api/devices/register")
+    headers = {
+        "X-Fleet-Id": fleet_id,
+        "X-Fleet-Timestamp": str(ts),
+        "X-Fleet-Nonce": n,
+        # CMS verifies hex despite the ``mac_b64`` name in the router.
+        # The wire format is hex SHA-256.
+        "X-Fleet-Mac": mac_hex,
+    }
+    body = {
+        "device_id": device_id,
+        "pubkey": pubkey_b64,
+        "pairing_secret_hash": pairing_secret_hash,
+        "metadata": dict(metadata or {}),
+    }
+
+    logger.debug(
+        "bootstrap.register_once device_id=%s fleet_id=%s ts=%d", device_id, fleet_id, ts
+    )
+
+    try:
+        async with session.post(
+            url,
+            json=body,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status in (200, 202):
+                return
+            detail = await _read_detail(resp)
+            _raise_register_error(resp.status, detail)
+    except aiohttp.ClientError as e:
+        raise BootstrapTransportError(f"register transport error: {e!r}") from e
+
+
+async def get_bootstrap_status_once(
+    session: aiohttp.ClientSession,
+    api_base: str,
+    *,
+    pubkey_b64: str,
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> BootstrapStatus:
+    """GET ``/api/devices/bootstrap-status?pubkey=...``.
+
+    Returns a :class:`BootstrapStatus` with the raw status string and
+    the base64 ciphertext (when adopted).  Does NOT decrypt — the
+    caller owns the ed25519 seed.
+
+    :raises PendingNotFoundError: 404.  Device hasn't registered yet
+        for this pubkey, or the pending row was reaped.
+    :raises RateLimitedError: 429.
+    :raises BootstrapServerError: any other non-2xx (400 on a malformed
+        pubkey, 500 on CMS bugs, etc.).
+    :raises BootstrapTransportError: network-layer failure.
+    """
+    url = _join(api_base, "/api/devices/bootstrap-status")
+    try:
+        async with session.get(
+            url,
+            params={"pubkey": pubkey_b64},
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                status = str(data.get("status") or "")
+                payload = data.get("payload")
+                if payload is not None and not isinstance(payload, str):
+                    raise BootstrapServerError(
+                        200, f"bootstrap-status payload had type {type(payload).__name__}"
+                    )
+                return BootstrapStatus(status=status, payload_b64=payload)
+            detail = await _read_detail(resp)
+            _raise_status_error(resp.status, detail)
+            # _raise_status_error always raises; unreachable.
+            raise BootstrapServerError(resp.status, detail)
+    except aiohttp.ClientError as e:
+        raise BootstrapTransportError(f"bootstrap-status transport error: {e!r}") from e
+
+
+async def fetch_connect_token(
+    session: aiohttp.ClientSession,
+    api_base: str,
+    *,
+    device_id: str,
+    seed: bytes,
+    timestamp: Optional[int] = None,
+    nonce: Optional[str] = None,
+    request_timeout: float = DEFAULT_REQUEST_TIMEOUT_S,
+) -> ConnectTokenResult:
+    """POST to ``/api/devices/connect-token`` with an ed25519-signed request.
+
+    The signature is over ``f"{device_id}|{timestamp}|{nonce}"`` as
+    UTF-8 bytes, matching
+    :func:`shared.bootstrap_identity.connect_token_canonical_bytes`.
+
+    :param device_id: CMS-assigned device UUID (as returned in the
+        decrypted bootstrap payload).
+    :param seed: raw 32-byte ed25519 seed.  Sensitive — never logged.
+    :param timestamp: unix seconds.  Defaults to ``int(time.time())``.
+    :param nonce: 32+ hex chars.  Defaults to ``secrets.token_hex(16)``.
+
+    :raises ConnectTokenRejectedError: 401 (bad signature, stale /
+        replayed nonce, device not adopted).  The caller MUST NOT retry
+        with the same nonce; a fresh one is mandatory.
+    :raises RateLimitedError: 429.
+    :raises BootstrapServerError: any other non-2xx (500 ``token_mint_failed``).
+    :raises BootstrapTransportError: network-layer failure.
+    """
+    ts = int(timestamp) if timestamp is not None else int(time.time())
+    n = nonce if nonce is not None else secrets.token_hex(16)
+
+    signature_b64 = sign_connect_token_request(seed, device_id, ts, n)
+
+    url = _join(api_base, "/api/devices/connect-token")
+    body = {
+        "device_id": device_id,
+        "timestamp": ts,
+        "nonce": n,
+        "signature": signature_b64,
+    }
+
+    logger.debug("bootstrap.fetch_connect_token device_id=%s ts=%d", device_id, ts)
+
+    try:
+        async with session.post(
+            url,
+            json=body,
+            timeout=aiohttp.ClientTimeout(total=request_timeout),
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                try:
+                    return ConnectTokenResult(
+                        wps_jwt=str(data["wps_jwt"]),
+                        wps_url=str(data["wps_url"]),
+                        expires_at=str(data["expires_at"]),
+                    )
+                except (KeyError, TypeError) as e:
+                    raise BootstrapServerError(
+                        200, f"connect-token response missing field: {e!r}"
+                    ) from e
+            detail = await _read_detail(resp)
+            _raise_connect_token_error(resp.status, detail)
+            raise BootstrapServerError(resp.status, detail)
+    except aiohttp.ClientError as e:
+        raise BootstrapTransportError(f"connect-token transport error: {e!r}") from e
+
+
+# ---------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------
+
+
+def _join(base: str, path: str) -> str:
+    """Join an API base and a leading-slash path, trimming a trailing slash."""
+    return base.rstrip("/") + path
+
+
+async def _read_detail(resp: aiohttp.ClientResponse) -> Optional[str]:
+    """Parse a FastAPI error body and return its ``detail`` field, or None."""
+    try:
+        data = await resp.json(content_type=None)
+    except (aiohttp.ContentTypeError, ValueError):
+        return None
+    if isinstance(data, dict):
+        d = data.get("detail")
+        if isinstance(d, str):
+            return d
+    return None
+
+
+def _raise_register_error(status: int, detail: Optional[str]) -> None:
+    if status == 401:
+        raise FleetHmacRejectedError(status, detail)
+    if status == 409:
+        raise PubkeyMismatchError(status, detail)
+    if status == 429:
+        raise RateLimitedError(status, detail)
+    if status == 503:
+        raise CapacityExceededError(status, detail)
+    raise BootstrapServerError(status, detail)
+
+
+def _raise_status_error(status: int, detail: Optional[str]) -> None:
+    if status == 404:
+        raise PendingNotFoundError(status, detail)
+    if status == 429:
+        raise RateLimitedError(status, detail)
+    raise BootstrapServerError(status, detail)
+
+
+def _raise_connect_token_error(status: int, detail: Optional[str]) -> None:
+    if status == 401:
+        raise ConnectTokenRejectedError(status, detail)
+    if status == 429:
+        raise RateLimitedError(status, detail)
+    raise BootstrapServerError(status, detail)
+
+
+__all__ = [
+    "BootstrapClientError",
+    "BootstrapServerError",
+    "BootstrapStatus",
+    "BootstrapTransportError",
+    "CapacityExceededError",
+    "ConnectTokenRejectedError",
+    "ConnectTokenResult",
+    "FleetHmacRejectedError",
+    "PendingNotFoundError",
+    "PubkeyMismatchError",
+    "RateLimitedError",
+    "fetch_connect_token",
+    "get_bootstrap_status_once",
+    "register_once",
+]

--- a/tests/test_bootstrap_client.py
+++ b/tests/test_bootstrap_client.py
@@ -1,0 +1,553 @@
+"""Unit tests for :mod:`cms_client.bootstrap_client`.
+
+Stage B.2 of the bootstrap redesign (issue #420).  These tests cover the
+three HTTP endpoints on the CMS as a pure library, with a
+lightweight fake :class:`aiohttp.ClientSession` so the suite doesn't take
+a new dependency or spin up a real server.
+
+The canonical HMAC / signature bytes are cross-checked against the B.1
+primitives so the device side stays in lockstep with what the CMS
+verifies.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import sys
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+# ``aiohttp`` is a real runtime dep (see requirements-cms-client.txt); we
+# import it directly so ``ClientError`` / ``ClientTimeout`` etc. are the
+# real classes.  The rest of the aiohttp surface is stubbed per-test.
+import aiohttp
+
+from cms_client.bootstrap_client import (
+    BootstrapServerError,
+    BootstrapStatus,
+    BootstrapTransportError,
+    CapacityExceededError,
+    ConnectTokenRejectedError,
+    ConnectTokenResult,
+    FleetHmacRejectedError,
+    PendingNotFoundError,
+    PubkeyMismatchError,
+    RateLimitedError,
+    fetch_connect_token,
+    get_bootstrap_status_once,
+    register_once,
+)
+from shared.bootstrap_identity import (
+    compute_fleet_hmac_hex,
+    connect_token_canonical_bytes,
+)
+
+
+# ---------------------------------------------------------------------
+# Fake aiohttp response / session
+# ---------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for aiohttp.ClientResponse."""
+
+    def __init__(
+        self,
+        status: int,
+        json_body: Any = None,
+        raise_content_type: bool = False,
+    ) -> None:
+        self.status = status
+        self._json_body = json_body
+        self._raise_content_type = raise_content_type
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+        return None
+
+    async def json(self, content_type: Any = None) -> Any:  # noqa: D401
+        if self._raise_content_type:
+            raise aiohttp.ContentTypeError(None, None, message="no json")
+        if self._json_body is None:
+            raise ValueError("no body")
+        return self._json_body
+
+
+class _FakeSession:
+    """Captures the last request arguments so tests can assert on them."""
+
+    def __init__(self, response: _FakeResponse | Exception) -> None:
+        self._response = response
+        self.last_method: str | None = None
+        self.last_url: str | None = None
+        self.last_json: Any = None
+        self.last_params: Any = None
+        self.last_headers: dict[str, str] | None = None
+
+    def _handle(self, method: str, url: str, **kwargs: Any) -> _FakeResponse:
+        self.last_method = method
+        self.last_url = url
+        self.last_json = kwargs.get("json")
+        self.last_params = kwargs.get("params")
+        self.last_headers = kwargs.get("headers")
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        return self._handle("POST", url, **kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        return self._handle("GET", url, **kwargs)
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def fleet_secret() -> bytes:
+    # 32 bytes of zeros is fine for a deterministic test vector.
+    return b"\x00" * 32
+
+
+@pytest.fixture
+def pubkey_b64() -> str:
+    # Deterministic pubkey (standard base64 of 32 zero bytes).
+    return base64.b64encode(b"\x00" * 32).decode("ascii")
+
+
+@pytest.fixture
+def pairing_secret_hash() -> str:
+    return hashlib.sha256(b"not-a-real-secret").hexdigest()
+
+
+# ---------------------------------------------------------------------
+# register_once
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_once_happy_path_202(
+    fleet_secret: bytes, pubkey_b64: str, pairing_secret_hash: str,
+) -> None:
+    sess = _FakeSession(_FakeResponse(status=202, json_body={"status": "pending"}))
+    await register_once(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com/",
+        device_id="dev-00001",
+        pubkey_b64=pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash,
+        fleet_id="fleet-A",
+        fleet_secret=fleet_secret,
+        metadata={"model": "pi5"},
+        timestamp=1714000000,
+        nonce="0" * 32,
+    )
+    assert sess.last_method == "POST"
+    assert sess.last_url == "https://cms.example.com/api/devices/register"
+    assert sess.last_json == {
+        "device_id": "dev-00001",
+        "pubkey": pubkey_b64,
+        "pairing_secret_hash": pairing_secret_hash,
+        "metadata": {"model": "pi5"},
+    }
+    hdr = sess.last_headers or {}
+    assert hdr["X-Fleet-Id"] == "fleet-A"
+    assert hdr["X-Fleet-Timestamp"] == "1714000000"
+    assert hdr["X-Fleet-Nonce"] == "0" * 32
+
+
+def test_register_once_mac_header_matches_shared_primitive(
+    fleet_secret: bytes, pubkey_b64: str, pairing_secret_hash: str,
+) -> None:
+    """The ``X-Fleet-Mac`` header is HEX (not base64), computed by the
+    same primitive the CMS uses to verify.  Canonicalising the
+    fleet HMAC on the device and on the CMS must match byte-for-byte.
+    """
+    expected = compute_fleet_hmac_hex(
+        fleet_secret,
+        device_id="dev-00001",
+        pubkey_b64=pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash,
+        fleet_id="fleet-A",
+        timestamp=1714000000,
+        nonce="ab" * 16,
+    )
+    # Independent re-derivation: match the canonical input the CMS hashes.
+    canonical = "|".join(
+        [
+            "register",
+            "dev-00001",
+            pubkey_b64,
+            pairing_secret_hash,
+            "fleet-A",
+            "1714000000",
+            "ab" * 16,
+        ]
+    ).encode("utf-8")
+    indep = hmac.new(fleet_secret, canonical, hashlib.sha256).hexdigest()
+    assert expected == indep
+    # 64 hex chars (SHA-256 digest length)
+    assert len(expected) == 64
+    int(expected, 16)  # no ValueError
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status, detail, expected_exc",
+    [
+        (401, "fleet_hmac_bad", FleetHmacRejectedError),
+        (401, "fleet_hmac_stale", FleetHmacRejectedError),
+        (401, "fleet_hmac_replay", FleetHmacRejectedError),
+        (409, "pubkey_mismatch", PubkeyMismatchError),
+        (429, "rate_limited", RateLimitedError),
+        (503, "registration_capacity_exceeded", CapacityExceededError),
+        (500, "internal_error", BootstrapServerError),
+    ],
+)
+async def test_register_once_error_mapping(
+    fleet_secret: bytes,
+    pubkey_b64: str,
+    pairing_secret_hash: str,
+    status: int,
+    detail: str,
+    expected_exc: type,
+) -> None:
+    sess = _FakeSession(_FakeResponse(status=status, json_body={"detail": detail}))
+    with pytest.raises(expected_exc) as excinfo:
+        await register_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-00001",
+            pubkey_b64=pubkey_b64,
+            pairing_secret_hash=pairing_secret_hash,
+            fleet_id="fleet-A",
+            fleet_secret=fleet_secret,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+    assert excinfo.value.status == status  # type: ignore[attr-defined]
+    assert excinfo.value.detail == detail  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_register_once_transport_error_wraps_client_error(
+    fleet_secret: bytes, pubkey_b64: str, pairing_secret_hash: str,
+) -> None:
+    sess = _FakeSession(aiohttp.ClientConnectionError("boom"))
+    with pytest.raises(BootstrapTransportError):
+        await register_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-00001",
+            pubkey_b64=pubkey_b64,
+            pairing_secret_hash=pairing_secret_hash,
+            fleet_id="fleet-A",
+            fleet_secret=fleet_secret,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+
+
+@pytest.mark.asyncio
+async def test_register_once_generates_timestamp_and_nonce_when_omitted(
+    fleet_secret: bytes, pubkey_b64: str, pairing_secret_hash: str,
+) -> None:
+    sess = _FakeSession(_FakeResponse(status=202, json_body={"status": "pending"}))
+    await register_once(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com",
+        device_id="dev-00001",
+        pubkey_b64=pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash,
+        fleet_id="fleet-A",
+        fleet_secret=fleet_secret,
+    )
+    hdr = sess.last_headers or {}
+    ts = int(hdr["X-Fleet-Timestamp"])
+    # Not strict: just verify it's a plausible current-era unix ts.
+    assert ts > 1_700_000_000
+    nonce = hdr["X-Fleet-Nonce"]
+    assert len(nonce) >= 32
+    int(nonce, 16)  # hex
+
+
+# ---------------------------------------------------------------------
+# get_bootstrap_status_once
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_returns_pending(pubkey_b64: str) -> None:
+    sess = _FakeSession(
+        _FakeResponse(status=200, json_body={"status": "pending", "payload": None})
+    )
+    result = await get_bootstrap_status_once(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com",
+        pubkey_b64=pubkey_b64,
+    )
+    assert isinstance(result, BootstrapStatus)
+    assert result.status == "pending"
+    assert result.payload_b64 is None
+    assert result.is_adopted is False
+    assert sess.last_method == "GET"
+    assert sess.last_params == {"pubkey": pubkey_b64}
+
+
+@pytest.mark.asyncio
+async def test_status_returns_adopted_with_ciphertext(pubkey_b64: str) -> None:
+    ciphertext_b64 = base64.b64encode(b"\x01" * 64).decode("ascii")
+    sess = _FakeSession(
+        _FakeResponse(
+            status=200,
+            json_body={"status": "adopted", "payload": ciphertext_b64},
+        )
+    )
+    result = await get_bootstrap_status_once(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com",
+        pubkey_b64=pubkey_b64,
+    )
+    assert result.status == "adopted"
+    assert result.payload_b64 == ciphertext_b64
+    assert result.is_adopted is True
+
+
+@pytest.mark.asyncio
+async def test_status_404_raises_pending_not_found(pubkey_b64: str) -> None:
+    sess = _FakeSession(_FakeResponse(status=404, json_body={"detail": "not_found"}))
+    with pytest.raises(PendingNotFoundError) as ei:
+        await get_bootstrap_status_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            pubkey_b64=pubkey_b64,
+        )
+    assert ei.value.status == 404
+    assert ei.value.detail == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_status_429_raises_rate_limited(pubkey_b64: str) -> None:
+    sess = _FakeSession(_FakeResponse(status=429, json_body={"detail": "rate_limited"}))
+    with pytest.raises(RateLimitedError):
+        await get_bootstrap_status_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            pubkey_b64=pubkey_b64,
+        )
+
+
+@pytest.mark.asyncio
+async def test_status_400_raises_generic(pubkey_b64: str) -> None:
+    sess = _FakeSession(_FakeResponse(status=400, json_body={"detail": "bad pubkey"}))
+    with pytest.raises(BootstrapServerError) as ei:
+        await get_bootstrap_status_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            pubkey_b64=pubkey_b64,
+        )
+    assert not isinstance(ei.value, (PendingNotFoundError, RateLimitedError))
+
+
+@pytest.mark.asyncio
+async def test_status_payload_wrong_type_raises(pubkey_b64: str) -> None:
+    sess = _FakeSession(
+        _FakeResponse(status=200, json_body={"status": "adopted", "payload": 42})
+    )
+    with pytest.raises(BootstrapServerError):
+        await get_bootstrap_status_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            pubkey_b64=pubkey_b64,
+        )
+
+
+@pytest.mark.asyncio
+async def test_status_transport_error_wraps_client_error(pubkey_b64: str) -> None:
+    sess = _FakeSession(aiohttp.ClientConnectionError("boom"))
+    with pytest.raises(BootstrapTransportError):
+        await get_bootstrap_status_once(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            pubkey_b64=pubkey_b64,
+        )
+
+
+# ---------------------------------------------------------------------
+# fetch_connect_token
+# ---------------------------------------------------------------------
+
+
+def _fresh_seed_and_pub() -> tuple[bytes, Ed25519PublicKey]:
+    priv = Ed25519PrivateKey.generate()
+    from cryptography.hazmat.primitives import serialization
+
+    seed = priv.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return seed, priv.public_key()
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_happy_path_signature_verifies() -> None:
+    seed, pub = _fresh_seed_and_pub()
+    sess = _FakeSession(
+        _FakeResponse(
+            status=200,
+            json_body={
+                "wps_jwt": "JWT.TOKEN.VALUE",
+                "wps_url": "wss://wps.example.com/client/hubs/agora",
+                "expires_at": "2026-04-24T12:00:00Z",
+            },
+        )
+    )
+    result = await fetch_connect_token(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com",
+        device_id="dev-row-uuid",
+        seed=seed,
+        timestamp=1714000000,
+        nonce="cd" * 16,
+    )
+    assert isinstance(result, ConnectTokenResult)
+    assert result.wps_jwt == "JWT.TOKEN.VALUE"
+    assert result.wps_url == "wss://wps.example.com/client/hubs/agora"
+    assert result.expires_at == "2026-04-24T12:00:00Z"
+    # Verify the signature actually checks out against the canonical
+    # bytes (what the CMS will verify).
+    body = sess.last_json
+    sig = base64.b64decode(body["signature"])
+    canonical = connect_token_canonical_bytes(
+        body["device_id"], body["timestamp"], body["nonce"]
+    )
+    pub.verify(sig, canonical)  # raises on mismatch
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_401_rejected() -> None:
+    seed, _ = _fresh_seed_and_pub()
+    sess = _FakeSession(_FakeResponse(status=401, json_body={"detail": "unauthorized"}))
+    with pytest.raises(ConnectTokenRejectedError) as ei:
+        await fetch_connect_token(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-row-uuid",
+            seed=seed,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+    assert ei.value.status == 401
+    assert ei.value.detail == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_429_rate_limited() -> None:
+    seed, _ = _fresh_seed_and_pub()
+    sess = _FakeSession(_FakeResponse(status=429, json_body={"detail": "rate_limited"}))
+    with pytest.raises(RateLimitedError):
+        await fetch_connect_token(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-row-uuid",
+            seed=seed,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_500_generic() -> None:
+    seed, _ = _fresh_seed_and_pub()
+    sess = _FakeSession(_FakeResponse(status=500, json_body={"detail": "token_mint_failed"}))
+    with pytest.raises(BootstrapServerError) as ei:
+        await fetch_connect_token(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-row-uuid",
+            seed=seed,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+    assert not isinstance(
+        ei.value, (ConnectTokenRejectedError, RateLimitedError)
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_missing_field_in_200_body() -> None:
+    seed, _ = _fresh_seed_and_pub()
+    sess = _FakeSession(
+        _FakeResponse(
+            status=200,
+            json_body={"wps_jwt": "t", "wps_url": "u"},  # missing expires_at
+        )
+    )
+    with pytest.raises(BootstrapServerError):
+        await fetch_connect_token(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-row-uuid",
+            seed=seed,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_transport_error() -> None:
+    seed, _ = _fresh_seed_and_pub()
+    sess = _FakeSession(aiohttp.ClientConnectionError("boom"))
+    with pytest.raises(BootstrapTransportError):
+        await fetch_connect_token(
+            sess,  # type: ignore[arg-type]
+            "https://cms.example.com",
+            device_id="dev-row-uuid",
+            seed=seed,
+            timestamp=1,
+            nonce="a" * 32,
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_connect_token_default_timestamp_and_nonce_are_fresh() -> None:
+    seed, pub = _fresh_seed_and_pub()
+    sess = _FakeSession(
+        _FakeResponse(
+            status=200,
+            json_body={"wps_jwt": "j", "wps_url": "u", "expires_at": "t"},
+        )
+    )
+    await fetch_connect_token(
+        sess,  # type: ignore[arg-type]
+        "https://cms.example.com",
+        device_id="dev-row-uuid",
+        seed=seed,
+    )
+    body = sess.last_json
+    assert isinstance(body["timestamp"], int)
+    assert body["timestamp"] > 1_700_000_000
+    nonce = body["nonce"]
+    assert len(nonce) >= 32
+    int(nonce, 16)
+    # Signature must verify against that fresh ts/nonce.
+    sig = base64.b64decode(body["signature"])
+    canonical = connect_token_canonical_bytes(
+        body["device_id"], body["timestamp"], body["nonce"]
+    )
+    pub.verify(sig, canonical)


### PR DESCRIPTION
# Stage B.2: device-side HTTP bootstrap client

## Summary

Adds `cms_client/bootstrap_client.py` — a pure library that wraps the three
anonymous bootstrap HTTP endpoints on the CMS for the device side of
issue #420.

This is **library only**.  Nothing calls it yet.  `cms_client/service.py`
is unchanged; the existing `auth_token` / `api_key` flow is fully intact.
Wire-in lands in Stage B.3 behind a feature flag.

## What's here

Three one-shot async functions (policy is the caller's, not ours):

* `register_once(...)` — `POST /api/devices/register`; computes the fleet
  HMAC from B.1 primitives and sends it in the four `X-Fleet-*` headers
  the CMS expects.  Accepts 202.
* `get_bootstrap_status_once(...)` — `GET /api/devices/bootstrap-status?pubkey=...`;
  returns a `BootstrapStatus` with the raw ciphertext base64.  **Does
  NOT decrypt** — the caller holds the ed25519 seed and invokes
  `shared.bootstrap_identity.decrypt_adopt_payload` itself.
* `fetch_connect_token(...)` — `POST /api/devices/connect-token`; signs
  the canonical `device_id|timestamp|nonce` bytes with the ed25519 seed
  (via `sign_connect_token_request`) and returns a typed
  `ConnectTokenResult`.

Typed exceptions map 1:1 to CMS responses the caller is expected to
branch on:

| CMS response | exception |
|---|---|
| `/register` 401 (fleet_hmac_*) | `FleetHmacRejectedError` |
| `/register` 409 (pubkey_mismatch) | `PubkeyMismatchError` |
| `/register` 503 (capacity_exceeded) | `CapacityExceededError` |
| `/bootstrap-status` 404 | `PendingNotFoundError` |
| `/connect-token` 401 | `ConnectTokenRejectedError` |
| 429 any | `RateLimitedError` |
| other non-2xx | `BootstrapServerError` |
| network failure | `BootstrapTransportError` |

`timestamp` and `nonce` are injectable on every signed call so tests
can pin canonical bytes deterministically (and so the future retry
policy in B.3 can mint a fresh nonce after a replay rejection without
reworking the API).

## Non-goals for this PR

* No wire-in to `_connect_and_run` — the legacy WS register flow is
  untouched.
* No settings / disk persistence — that's B.3.
* No `wait_for_adoption` convenience loop.  Register/poll cadence and
  404 semantics (never-registered vs reaped-row) are policy decisions
  that belong next to the service lifecycle, not in the library.

## Tests

`tests/test_bootstrap_client.py` — 25 tests, fully offline using a
lightweight fake `ClientSession` so no new deps.  Covers:

* Happy paths for all three endpoints, including signature
  round-trip verification against the public key (the same
  verification the CMS performs).
* Full error-code matrix for every status the CMS can return.
* Transport errors wrap `aiohttp.ClientError`.
* Default `timestamp` / `nonce` produce plausible fresh values and the
  generated signature still verifies.
* `X-Fleet-Mac` is HEX (not base64) — matches the CMS verifier
  implementation even though the CMS router names the variable
  `mac_b64`.

Run locally:

```
python -m pytest tests/test_bootstrap_client.py -p no:timeout -v
# 25 passed
```

## Rubber-duck course-corrections

Original scope had a `wait_for_adoption` high-level loop in the
library; dropped it after a rubber-duck critique pointed out that
`/bootstrap-status` 404 has policy-sensitive semantics (never-registered
vs reaped-row) that a library loop can't resolve correctly.  Also added
the 409 / 503 / 429 typed errors that the first draft missed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
