### PR TITLE
feat(bootstrap): stage B.3 - runtime wire-in + JWT renewal

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -42,6 +42,22 @@ class Settings(BaseSettings):
     # the value stored in <persist_dir>/api_key.
     device_api_key: str = ""
 
+    # Bootstrap v2 (issue #420): when true, the device uses the new HTTPS
+    # bootstrap flow (POST /register → poll /bootstrap-status → decrypt →
+    # open WPS with the pre-minted JWT; POST /connect-token for renewal).
+    # When false (default), the legacy api_key path is used.
+    bootstrap_v2: bool = False
+    # Fleet identity for the fleet-HMAC gate on /register.  Baked into
+    # firmware builds; both must be set when bootstrap_v2=true and the
+    # device has no cached bootstrap state (first boot).  fleet_secret_hex
+    # is the raw HMAC key, hex-encoded.  When the device is already
+    # adopted, neither is used — only the signed /connect-token path.
+    fleet_id: str = ""
+    fleet_secret_hex: str = ""
+    # Seconds before JWT expiry to refresh.  The renewal task sleeps until
+    # (expires_at - jwt_refresh_lead_seconds) and then calls /connect-token.
+    jwt_refresh_lead_seconds: int = 600  # 10 min
+
     # Asset budget (0 = 80% of partition)
     asset_budget_mb: int = 0
 
@@ -88,6 +104,21 @@ class Settings(BaseSettings):
     @property
     def auth_token_path(self) -> Path:
         return self.persist_dir / "cms_auth_token"
+
+    @property
+    def device_key_path(self) -> Path:
+        """Bootstrap v2: ed25519 seed file (mode 0400)."""
+        return self.persist_dir / "device_key"
+
+    @property
+    def pairing_secret_path(self) -> Path:
+        """Bootstrap v2: pairing-secret file (mode 0400)."""
+        return self.persist_dir / "pairing_secret"
+
+    @property
+    def bootstrap_state_path(self) -> Path:
+        """Bootstrap v2: JSON state (adopted marker + cached WPS JWT, mode 0600)."""
+        return self.persist_dir / "bootstrap_state.json"
 
     @property
     def cms_config_path(self) -> Path:

--- a/cms_client/bootstrap_boot.py
+++ b/cms_client/bootstrap_boot.py
@@ -1,0 +1,541 @@
+"""Device-side bootstrap orchestration (stage B.3 of issue #420).
+
+Wraps :mod:`cms_client.bootstrap_client` (pure HTTP primitives) and
+:mod:`shared.bootstrap_identity` (crypto + secret-file primitives) into
+the two entry points the service lifecycle actually needs:
+
+* :func:`ensure_wps_credentials` — used at connect time.  Returns a
+  valid ``(wps_url, wps_jwt, expires_at)`` triple, choosing between
+  three branches:
+
+    1. cached state exists and JWT not yet expired → return as-is;
+    2. cached state exists but JWT is expired → signed
+       ``/connect-token`` to mint a fresh one;
+    3. no cached state → first-boot path: register, poll until adopted,
+       decrypt the outbox, then signed ``/connect-token``.
+
+* :func:`refresh_wps_jwt` — used by the background renewal task.  Always
+  goes through the signed ``/connect-token`` path.  Assumes the device
+  is already adopted; if it isn't, the call will raise
+  :class:`ConnectTokenRejectedError` and the caller decides policy.
+
+The state file (``<persist_dir>/bootstrap_state.json``, mode 0600) is
+the adopted marker.  It records the CMS base URL the device was adopted
+against so we can invalidate on a CMS URL change.
+
+Invariants this module enforces:
+
+* Seeds and JWTs never appear in log messages at INFO or above.
+* State writes are atomic (temp-file + ``os.replace``) and fsynced.
+* Cached JWT is treated as expired ``JWT_EARLY_REFRESH_SEC`` seconds
+  before its notarized ``expires_at`` — this prevents the "connect with
+  JWT that expires 2 seconds later" race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from shared.bootstrap_identity import (
+    DeviceIdentity,
+    decrypt_adopt_payload,
+    load_or_create_device_identity,
+    load_or_create_pairing_secret,
+    pairing_secret_hash_hex,
+)
+
+from cms_client.bootstrap_client import (
+    BootstrapServerError,
+    BootstrapTransportError,
+    ConnectTokenRejectedError,
+    ConnectTokenResult,
+    PendingNotFoundError,
+    PubkeyMismatchError,
+    RateLimitedError,
+    fetch_connect_token,
+    get_bootstrap_status_once,
+    register_once,
+)
+
+logger = logging.getLogger("agora.cms_client.bootstrap_boot")
+
+
+STATE_SCHEMA_VERSION = 1
+# Treat the cached JWT as expired this many seconds before its notarized
+# expiry.  Guards against opening a WPS connection with a JWT that dies
+# seconds later.
+JWT_EARLY_REFRESH_SEC = 60
+# Default poll cadence for GET /bootstrap-status during first-boot.  The
+# operator may take seconds to minutes to click "Adopt".  Start fast,
+# back off to reduce CMS load for abandoned pending devices.
+FIRST_BOOT_POLL_SHORT_SEC = 5.0
+FIRST_BOOT_POLL_LONG_SEC = 30.0
+# Switch to the long cadence after this many short-cadence polls.
+FIRST_BOOT_POLL_SHORT_COUNT = 24  # ~2 minutes at 5s cadence
+
+
+class BootstrapConfigError(RuntimeError):
+    """Caller asked for bootstrap v2 but missing config (fleet_id/secret)."""
+
+
+class BootstrapCancelledError(Exception):
+    """First-boot poll loop was cancelled externally."""
+
+
+@dataclass(frozen=True)
+class BootstrapCredentials:
+    """Result of :func:`ensure_wps_credentials` / :func:`refresh_wps_jwt`."""
+
+    wps_url: str
+    wps_jwt: str
+    expires_at: str  # RFC3339 UTC string from the CMS
+    device_id: str  # the device_id used at adopt time (Pi serial for agora)
+
+
+# ---------------------------------------------------------------------
+# State file helpers
+# ---------------------------------------------------------------------
+
+
+def _parse_expires_at(expires_at: str) -> Optional[datetime]:
+    """Parse an RFC3339 UTC timestamp; return None on garbage."""
+    if not expires_at:
+        return None
+    # Tolerate the "...Z" suffix that CMS emits.
+    s = expires_at.replace("Z", "+00:00") if expires_at.endswith("Z") else expires_at
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def load_state(path: Path) -> Optional[dict]:
+    """Load cached bootstrap state, or return None if missing/unreadable."""
+    try:
+        raw = path.read_text()
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("bootstrap_state.json corrupt — ignoring")
+        return None
+    if not isinstance(data, dict) or data.get("schema_version") != STATE_SCHEMA_VERSION:
+        logger.warning(
+            "bootstrap_state.json has unsupported schema_version=%r — ignoring",
+            data.get("schema_version") if isinstance(data, dict) else None,
+        )
+        return None
+    return data
+
+
+def save_state(path: Path, state: dict) -> None:
+    """Atomically write state, fsync, chmod 0600."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(state, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=".bootstrap_state.", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        try:
+            os.write(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        # fsync the parent dir so the rename is durable
+        try:
+            dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def clear_state(path: Path) -> None:
+    """Best-effort delete; never raises."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _is_state_fresh(state: dict, cms_api_base: str, now_unix: float) -> bool:
+    """Is the cached state valid for ``cms_api_base`` and not near expiry?"""
+    if state.get("cms_api_base") != cms_api_base:
+        logger.info(
+            "Cached bootstrap state was minted for a different CMS — discarding"
+        )
+        return False
+    expires_at = state.get("expires_at") or ""
+    dt = _parse_expires_at(str(expires_at))
+    if dt is None:
+        return False
+    remaining = dt.timestamp() - now_unix
+    if remaining <= JWT_EARLY_REFRESH_SEC:
+        logger.info(
+            "Cached WPS JWT expires in %.0fs — will refresh", remaining
+        )
+        return False
+    return True
+
+
+def _state_from_token(
+    *, cms_api_base: str, device_id: str, token: ConnectTokenResult
+) -> dict:
+    return {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "cms_api_base": cms_api_base,
+        "device_id": device_id,
+        "wps_url": token.wps_url,
+        "wps_jwt": token.wps_jwt,
+        "expires_at": token.expires_at,
+    }
+
+
+# ---------------------------------------------------------------------
+# Identity loader
+# ---------------------------------------------------------------------
+
+
+def ensure_identity(
+    *,
+    device_key_path: Path,
+    pairing_secret_path: Path,
+) -> tuple[DeviceIdentity, str]:
+    """Load (or first-boot generate) the keypair and pairing secret.
+
+    Returns ``(identity, pairing_secret)``.  The pairing secret is needed
+    by :func:`register_once` for the fleet-HMAC canonical input and
+    should be treated as a low-entropy shared secret with the admin who
+    scans the QR code.
+    """
+    identity = load_or_create_device_identity(device_key_path)
+    secret = load_or_create_pairing_secret(pairing_secret_path)
+    return identity, secret
+
+
+# ---------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------
+
+
+async def ensure_wps_credentials(
+    session: Any,  # aiohttp.ClientSession (kept untyped to avoid hard dep at module import)
+    *,
+    cms_api_base: str,
+    device_id: str,
+    identity: DeviceIdentity,
+    pairing_secret: str,
+    state_path: Path,
+    fleet_id: str,
+    fleet_secret: bytes,
+    metadata: Optional[dict] = None,
+    poll_cancel_event: Optional[asyncio.Event] = None,
+    now_unix: Optional[float] = None,
+) -> BootstrapCredentials:
+    """Return a valid ``BootstrapCredentials`` for opening a WPS connection.
+
+    Branches:
+
+    1. Cached state exists and JWT not within
+       :data:`JWT_EARLY_REFRESH_SEC` of expiry → return cached.
+    2. Cached state exists but JWT is stale → signed ``/connect-token``,
+       persist fresh state.
+    3. No cached state (or cache was for a different CMS URL) → first
+       boot: ``/register`` then poll ``/bootstrap-status`` until adopted,
+       decrypt the outbox, then signed ``/connect-token``.
+
+    :param session: an open ``aiohttp.ClientSession``.
+    :param cms_api_base: CMS HTTP(S) base, e.g. ``"https://cms.example.com"``.
+    :param device_id: the advisory device_id used at ``/register``.
+        Must be the same value the device used at prior adopt time.
+    :param identity: already-loaded :class:`DeviceIdentity`.
+    :param pairing_secret: raw pairing secret string.
+    :param state_path: path to ``bootstrap_state.json``.
+    :param fleet_id: fleet identifier (empty string OK iff the device is
+        already adopted — we'll never call ``/register``).
+    :param fleet_secret: raw fleet HMAC key (empty bytes OK iff already
+        adopted).
+    :param metadata: optional advisory metadata dict for ``/register``.
+    :param poll_cancel_event: optional ``asyncio.Event`` — if set during
+        first-boot polling, the loop stops promptly and raises
+        :class:`BootstrapCancelledError`.
+    :param now_unix: clock override for tests.
+
+    :raises BootstrapConfigError: first-boot path entered with empty
+        fleet credentials.
+    :raises BootstrapCancelledError: first-boot poll was cancelled.
+    """
+    now = now_unix if now_unix is not None else time.time()
+    cached = load_state(state_path)
+
+    # Fast path: cached + fresh.
+    if cached and _is_state_fresh(cached, cms_api_base, now):
+        return BootstrapCredentials(
+            wps_url=str(cached["wps_url"]),
+            wps_jwt=str(cached["wps_jwt"]),
+            expires_at=str(cached["expires_at"]),
+            device_id=str(cached.get("device_id") or device_id),
+        )
+
+    # Medium path: cached state for this CMS, JWT just stale — signed refresh.
+    if cached and cached.get("cms_api_base") == cms_api_base:
+        logger.info("Refreshing WPS JWT via signed /connect-token (cached state)")
+        token = await fetch_connect_token(
+            session,
+            cms_api_base,
+            device_id=str(cached.get("device_id") or device_id),
+            seed=identity.seed,
+        )
+        state = _state_from_token(
+            cms_api_base=cms_api_base,
+            device_id=str(cached.get("device_id") or device_id),
+            token=token,
+        )
+        save_state(state_path, state)
+        return BootstrapCredentials(
+            wps_url=token.wps_url,
+            wps_jwt=token.wps_jwt,
+            expires_at=token.expires_at,
+            device_id=str(cached.get("device_id") or device_id),
+        )
+
+    # Slow path: first boot (or state was for a different CMS).
+    if not fleet_id or not fleet_secret:
+        raise BootstrapConfigError(
+            "bootstrap v2 first-boot path requires AGORA_FLEET_ID and "
+            "AGORA_FLEET_SECRET_HEX to be set"
+        )
+
+    logger.info("First-boot bootstrap: registering with CMS %s", cms_api_base)
+    await register_once(
+        session,
+        cms_api_base,
+        device_id=device_id,
+        pubkey_b64=identity.pubkey_b64,
+        pairing_secret_hash=pairing_secret_hash_hex(pairing_secret),
+        fleet_id=fleet_id,
+        fleet_secret=fleet_secret,
+        metadata=metadata,
+    )
+    logger.info("Registered; polling /bootstrap-status until adopted")
+
+    await _poll_until_adopted(
+        session,
+        cms_api_base=cms_api_base,
+        identity=identity,
+        pairing_secret=pairing_secret,
+        fleet_id=fleet_id,
+        fleet_secret=fleet_secret,
+        device_id=device_id,
+        metadata=metadata,
+        poll_cancel_event=poll_cancel_event,
+    )
+    # _poll_until_adopted returned without raising → device is adopted
+    # and we know the decrypted device_id from the outbox.
+    status = await get_bootstrap_status_once(
+        session, cms_api_base, pubkey_b64=identity.pubkey_b64,
+    )
+    if not status.is_adopted or not status.payload_b64:
+        # Extremely unlikely — we just saw adopted in the loop and the
+        # CMS doesn't unadopt.  Treat as transport anomaly.
+        raise BootstrapTransportError(
+            "/bootstrap-status flipped from adopted to non-adopted"
+        )
+    plaintext = decrypt_adopt_payload(identity.seed, status.payload_b64)
+    try:
+        payload = json.loads(plaintext.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise BootstrapTransportError(f"adopt payload was not JSON: {e!r}") from e
+    adopted_device_id = str(payload.get("device_id") or device_id)
+
+    logger.info("Adopted; minting WPS JWT via /connect-token")
+    token = await fetch_connect_token(
+        session, cms_api_base, device_id=adopted_device_id, seed=identity.seed,
+    )
+    state = _state_from_token(
+        cms_api_base=cms_api_base, device_id=adopted_device_id, token=token,
+    )
+    save_state(state_path, state)
+    return BootstrapCredentials(
+        wps_url=token.wps_url,
+        wps_jwt=token.wps_jwt,
+        expires_at=token.expires_at,
+        device_id=adopted_device_id,
+    )
+
+
+async def _poll_until_adopted(
+    session: Any,
+    *,
+    cms_api_base: str,
+    identity: DeviceIdentity,
+    pairing_secret: str,
+    fleet_id: str,
+    fleet_secret: bytes,
+    device_id: str,
+    metadata: Optional[dict],
+    poll_cancel_event: Optional[asyncio.Event],
+) -> None:
+    """Poll /bootstrap-status until the operator adopts.
+
+    Handles transient errors with local backoff.  If the pending row was
+    reaped (404), re-register and continue polling.
+    """
+    poll_count = 0
+    while True:
+        if poll_cancel_event is not None and poll_cancel_event.is_set():
+            raise BootstrapCancelledError("first-boot poll cancelled")
+        try:
+            status = await get_bootstrap_status_once(
+                session, cms_api_base, pubkey_b64=identity.pubkey_b64,
+            )
+            if status.is_adopted:
+                return
+        except PendingNotFoundError:
+            # Pending row was reaped by the CMS garbage collector.  Re-register.
+            logger.info("Pending row reaped — re-registering")
+            try:
+                await register_once(
+                    session,
+                    cms_api_base,
+                    device_id=device_id,
+                    pubkey_b64=identity.pubkey_b64,
+                    pairing_secret_hash=pairing_secret_hash_hex(pairing_secret),
+                    fleet_id=fleet_id,
+                    fleet_secret=fleet_secret,
+                    metadata=metadata,
+                )
+            except PubkeyMismatchError:
+                # Extremely unlikely (row just got reaped).  Give up and
+                # let the caller handle it.
+                raise
+            except (RateLimitedError, BootstrapTransportError, BootstrapServerError):
+                pass  # fall through to sleep
+        except RateLimitedError:
+            pass  # sleep below
+        except BootstrapTransportError:
+            pass  # sleep below
+        except BootstrapServerError as e:
+            # 400 / 500 — log and keep trying; the CMS may be restarting.
+            logger.warning("/bootstrap-status returned %s — retrying", e.status)
+
+        delay = (
+            FIRST_BOOT_POLL_SHORT_SEC
+            if poll_count < FIRST_BOOT_POLL_SHORT_COUNT
+            else FIRST_BOOT_POLL_LONG_SEC
+        )
+        poll_count += 1
+        # Cooperatively wait so external cancellers wake us.
+        if poll_cancel_event is not None:
+            try:
+                await asyncio.wait_for(poll_cancel_event.wait(), timeout=delay)
+            except asyncio.TimeoutError:
+                pass
+            else:
+                raise BootstrapCancelledError("first-boot poll cancelled")
+        else:
+            await asyncio.sleep(delay)
+
+
+async def refresh_wps_jwt(
+    session: Any,
+    *,
+    cms_api_base: str,
+    identity: DeviceIdentity,
+    state_path: Path,
+    device_id: Optional[str] = None,
+) -> BootstrapCredentials:
+    """Mint a fresh WPS JWT via signed ``/connect-token`` and persist it.
+
+    Used by the background renewal task.  Assumes the device is already
+    adopted; if it isn't, :class:`ConnectTokenRejectedError` (401) bubbles
+    out and the caller decides policy (retry with backoff, clear state
+    after repeated failures, etc.).
+
+    If ``device_id`` is omitted, the cached state's ``device_id`` is used.
+    If no cached state exists, this function raises ``LookupError`` — the
+    renewal task should never be reachable in that case.
+
+    :raises ConnectTokenRejectedError: CMS returned 401.  Terminal for
+        this JWT (do NOT retry with the same nonce), but the caller's
+        policy decides whether to clear state.
+    :raises RateLimitedError: CMS returned 429.
+    :raises BootstrapTransportError: network-layer failure.
+    """
+    cached = load_state(state_path)
+    effective_device_id = device_id
+    if effective_device_id is None:
+        if cached is None:
+            raise LookupError(
+                "refresh_wps_jwt called with no cached state and no device_id"
+            )
+        effective_device_id = str(cached.get("device_id") or "")
+        if not effective_device_id:
+            raise LookupError(
+                "cached bootstrap state has no device_id — cannot refresh"
+            )
+
+    token = await fetch_connect_token(
+        session,
+        cms_api_base,
+        device_id=effective_device_id,
+        seed=identity.seed,
+    )
+    state = _state_from_token(
+        cms_api_base=cms_api_base,
+        device_id=effective_device_id,
+        token=token,
+    )
+    save_state(state_path, state)
+    return BootstrapCredentials(
+        wps_url=token.wps_url,
+        wps_jwt=token.wps_jwt,
+        expires_at=token.expires_at,
+        device_id=effective_device_id,
+    )
+
+
+# Re-export common error types so callers don't need to know the
+# underlying module layout.
+__all__ = [
+    "BootstrapCancelledError",
+    "BootstrapConfigError",
+    "BootstrapCredentials",
+    "BootstrapServerError",
+    "BootstrapTransportError",
+    "ConnectTokenRejectedError",
+    "JWT_EARLY_REFRESH_SEC",
+    "PendingNotFoundError",
+    "PubkeyMismatchError",
+    "RateLimitedError",
+    "clear_state",
+    "ensure_identity",
+    "ensure_wps_credentials",
+    "load_state",
+    "refresh_wps_jwt",
+    "save_state",
+]

--- a/cms_client/bootstrap_client.py
+++ b/cms_client/bootstrap_client.py
@@ -325,8 +325,10 @@ async def fetch_connect_token(
     UTF-8 bytes, matching
     :func:`shared.bootstrap_identity.connect_token_canonical_bytes`.
 
-    :param device_id: CMS-assigned device UUID (as returned in the
-        decrypted bootstrap payload).
+    :param device_id: the device_id the CMS has recorded for this pubkey
+        (for agora, the Raspberry Pi CPU serial the device used at
+        ``/register``).  Must match ``Device.id`` on the CMS side, which
+        is pinned at adoption time.
     :param seed: raw 32-byte ed25519 seed.  Sensitive — never logged.
     :param timestamp: unix seconds.  Defaults to ``int(time.time())``.
     :param nonce: 32+ hex chars.  Defaults to ``secrets.token_hex(16)``.

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -35,6 +35,17 @@ logger = logging.getLogger("agora.cms_client")
 
 PROTOCOL_VERSION = 2
 
+# Bootstrap v2 renewal policy (issue #420 stage B.3).
+# Minimum delay between JWT refreshes on the renewal task, so a clock
+# skew or an early-expired JWT doesn't spin at full speed.
+JWT_REFRESH_MIN_INTERVAL = 30  # seconds
+# 401s from /connect-token can mean many things (bad sig, stale nonce,
+# clock skew, revoked pubkey).  Don't treat the first 401 as terminal.
+# Only clear adopted state after this many consecutive 401s.
+JWT_REFRESH_401_MAX = 3
+# Backoff after a non-success renewal attempt before retrying.
+JWT_REFRESH_RETRY_SEC = 60
+
 # Log request transport:
 # - Small payloads (<= LOGS_JSON_MAX_BYTES) ride the WS as a single
 #   ``logs_response`` JSON message (legacy path, unchanged).
@@ -278,6 +289,13 @@ class CMSClient:
         self._current_asset: str | None = None
         self._eval_wake = asyncio.Event()      # triggers immediate schedule re-eval
         self._last_player_mode: str | None = None
+        # Bootstrap v2 state (only populated when settings.bootstrap_v2 is true)
+        self._bootstrap_identity = None  # shared.bootstrap_identity.DeviceIdentity
+        self._bootstrap_pairing_secret: str | None = None
+        self._jwt_refresh_401_count: int = 0
+        # Per-connect cancel signal for first-boot polling; set by
+        # _config_watch_loop when cms_url changes or by stop().
+        self._bootstrap_poll_cancel: asyncio.Event | None = None
         self.asset_manager = AssetManager(
             manifest_path=settings.manifest_path,
             assets_dir=settings.assets_dir,
@@ -415,6 +433,10 @@ class CMSClient:
 
     async def stop(self) -> None:
         self._running = False
+        # Abort any in-flight bootstrap v2 first-boot poll.
+        cancel_ev = getattr(self, "_bootstrap_poll_cancel", None)
+        if cancel_ev is not None:
+            cancel_ev.set()
         if self._ws:
             await self._ws.close()
 
@@ -432,16 +454,97 @@ class CMSClient:
                     self._active_cms_url = new_url
                     # Clear auth token — the new CMS won't recognise it
                     _save_auth_token(self.settings.auth_token_path, "")
+                    # Bootstrap v2 cached WPS JWT was minted by the old
+                    # CMS (different signer/base); it's useless now.
+                    # Identity keypair stays — the pubkey is still ours.
+                    if self._bootstrap_v2_enabled():
+                        try:
+                            from cms_client import bootstrap_boot
+                            bootstrap_boot.clear_state(
+                                self.settings.bootstrap_state_path,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to clear bootstrap_state on CMS URL change",
+                                exc_info=True,
+                            )
                     self._write_cms_status(
                         "connecting",
                         message="CMS URL changed. Reconnecting\u2026",
                     )
+                    # Signal any in-flight bootstrap v2 first-boot poll to
+                    # abort — otherwise it keeps polling the old CMS for
+                    # minutes despite our URL change.
+                    cancel_ev = getattr(self, "_bootstrap_poll_cancel", None)
+                    if cancel_ev is not None:
+                        cancel_ev.set()
                     if self._ws:
                         await self._ws.close()
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.debug("Config watch error", exc_info=True)
+
+    def _bootstrap_v2_enabled(self) -> bool:
+        return bool(getattr(self.settings, "bootstrap_v2", False))
+
+    async def _mint_wps_credentials_v2(self, cms_url: str):
+        """Bootstrap v2: obtain (pre_minted_url, pre_minted_token) via HTTPS.
+
+        Returns the :class:`BootstrapCredentials` and the
+        ``aiohttp.ClientSession`` used to obtain them (the session is
+        kept open for later renewal calls; caller is responsible for
+        closing it).
+        """
+        import aiohttp
+        from cms_client import bootstrap_boot
+
+        # Lazy-load identity so this runs only when the flag is on.
+        if self._bootstrap_identity is None or self._bootstrap_pairing_secret is None:
+            identity, secret = bootstrap_boot.ensure_identity(
+                device_key_path=self.settings.device_key_path,
+                pairing_secret_path=self.settings.pairing_secret_path,
+            )
+            self._bootstrap_identity = identity
+            self._bootstrap_pairing_secret = secret
+
+        api_base = (
+            getattr(self.settings, "cms_api_url", "") or _derive_api_base(cms_url)
+        )
+
+        fleet_secret_hex = getattr(self.settings, "fleet_secret_hex", "") or ""
+        try:
+            fleet_secret = bytes.fromhex(fleet_secret_hex) if fleet_secret_hex else b""
+        except ValueError as e:
+            raise TransportError(
+                f"AGORA_FLEET_SECRET_HEX is not valid hex: {e}"
+            ) from e
+        fleet_id = getattr(self.settings, "fleet_id", "") or ""
+
+        metadata = {
+            "firmware_version": self._get_version(),
+            "device_type": _get_device_type(),
+            "device_name": self.settings.device_name,
+        }
+
+        session = aiohttp.ClientSession()
+        try:
+            creds = await bootstrap_boot.ensure_wps_credentials(
+                session,
+                cms_api_base=api_base,
+                device_id=self.device_id,
+                identity=self._bootstrap_identity,
+                pairing_secret=self._bootstrap_pairing_secret,
+                state_path=self.settings.bootstrap_state_path,
+                fleet_id=fleet_id,
+                fleet_secret=fleet_secret,
+                metadata=metadata,
+                poll_cancel_event=self._bootstrap_poll_cancel,
+            )
+        except Exception:
+            await session.close()
+            raise
+        return creds, session, api_base
 
     async def _connect_and_run(self) -> None:
         """Single connection lifecycle: connect → register → message loop."""
@@ -453,7 +556,32 @@ class CMSClient:
         )
 
         api_key = ""
-        if transport_mode == "wps":
+        pre_minted_url = ""
+        pre_minted_token = ""
+        pre_minted_expires_at = ""
+        http_session = None
+        bootstrap_api_base = ""
+
+        bootstrap_v2 = self._bootstrap_v2_enabled() and transport_mode == "wps"
+
+        if bootstrap_v2:
+            logger.info("Bootstrap v2 enabled — obtaining WPS JWT via HTTPS")
+            # Fresh cancel event per connect attempt — allows
+            # _config_watch_loop and stop() to interrupt slow first-boot
+            # polling when cms_url changes or shutdown is requested.
+            self._bootstrap_poll_cancel = asyncio.Event()
+            try:
+                creds, http_session, bootstrap_api_base = (
+                    await self._mint_wps_credentials_v2(cms_url)
+                )
+            except Exception as e:
+                # Map orchestration errors into TransportError so the outer
+                # reconnect loop backs off uniformly.
+                raise TransportError(f"bootstrap v2 failed: {e!r}") from e
+            pre_minted_url = creds.wps_url
+            pre_minted_token = creds.wps_jwt
+            pre_minted_expires_at = creds.expires_at
+        elif transport_mode == "wps":
             api_key = _resolve_device_api_key(self.settings)
             if not api_key:
                 raise TransportError(
@@ -461,13 +589,20 @@ class CMSClient:
                     "or a populated <persist_dir>/api_key file"
                 )
 
-        transport = await open_transport(
-            mode=transport_mode,
-            cms_url=cms_url,
-            device_id=self.device_id,
-            api_key=api_key,
-            api_base=getattr(self.settings, "cms_api_url", "") or None,
-        )
+        try:
+            transport = await open_transport(
+                mode=transport_mode,
+                cms_url=cms_url,
+                device_id=self.device_id,
+                api_key=api_key,
+                api_base=getattr(self.settings, "cms_api_url", "") or None,
+                pre_minted_url=pre_minted_url,
+                pre_minted_token=pre_minted_token,
+            )
+        except Exception:
+            if http_session is not None:
+                await http_session.close()
+            raise
 
         async with transport as ws:
             self._ws = ws
@@ -501,6 +636,14 @@ class CMSClient:
             logger.info("Sent register message (device_id=%s)", self.device_id)
 
             status_task = asyncio.create_task(self._status_loop(ws))
+            renewal_task: asyncio.Task | None = None
+            if bootstrap_v2:
+                renewal_task = asyncio.create_task(
+                    self._jwt_renewal_loop(
+                        ws, http_session, bootstrap_api_base,
+                        pre_minted_expires_at,
+                    )
+                )
 
             try:
                 async for raw in ws:
@@ -569,6 +712,125 @@ class CMSClient:
                     await status_task
                 except asyncio.CancelledError:
                     pass
+                if renewal_task is not None:
+                    renewal_task.cancel()
+                    try:
+                        await renewal_task
+                    except asyncio.CancelledError:
+                        pass
+                if http_session is not None:
+                    await http_session.close()
+
+    async def _jwt_renewal_loop(
+        self, ws, session, api_base: str, expires_at: str,
+    ) -> None:
+        """Background: refresh the WPS JWT before it expires, then reconnect.
+
+        Policy:
+
+        * Sleep until ``expires_at - jwt_refresh_lead_seconds``.
+        * On success: persist new state, close ``ws`` to force a
+          reconnect in the outer loop (which will read the new state).
+        * On :class:`ConnectTokenRejectedError` (401): do NOT clear
+          adopted state on the first hit — this often means clock skew,
+          replayed nonce, or a transient CMS glitch.  Only clear after
+          :data:`JWT_REFRESH_401_MAX` consecutive 401s.
+        * On 429 / transport error: back off and retry.
+        """
+        from cms_client import bootstrap_boot
+
+        try:
+            from datetime import timedelta
+            lead = int(getattr(self.settings, "jwt_refresh_lead_seconds", 600) or 600)
+            current_expires_at = expires_at
+            while self._running:
+                expires_dt = bootstrap_boot._parse_expires_at(current_expires_at)
+                if expires_dt is None:
+                    logger.warning(
+                        "JWT expires_at unparseable (%r) — skipping renewal",
+                        current_expires_at,
+                    )
+                    return
+                now_dt = datetime.now(timezone.utc)
+                sleep_seconds = (
+                    expires_dt - now_dt - timedelta(seconds=lead)
+                ).total_seconds()
+                if sleep_seconds < JWT_REFRESH_MIN_INTERVAL:
+                    sleep_seconds = JWT_REFRESH_MIN_INTERVAL
+                logger.debug("JWT renewal sleeping %.0fs", sleep_seconds)
+                await asyncio.sleep(sleep_seconds)
+
+                try:
+                    new_creds = await bootstrap_boot.refresh_wps_jwt(
+                        session,
+                        cms_api_base=api_base,
+                        identity=self._bootstrap_identity,
+                        state_path=self.settings.bootstrap_state_path,
+                    )
+                except bootstrap_boot.ConnectTokenRejectedError:
+                    self._jwt_refresh_401_count += 1
+                    logger.warning(
+                        "WPS JWT refresh rejected (401) — consecutive=%d",
+                        self._jwt_refresh_401_count,
+                    )
+                    if self._jwt_refresh_401_count >= JWT_REFRESH_401_MAX:
+                        logger.error(
+                            "Giving up on current adopted state after %d "
+                            "consecutive 401s — rotating identity to force "
+                            "true first-boot re-registration",
+                            self._jwt_refresh_401_count,
+                        )
+                        # Rotate everything: JWT state, identity keypair,
+                        # pairing secret, and auth token. Keeping the old
+                        # pubkey would leave us re-registering with a key
+                        # the CMS may have already revoked.
+                        bootstrap_boot.clear_state(
+                            self.settings.bootstrap_state_path,
+                        )
+                        for p in (
+                            self.settings.device_key_path,
+                            self.settings.pairing_secret_path,
+                            self.settings.auth_token_path,
+                        ):
+                            try:
+                                p.unlink()
+                            except FileNotFoundError:
+                                pass
+                            except Exception:
+                                logger.debug(
+                                    "Failed to unlink %s on terminal 401", p,
+                                    exc_info=True,
+                                )
+                        self._bootstrap_identity = None
+                        self._bootstrap_pairing_secret = None
+                        await ws.close()
+                        return
+                    await asyncio.sleep(JWT_REFRESH_RETRY_SEC)
+                    continue
+                except bootstrap_boot.RateLimitedError:
+                    logger.info("WPS JWT refresh rate-limited — backing off")
+                    await asyncio.sleep(JWT_REFRESH_RETRY_SEC)
+                    continue
+                except bootstrap_boot.BootstrapTransportError as e:
+                    logger.warning("WPS JWT refresh transport error: %r", e)
+                    await asyncio.sleep(JWT_REFRESH_RETRY_SEC)
+                    continue
+                except Exception:
+                    logger.exception("Unexpected error refreshing WPS JWT")
+                    await asyncio.sleep(JWT_REFRESH_RETRY_SEC)
+                    continue
+
+                self._jwt_refresh_401_count = 0
+                logger.info(
+                    "WPS JWT refreshed — forcing reconnect to pick up new token"
+                )
+                try:
+                    await ws.close()
+                except Exception:
+                    pass
+                return
+        except asyncio.CancelledError:
+            raise
 
     async def _send_status(self) -> None:
         """Build and send a single status heartbeat."""
@@ -1420,6 +1682,12 @@ class CMSClient:
         _safe_unlink(persist_dir / "device_name")
         _safe_unlink(persist_dir / "api_key")
         _safe_unlink(persist_dir / "local_api_enabled")
+
+        # Bootstrap v2 identity + cached credentials.  These are safe to
+        # always remove — on non-v2 builds the paths just don't exist.
+        _safe_unlink(persist_dir / "device_key")
+        _safe_unlink(persist_dir / "pairing_secret")
+        _safe_unlink(persist_dir / "bootstrap_state.json")
 
         # Remove state files
         _safe_unlink(state_dir / "cms_status.json")

--- a/cms_client/transport.py
+++ b/cms_client/transport.py
@@ -202,21 +202,37 @@ async def open_wps(
     *,
     cms_url: str,
     device_id: str,
-    api_key: str,
+    api_key: str = "",
     api_base: Optional[str] = None,
+    pre_minted_url: str = "",
+    pre_minted_token: str = "",
 ) -> WPSTransport:
     """Bootstrap a WPS transport.
 
-    Steps:
-      1. Derive HTTP(S) API base from ``cms_url`` (or use override).
-      2. POST /api/devices/{device_id}/connect-token with X-Device-API-Key.
-      3. Open a websocket to the returned URL using the WPS subprotocol.
-      4. Return a WPSTransport wrapping the socket.
+    Two modes:
+
+    * Legacy (``api_key`` path): derives the API base from ``cms_url``,
+      POSTs to ``/api/devices/{id}/connect-token`` with
+      ``X-Device-API-Key``, joins the returned ``access_token`` into the
+      URL, opens the websocket.
+    * Bootstrap v2 (``pre_minted_url`` + ``pre_minted_token``): skips the
+      api-key-based mint step; caller has already obtained the WPS URL
+      and JWT (via the new ``/api/devices/connect-token`` signed flow).
+      The ``access_token`` query param is joined in the same way.
+
+    At least one of ``api_key`` or (``pre_minted_url`` + ``pre_minted_token``)
+    must be provided.
     """
-    if not api_key:
-        raise TransportError("WPS transport requires a device_api_key")
-    base = api_base or _derive_api_base(cms_url)
-    wss_url, access_token = await _request_connect_token(base, device_id, api_key)
+    if pre_minted_url and pre_minted_token:
+        wss_url, access_token = pre_minted_url, pre_minted_token
+    else:
+        if not api_key:
+            raise TransportError(
+                "WPS transport requires a device_api_key or a pre-minted "
+                "(wps_url, wps_jwt) pair"
+            )
+        base = api_base or _derive_api_base(cms_url)
+        wss_url, access_token = await _request_connect_token(base, device_id, api_key)
     if access_token and "access_token=" not in wss_url:
         joiner = "&" if "?" in wss_url else "?"
         wss_url = f"{wss_url}{joiner}access_token={access_token}"
@@ -237,6 +253,8 @@ async def open_transport(
     device_id: str,
     api_key: str = "",
     api_base: Optional[str] = None,
+    pre_minted_url: str = "",
+    pre_minted_token: str = "",
 ) -> _Transport:
     """Factory: open the transport matching ``mode`` ("direct" or "wps")."""
     m = (mode or "direct").lower().strip()
@@ -248,5 +266,7 @@ async def open_transport(
             device_id=device_id,
             api_key=api_key,
             api_base=api_base,
+            pre_minted_url=pre_minted_url,
+            pre_minted_token=pre_minted_token,
         )
     raise TransportError(f"Unknown transport mode {mode!r} (expected 'direct' or 'wps')")

--- a/tests/test_bootstrap_boot.py
+++ b/tests/test_bootstrap_boot.py
@@ -1,0 +1,579 @@
+"""Unit tests for :mod:`cms_client.bootstrap_boot`.
+
+Stage B.3 of the bootstrap redesign (issue #420).  The orchestration
+layer is exercised offline by monkeypatching the three
+``bootstrap_client`` HTTP primitives (``register_once``,
+``get_bootstrap_status_once``, ``fetch_connect_token``) so no real
+network / ``aiohttp`` is involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+# ``shared.bootstrap_identity.load_or_create_device_identity`` uses
+# ``os.O_NOFOLLOW`` which doesn't exist on Windows.  CI runs on Linux;
+# on Windows we skip the identity-dependent classes below but still
+# exercise the pure state helpers.
+_POSIX = sys.platform != "win32"
+posix_only = pytest.mark.skipif(
+    not _POSIX,
+    reason="bootstrap identity primitives are POSIX-only (fd-based invariants)",
+)
+
+from cms_client import bootstrap_boot
+from cms_client.bootstrap_client import (
+    BootstrapTransportError,
+    ConnectTokenRejectedError,
+    ConnectTokenResult,
+    PendingNotFoundError,
+    BootstrapStatus,
+)
+from shared.bootstrap_identity import (
+    load_or_create_device_identity,
+    load_or_create_pairing_secret,
+)
+
+
+# --------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_persist(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def identity(tmp_persist: Path):
+    return load_or_create_device_identity(tmp_persist / "device_key")
+
+
+@pytest.fixture
+def pairing_secret(tmp_persist: Path) -> str:
+    return load_or_create_pairing_secret(tmp_persist / "pairing_secret")
+
+
+def _rfc3339(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _fresh_token(minutes: int = 60) -> ConnectTokenResult:
+    return ConnectTokenResult(
+        wps_url="wss://wps.example.com/agent",
+        wps_jwt="jwt-abc",
+        expires_at=_rfc3339(datetime.now(timezone.utc) + timedelta(minutes=minutes)),
+    )
+
+
+# --------------------------------------------------------------------
+# State helpers
+# --------------------------------------------------------------------
+
+
+class TestState:
+    def test_save_load_roundtrip(self, tmp_path):
+        p = tmp_path / "s.json"
+        data = {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-serial-xyz",
+            "wps_url": "wss://wps/x",
+            "wps_jwt": "jwt",
+            "expires_at": _rfc3339(datetime.now(timezone.utc) + timedelta(hours=1)),
+        }
+        bootstrap_boot.save_state(p, data)
+        assert bootstrap_boot.load_state(p) == data
+
+    def test_save_state_is_atomic_no_partial_file(self, tmp_path, monkeypatch):
+        """If the rename is interrupted, the on-disk file stays intact."""
+        p = tmp_path / "s.json"
+        bootstrap_boot.save_state(p, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://a", "device_id": "d",
+            "wps_url": "w", "wps_jwt": "j",
+            "expires_at": _rfc3339(datetime.now(timezone.utc) + timedelta(hours=1)),
+        })
+        good = p.read_text()
+
+        real_replace = os.replace
+        def boom(*a, **kw):
+            raise OSError("disk full")
+        monkeypatch.setattr(bootstrap_boot.os, "replace", boom)
+        with pytest.raises(OSError):
+            bootstrap_boot.save_state(p, {
+                "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+                "cms_api_base": "https://b", "device_id": "d2",
+                "wps_url": "w2", "wps_jwt": "j2", "expires_at": "x",
+            })
+        # Original file unchanged.
+        assert p.read_text() == good
+        # No stray temp files.
+        leftover = [x for x in tmp_path.iterdir()
+                    if x.name.startswith(".bootstrap_state.")]
+        assert leftover == [], leftover
+
+    def test_load_ignores_unknown_schema(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text(json.dumps({"schema_version": 99, "anything": 1}))
+        assert bootstrap_boot.load_state(p) is None
+
+    def test_load_ignores_corrupt_json(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text("not json at all{")
+        assert bootstrap_boot.load_state(p) is None
+
+    def test_clear_state_missing_is_ok(self, tmp_path):
+        bootstrap_boot.clear_state(tmp_path / "missing.json")  # no exception
+
+    def test_clear_state_deletes_existing(self, tmp_path):
+        p = tmp_path / "s.json"
+        p.write_text("x")
+        bootstrap_boot.clear_state(p)
+        assert not p.exists()
+
+
+class TestParseExpiresAt:
+    def test_z_suffix(self):
+        dt = bootstrap_boot._parse_expires_at("2026-01-01T00:00:00Z")
+        assert dt is not None
+        assert dt.tzinfo is not None
+
+    def test_offset(self):
+        dt = bootstrap_boot._parse_expires_at("2026-01-01T00:00:00+00:00")
+        assert dt is not None
+
+    def test_naive_treated_as_utc(self):
+        dt = bootstrap_boot._parse_expires_at("2026-01-01T00:00:00")
+        assert dt is not None
+        assert dt.tzinfo is timezone.utc
+
+    def test_empty(self):
+        assert bootstrap_boot._parse_expires_at("") is None
+
+    def test_garbage(self):
+        assert bootstrap_boot._parse_expires_at("nope") is None
+
+
+class TestIsStateFresh:
+    def _state(self, *, base="https://cms.example.com", expires):
+        return {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": base, "device_id": "d",
+            "wps_url": "w", "wps_jwt": "j",
+            "expires_at": expires,
+        }
+
+    def test_fresh_returns_true(self):
+        exp = _rfc3339(datetime.now(timezone.utc) + timedelta(hours=1))
+        assert bootstrap_boot._is_state_fresh(
+            self._state(expires=exp),
+            "https://cms.example.com",
+            time.time(),
+        ) is True
+
+    def test_different_cms_base_is_stale(self):
+        exp = _rfc3339(datetime.now(timezone.utc) + timedelta(hours=1))
+        assert bootstrap_boot._is_state_fresh(
+            self._state(base="https://old.example.com", expires=exp),
+            "https://cms.example.com",
+            time.time(),
+        ) is False
+
+    def test_within_early_refresh_window_is_stale(self):
+        # Expires in JWT_EARLY_REFRESH_SEC - 1 seconds → stale.
+        exp = _rfc3339(
+            datetime.now(timezone.utc)
+            + timedelta(seconds=bootstrap_boot.JWT_EARLY_REFRESH_SEC - 1)
+        )
+        assert bootstrap_boot._is_state_fresh(
+            self._state(expires=exp),
+            "https://cms.example.com",
+            time.time(),
+        ) is False
+
+    def test_garbage_expires_is_stale(self):
+        assert bootstrap_boot._is_state_fresh(
+            self._state(expires="nope"),
+            "https://cms.example.com",
+            time.time(),
+        ) is False
+
+
+# --------------------------------------------------------------------
+# ensure_wps_credentials — three branches
+# --------------------------------------------------------------------
+
+
+class TestEnsureWpsCredentialsFresh:
+    """Branch 1: cached state is fresh — no HTTP calls."""
+
+    pytestmark = posix_only
+
+    @pytest.mark.asyncio
+    async def test_returns_cached(self, tmp_path, identity, pairing_secret, monkeypatch):
+        state_path = tmp_path / "bootstrap_state.json"
+        exp = _rfc3339(datetime.now(timezone.utc) + timedelta(hours=2))
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-1234",
+            "wps_url": "wss://wps/x",
+            "wps_jwt": "cached-jwt",
+            "expires_at": exp,
+        })
+
+        # Any HTTP primitive being called would be a bug on the fast path.
+        called = {"n": 0}
+        async def boom(*a, **kw):
+            called["n"] += 1
+            raise AssertionError("HTTP primitive invoked on fresh-cache path")
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", boom)
+        monkeypatch.setattr(bootstrap_boot, "register_once", boom)
+        monkeypatch.setattr(bootstrap_boot, "get_bootstrap_status_once", boom)
+
+        creds = await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-1234",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=state_path,
+            fleet_id="",  # empty OK — we're on the fast path
+            fleet_secret=b"",
+            metadata=None,
+        )
+        assert creds.wps_jwt == "cached-jwt"
+        assert creds.device_id == "pi-1234"
+        assert called["n"] == 0
+
+
+class TestEnsureWpsCredentialsStaleRefresh:
+    """Branch 2: cached state matches CMS but JWT stale — signed refresh."""
+
+    pytestmark = posix_only
+
+    @pytest.mark.asyncio
+    async def test_signed_refresh_persists_new_state(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        state_path = tmp_path / "bootstrap_state.json"
+        stale_exp = _rfc3339(datetime.now(timezone.utc) + timedelta(seconds=10))
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-1234",
+            "wps_url": "wss://old", "wps_jwt": "old",
+            "expires_at": stale_exp,
+        })
+
+        new_token = _fresh_token(minutes=55)
+        captured = {}
+        async def fake_fetch(session, base, *, device_id, seed):
+            captured["base"] = base
+            captured["device_id"] = device_id
+            return new_token
+        async def no_register(*a, **kw):
+            raise AssertionError("register_once should not be called")
+        async def no_status(*a, **kw):
+            raise AssertionError("get_bootstrap_status_once should not be called")
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+        monkeypatch.setattr(bootstrap_boot, "register_once", no_register)
+        monkeypatch.setattr(bootstrap_boot, "get_bootstrap_status_once", no_status)
+
+        creds = await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-DIFFERENT",  # should be overridden by cached device_id
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=state_path,
+            fleet_id="",
+            fleet_secret=b"",
+        )
+        assert creds.wps_jwt == new_token.wps_jwt
+        assert captured["device_id"] == "pi-1234"  # cached wins
+        assert captured["base"] == "https://cms.example.com"
+
+        # State persisted with new token.
+        reloaded = bootstrap_boot.load_state(state_path)
+        assert reloaded is not None
+        assert reloaded["wps_jwt"] == new_token.wps_jwt
+        assert reloaded["device_id"] == "pi-1234"
+
+
+class TestEnsureWpsCredentialsFirstBoot:
+    """Branch 3: no cached state — register, poll, decrypt, connect."""
+
+    pytestmark = posix_only
+
+    @pytest.mark.asyncio
+    async def test_requires_fleet_credentials(
+        self, tmp_path, identity, pairing_secret,
+    ):
+        with pytest.raises(bootstrap_boot.BootstrapConfigError):
+            await bootstrap_boot.ensure_wps_credentials(
+                session=object(),
+                cms_api_base="https://cms.example.com",
+                device_id="pi-1234",
+                identity=identity,
+                pairing_secret=pairing_secret,
+                state_path=tmp_path / "bootstrap_state.json",
+                fleet_id="",
+                fleet_secret=b"",  # missing → error
+            )
+
+    @pytest.mark.asyncio
+    async def test_first_boot_happy_path(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        # We don't have a CMS-side encrypt helper handy, so bypass the
+        # decrypt primitive directly.
+        monkeypatch.setattr(
+            bootstrap_boot, "decrypt_adopt_payload",
+            lambda seed, payload_b64: json.dumps({"device_id": "pi-9999"}).encode("utf-8"),
+        )
+
+        reg_calls = {"n": 0}
+        async def fake_register(session, base, **kw):
+            reg_calls["n"] += 1
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+
+        # Two status polls: first pending, then adopted.
+        status_calls = {"n": 0}
+        async def fake_status(session, base, *, pubkey_b64):
+            status_calls["n"] += 1
+            if status_calls["n"] == 1:
+                return BootstrapStatus(status="pending", payload_b64=None)
+            return BootstrapStatus(status="adopted", payload_b64="ignored-by-mock")
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", fake_status,
+        )
+
+        new_token = _fresh_token(60)
+        fetch_calls = {"device_id": None}
+        async def fake_fetch(session, base, *, device_id, seed):
+            fetch_calls["device_id"] = device_id
+            return new_token
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+
+        # Short-circuit the poll sleep.
+        async def no_sleep(*a, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot.asyncio, "sleep", no_sleep)
+
+        state_path = tmp_path / "bootstrap_state.json"
+        creds = await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-initial",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=state_path,
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+            metadata={"firmware_version": "1.0.0"},
+        )
+        assert reg_calls["n"] == 1
+        assert status_calls["n"] == 3  # pending + adopted in poll loop, then fetch-payload
+        assert fetch_calls["device_id"] == "pi-9999"  # from decrypted outbox
+        assert creds.device_id == "pi-9999"
+        assert creds.wps_jwt == new_token.wps_jwt
+
+        reloaded = bootstrap_boot.load_state(state_path)
+        assert reloaded["device_id"] == "pi-9999"
+        assert reloaded["cms_api_base"] == "https://cms.example.com"
+
+    @pytest.mark.asyncio
+    async def test_first_boot_404_reregisters(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        """If /bootstrap-status returns 404 (row reaped), we re-register."""
+        monkeypatch.setattr(
+            bootstrap_boot, "decrypt_adopt_payload",
+            lambda seed, payload_b64: b'{"device_id": "pi-xyz"}',
+        )
+
+        reg_calls = {"n": 0}
+        async def fake_register(session, base, **kw):
+            reg_calls["n"] += 1
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+
+        call_seq = {"n": 0}
+        async def fake_status(session, base, *, pubkey_b64):
+            call_seq["n"] += 1
+            if call_seq["n"] == 1:
+                raise PendingNotFoundError(404, "reaped")
+            # After re-register, next poll shows adopted.
+            return BootstrapStatus(status="adopted", payload_b64="x")
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", fake_status,
+        )
+
+        async def fake_fetch(session, base, *, device_id, seed):
+            return _fresh_token(60)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+
+        async def no_sleep(*a, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot.asyncio, "sleep", no_sleep)
+
+        await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-abc",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=tmp_path / "s.json",
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+        )
+        # Initial + re-register after 404.
+        assert reg_calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_first_boot_cancel_event(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        async def fake_register(session, base, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+
+        async def always_pending(session, base, *, pubkey_b64):
+            return BootstrapStatus(status="pending", payload_b64=None)
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", always_pending,
+        )
+
+        cancel = asyncio.Event()
+        cancel.set()  # cancel before first poll
+
+        with pytest.raises(bootstrap_boot.BootstrapCancelledError):
+            await bootstrap_boot.ensure_wps_credentials(
+                session=object(),
+                cms_api_base="https://cms.example.com",
+                device_id="pi-abc",
+                identity=identity,
+                pairing_secret=pairing_secret,
+                state_path=tmp_path / "s.json",
+                fleet_id="fleet-A",
+                fleet_secret=b"\x00" * 32,
+                poll_cancel_event=cancel,
+            )
+
+
+# --------------------------------------------------------------------
+# refresh_wps_jwt
+# --------------------------------------------------------------------
+
+
+class TestRefreshWpsJwt:
+    pytestmark = posix_only
+
+    @pytest.mark.asyncio
+    async def test_refresh_uses_cached_device_id(
+        self, tmp_path, identity, monkeypatch,
+    ):
+        state_path = tmp_path / "s.json"
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-cached",
+            "wps_url": "w", "wps_jwt": "old-jwt",
+            "expires_at": _rfc3339(datetime.now(timezone.utc) + timedelta(seconds=5)),
+        })
+
+        captured = {}
+        async def fake_fetch(session, base, *, device_id, seed):
+            captured["device_id"] = device_id
+            return _fresh_token(60)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+
+        creds = await bootstrap_boot.refresh_wps_jwt(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            identity=identity,
+            state_path=state_path,
+        )
+        assert captured["device_id"] == "pi-cached"
+        assert creds.device_id == "pi-cached"
+        reloaded = bootstrap_boot.load_state(state_path)
+        assert reloaded["wps_jwt"] == creds.wps_jwt
+
+    @pytest.mark.asyncio
+    async def test_refresh_401_bubbles_up(
+        self, tmp_path, identity, monkeypatch,
+    ):
+        state_path = tmp_path / "s.json"
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-cached",
+            "wps_url": "w", "wps_jwt": "j",
+            "expires_at": _rfc3339(datetime.now(timezone.utc) + timedelta(seconds=5)),
+        })
+        async def fake_fetch(session, base, *, device_id, seed):
+            raise ConnectTokenRejectedError(401, "nope")
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+
+        with pytest.raises(ConnectTokenRejectedError):
+            await bootstrap_boot.refresh_wps_jwt(
+                session=object(),
+                cms_api_base="https://cms.example.com",
+                identity=identity,
+                state_path=state_path,
+            )
+        # State file NOT cleared — policy decision lives in the caller.
+        assert state_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_refresh_no_state_no_device_id_raises(
+        self, tmp_path, identity,
+    ):
+        with pytest.raises(LookupError):
+            await bootstrap_boot.refresh_wps_jwt(
+                session=object(),
+                cms_api_base="https://cms.example.com",
+                identity=identity,
+                state_path=tmp_path / "missing.json",
+            )
+
+
+# --------------------------------------------------------------------
+# ensure_identity
+# --------------------------------------------------------------------
+
+
+class TestEnsureIdentity:
+    pytestmark = posix_only
+
+    def test_generates_keys_on_first_call(self, tmp_path):
+        ident, secret = bootstrap_boot.ensure_identity(
+            device_key_path=tmp_path / "device_key",
+            pairing_secret_path=tmp_path / "pairing_secret",
+        )
+        assert (tmp_path / "device_key").exists()
+        assert (tmp_path / "pairing_secret").exists()
+        assert ident.pubkey_b64
+        assert secret
+
+    def test_second_call_is_stable(self, tmp_path):
+        ident1, sec1 = bootstrap_boot.ensure_identity(
+            device_key_path=tmp_path / "device_key",
+            pairing_secret_path=tmp_path / "pairing_secret",
+        )
+        ident2, sec2 = bootstrap_boot.ensure_identity(
+            device_key_path=tmp_path / "device_key",
+            pairing_secret_path=tmp_path / "pairing_secret",
+        )
+        assert ident1.pubkey_b64 == ident2.pubkey_b64
+        assert sec1 == sec2

--- a/tests/test_bootstrap_v2_service.py
+++ b/tests/test_bootstrap_v2_service.py
@@ -1,0 +1,272 @@
+"""Service-level tests for the bootstrap v2 wire-up in CMSClient.
+
+These tests verify the `_connect_and_run` path selected when
+``settings.bootstrap_v2`` is true and ``cms_transport == "wps"``:
+
+* ``_mint_wps_credentials_v2`` is invoked (instead of the legacy
+  api-key path) and its returned (url, jwt) tuple is threaded to
+  ``open_transport`` as ``pre_minted_url`` / ``pre_minted_token``.
+* The ``http_session`` returned alongside the creds is closed in
+  the ``finally`` block, even if ``open_transport`` raises.
+* When the flag is off, the legacy api-key path is used unchanged.
+
+The tests stub out the websocket handshake + inner message loop
+so only the bootstrap-selection branch executes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock heavy deps before importing the service module.
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("websockets.asyncio", MagicMock())
+sys.modules.setdefault("websockets.asyncio.client", MagicMock())
+sys.modules.setdefault("aiohttp", MagicMock())
+
+from cms_client.service import CMSClient  # noqa: E402
+from cms_client.transport import TransportError  # noqa: E402
+
+
+def _make_client(tmp_path, *, bootstrap_v2: bool, transport: str = "wps"):
+    """Construct a minimally-initialized CMSClient for wire-up tests."""
+    settings = MagicMock()
+    settings.agora_base = tmp_path
+    settings.assets_dir = tmp_path / "assets"
+    settings.assets_dir.mkdir()
+    settings.videos_dir = tmp_path / "assets" / "videos"
+    settings.videos_dir.mkdir()
+    settings.images_dir = tmp_path / "assets" / "images"
+    settings.images_dir.mkdir()
+    settings.splash_dir = tmp_path / "assets" / "splash"
+    settings.splash_dir.mkdir()
+    settings.manifest_path = tmp_path / "state" / "assets.json"
+    settings.manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    settings.schedule_path = tmp_path / "state" / "schedule.json"
+    settings.desired_state_path = tmp_path / "state" / "desired.json"
+    settings.asset_budget_mb = 100
+    settings.cms_status_path = tmp_path / "state" / "cms_status.json"
+    settings.cms_transport = transport
+    settings.bootstrap_v2 = bootstrap_v2
+    settings.cms_api_url = "https://cms.example.com"
+    settings.device_name = "test-device"
+    settings.fleet_id = "fleet-01"
+    settings.fleet_secret_hex = "00" * 32
+    settings.jwt_refresh_lead_seconds = 60
+    settings.auth_token_path = tmp_path / "state" / "auth_token"
+    settings.device_key_path = tmp_path / "state" / "device_key"
+    settings.pairing_secret_path = tmp_path / "state" / "pairing_secret"
+    settings.bootstrap_state_path = tmp_path / "state" / "bootstrap_state.json"
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        client = CMSClient(settings)
+    client.settings = settings
+    client.device_id = "pi-01"
+    client._ws = None
+    client._bootstrap_identity = None
+    client._bootstrap_pairing_secret = None
+    client._jwt_refresh_401_count = 0
+    client._bootstrap_poll_cancel = None
+    client._get_cms_url = lambda: "wss://cms.example.com/ws/device"
+    client._active_cms_url = None
+    client._write_cms_status = MagicMock()
+    return client
+
+
+class TestBootstrapV2Enabled:
+    def test_flag_off_by_default(self, tmp_path):
+        c = _make_client(tmp_path, bootstrap_v2=False)
+        assert c._bootstrap_v2_enabled() is False
+
+    def test_flag_on(self, tmp_path):
+        c = _make_client(tmp_path, bootstrap_v2=True)
+        assert c._bootstrap_v2_enabled() is True
+
+
+class TestMintWpsCredentialsV2:
+    @pytest.mark.asyncio
+    async def test_returns_creds_session_and_api_base(self, tmp_path):
+        """Happy path: ensure_identity + ensure_wps_credentials are called,
+        session is returned alive for the renewal task."""
+        c = _make_client(tmp_path, bootstrap_v2=True)
+
+        fake_identity = MagicMock()
+        fake_secret = b"pair-secret-bytes"
+        fake_creds = MagicMock()
+        fake_creds.wps_url = "wss://wps.example.com/client"
+        fake_creds.wps_jwt = "jwt-abc"
+        fake_creds.expires_at = "2026-01-01T00:00:00Z"
+
+        import aiohttp as aiohttp_mod  # the MagicMock stub from sys.modules
+
+        with patch("cms_client.bootstrap_boot.ensure_identity") as ensure_identity, \
+             patch("cms_client.bootstrap_boot.ensure_wps_credentials", new=AsyncMock(return_value=fake_creds)) as ensure_wps:
+            ensure_identity.return_value = (fake_identity, fake_secret)
+
+            fake_session = MagicMock()
+            fake_session.close = AsyncMock()
+            aiohttp_mod.ClientSession = MagicMock(return_value=fake_session)
+
+            creds, session, api_base = await c._mint_wps_credentials_v2(
+                "wss://cms.example.com/ws/device"
+            )
+
+        assert creds is fake_creds
+        assert session is fake_session
+        assert api_base == "https://cms.example.com"
+        fake_session.close.assert_not_called()
+        ensure_identity.assert_called_once()
+        ensure_wps.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_bad_fleet_secret_hex_raises_transport_error(self, tmp_path):
+        c = _make_client(tmp_path, bootstrap_v2=True)
+        c.settings.fleet_secret_hex = "not-hex!!"
+
+        with patch("cms_client.bootstrap_boot.ensure_identity") as ensure_identity:
+            ensure_identity.return_value = (MagicMock(), b"")
+
+            with pytest.raises(TransportError, match="not valid hex"):
+                await c._mint_wps_credentials_v2(
+                    "wss://cms.example.com/ws/device"
+                )
+
+    @pytest.mark.asyncio
+    async def test_mint_failure_closes_session(self, tmp_path):
+        """If ensure_wps_credentials raises, the http_session must be closed
+        so we don't leak an aiohttp ClientSession on every failed reconnect."""
+        c = _make_client(tmp_path, bootstrap_v2=True)
+
+        import aiohttp as aiohttp_mod
+
+        with patch("cms_client.bootstrap_boot.ensure_identity") as ensure_identity, \
+             patch(
+                 "cms_client.bootstrap_boot.ensure_wps_credentials",
+                 new=AsyncMock(side_effect=RuntimeError("mint exploded")),
+             ):
+            ensure_identity.return_value = (MagicMock(), b"secret")
+            fake_session = MagicMock()
+            fake_session.close = AsyncMock()
+            aiohttp_mod.ClientSession = MagicMock(return_value=fake_session)
+
+            with pytest.raises(RuntimeError, match="mint exploded"):
+                await c._mint_wps_credentials_v2(
+                    "wss://cms.example.com/ws/device"
+                )
+
+        fake_session.close.assert_awaited_once()
+
+
+class TestConnectAndRunRouting:
+    """Verify _connect_and_run selects the bootstrap v2 vs legacy path."""
+
+    @pytest.mark.asyncio
+    async def test_v2_path_passes_pre_minted_to_open_transport(self, tmp_path):
+        c = _make_client(tmp_path, bootstrap_v2=True, transport="wps")
+
+        fake_creds = MagicMock()
+        fake_creds.wps_url = "wss://wps.example.com/client"
+        fake_creds.wps_jwt = "jwt-abc"
+        fake_creds.expires_at = "2026-01-01T00:00:00Z"
+        fake_session = MagicMock()
+        fake_session.close = AsyncMock()
+
+        c._mint_wps_credentials_v2 = AsyncMock(
+            return_value=(fake_creds, fake_session, "https://cms.example.com")
+        )
+
+        # Abort _connect_and_run after open_transport is invoked — we only
+        # care about HOW it was called.
+        sentinel = RuntimeError("stop-here")
+        open_transport_mock = AsyncMock(side_effect=sentinel)
+
+        with patch("cms_client.service.open_transport", open_transport_mock):
+            with pytest.raises(RuntimeError, match="stop-here"):
+                await c._connect_and_run()
+
+        open_transport_mock.assert_awaited_once()
+        kwargs = open_transport_mock.await_args.kwargs
+        assert kwargs["mode"] == "wps"
+        assert kwargs["pre_minted_url"] == "wss://wps.example.com/client"
+        assert kwargs["pre_minted_token"] == "jwt-abc"
+        assert kwargs["api_key"] == ""
+        # Session must be closed in the finally when open_transport fails.
+        fake_session.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_unchanged_when_flag_off(self, tmp_path):
+        c = _make_client(tmp_path, bootstrap_v2=False, transport="wps")
+        c._mint_wps_credentials_v2 = AsyncMock(
+            side_effect=AssertionError("must not mint v2 when flag is off")
+        )
+
+        sentinel = RuntimeError("stop-here")
+        open_transport_mock = AsyncMock(side_effect=sentinel)
+
+        with patch("cms_client.service.open_transport", open_transport_mock), \
+             patch(
+                 "cms_client.service._resolve_device_api_key",
+                 return_value="legacy_api_key_abc",
+             ):
+            with pytest.raises(RuntimeError, match="stop-here"):
+                await c._connect_and_run()
+
+        c._mint_wps_credentials_v2.assert_not_awaited()
+        kwargs = open_transport_mock.await_args.kwargs
+        assert kwargs["api_key"] == "legacy_api_key_abc"
+        assert kwargs["pre_minted_url"] == ""
+        assert kwargs["pre_minted_token"] == ""
+
+    @pytest.mark.asyncio
+    async def test_v2_flag_ignored_when_transport_direct(self, tmp_path):
+        """bootstrap_v2=True + cms_transport=direct → still direct mode,
+        no minting happens (flag only activates for WPS)."""
+        c = _make_client(tmp_path, bootstrap_v2=True, transport="direct")
+        c._mint_wps_credentials_v2 = AsyncMock(
+            side_effect=AssertionError("must not mint v2 in direct mode")
+        )
+
+        sentinel = RuntimeError("stop-here")
+        open_transport_mock = AsyncMock(side_effect=sentinel)
+
+        with patch("cms_client.service.open_transport", open_transport_mock):
+            with pytest.raises(RuntimeError, match="stop-here"):
+                await c._connect_and_run()
+
+        c._mint_wps_credentials_v2.assert_not_awaited()
+        kwargs = open_transport_mock.await_args.kwargs
+        assert kwargs["mode"] == "direct"
+        assert kwargs["pre_minted_url"] == ""
+        assert kwargs["pre_minted_token"] == ""
+
+    @pytest.mark.asyncio
+    async def test_v2_creates_fresh_poll_cancel_event(self, tmp_path):
+        """A fresh asyncio.Event is created per _connect_and_run, and it's
+        threaded through to ensure_wps_credentials so first-boot polling
+        can be interrupted by CMS URL change / shutdown."""
+        c = _make_client(tmp_path, bootstrap_v2=True, transport="wps")
+        # Pre-existing stale event from a previous connect — must be replaced.
+        stale = asyncio.Event()
+        stale.set()
+        c._bootstrap_poll_cancel = stale
+
+        captured = {}
+
+        async def fake_mint(cms_url):
+            captured["cancel_event"] = c._bootstrap_poll_cancel
+            # Propagate to what ensure_wps_credentials would see.
+            raise RuntimeError("stop-here")
+
+        c._mint_wps_credentials_v2 = fake_mint
+
+        with patch("cms_client.service.open_transport"):
+            with pytest.raises(Exception):
+                await c._connect_and_run()
+
+        ev = captured["cancel_event"]
+        assert ev is not stale, "must create a fresh event, not reuse stale one"
+        assert not ev.is_set(), "fresh event must start unset"

--- a/tests/test_cms_client_transport.py
+++ b/tests/test_cms_client_transport.py
@@ -286,3 +286,57 @@ class TestOpenTransport:
                 device_id="pi-01",
             )
         assert isinstance(t, DirectTransport)
+
+    @pytest.mark.asyncio
+    async def test_wps_pre_minted_skips_connect_token(self):
+        """Bootstrap v2: when pre_minted_url+token are supplied, the
+        legacy /connect-token mint is NOT called and the URL is used
+        verbatim (with access_token appended if missing)."""
+        fake_ws = _FakeWS()
+        captured = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["url"] = url
+            captured["subprotocols"] = kwargs.get("subprotocols")
+            return fake_ws
+
+        async def fake_request_token(*args, **kwargs):
+            captured["legacy_mint_called"] = True
+            return ("should-not-be-used", "should-not-be-used")
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect), \
+             patch.object(transport_mod, "_request_connect_token", side_effect=fake_request_token):
+            t = await open_transport(
+                mode="wps",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+                api_key="",  # deliberately empty — pre-minted path supplies auth
+                pre_minted_url="wss://wps.example.com/client/hubs/devices",
+                pre_minted_token="jwt_v2_token",
+            )
+        assert isinstance(t, WPSTransport)
+        assert "legacy_mint_called" not in captured
+        assert captured["url"] == "wss://wps.example.com/client/hubs/devices?access_token=jwt_v2_token"
+        assert captured["subprotocols"] == ["json.webpubsub.azure.v1"]
+
+    @pytest.mark.asyncio
+    async def test_wps_pre_minted_preserves_existing_token_in_url(self):
+        """If pre_minted_url already has access_token=, don't append again."""
+        fake_ws = _FakeWS()
+        captured = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["url"] = url
+            return fake_ws
+
+        with patch.object(transport_mod.websockets, "connect", side_effect=fake_connect):
+            await open_transport(
+                mode="wps",
+                cms_url="wss://cms.example.com/ws/device",
+                device_id="pi-01",
+                pre_minted_url="wss://wps.example.com/client/hubs/devices?access_token=embedded",
+                pre_minted_token="jwt_v2_token",
+            )
+        # Token already in URL → not re-appended.
+        assert captured["url"].count("access_token=") == 1
+        assert "access_token=embedded" in captured["url"]


### PR DESCRIPTION
# Stage B.3 — Bootstrap v2 runtime wire-in + JWT renewal

Wires the bootstrap v2 orchestration module (`cms_client/bootstrap_boot.py`,
shipped in B.1/B.2) into the running service. **Feature-flagged OFF by
default** — flip `AGORA_BOOTSTRAP_V2=true` + `AGORA_CMS_TRANSPORT=wps` to
activate on a device. Direct mode and legacy api-key WPS mode are unchanged.

## What changes

### `cms_client/transport.py`
- `open_wps` / `open_transport` accept `pre_minted_url` + `pre_minted_token`
  kwargs. When supplied, the legacy `POST /api/devices/{id}/connect-token`
  mint is skipped — caller provides the WPS URL + JWT directly from the new
  signed `/api/devices/connect-token` flow.
- At least one of `api_key` or the pre-minted pair is required for WPS.

### `cms_client/service.py`
- New feature gate: `bootstrap_v2 = settings.bootstrap_v2 and transport_mode == "wps"`.
- `_mint_wps_credentials_v2` — ensures device identity, opens a shared
  `aiohttp.ClientSession`, calls `bootstrap_boot.ensure_wps_credentials`.
  On failure the session is closed before re-raising.
- `_connect_and_run` threads the minted `(wps_url, wps_jwt)` into
  `open_transport` via `pre_minted_url` / `pre_minted_token`.
- `_jwt_renewal_loop` — background task per WS connection. Sleeps until
  `expires_at - jwt_refresh_lead_seconds` (floor 30s). Success → persist
  state + close ws to force reconnect with new token. 401 → count;
  after 3 consecutive, rotate **everything** (bootstrap state, device key,
  pairing secret, auth token) and force a true first-boot re-registration
  (same-pubkey re-registration would be pointless if the key was revoked).
  429 / transport error → 60s backoff, same WS.
- Per-connect `_bootstrap_poll_cancel` event — allows
  `_config_watch_loop` (CMS URL change) and `stop()` to interrupt a slow
  first-boot `/bootstrap-status` poll instead of polling the old CMS for
  minutes after a URL change.
- `_handle_factory_reset` additionally unlinks `device_key`,
  `pairing_secret`, `bootstrap_state.json`.
- `_config_watch_loop` also clears `bootstrap_state.json` on CMS URL
  change (JWT was minted by old signer; identity pubkey stays — still ours).

### `api/config.py`
- `Settings` gains: `bootstrap_v2: bool = False`, `fleet_id: str = ""`,
  `fleet_secret_hex: str = ""`, `jwt_refresh_lead_seconds: int = 60`.
- Path properties for `device_key_path`, `pairing_secret_path`,
  `bootstrap_state_path`.

## Tests

- `tests/test_bootstrap_boot.py` (**new**, 26) — state helpers, expiry
  parsing, freshness, all three `ensure_wps_credentials` branches (fast
  path / stale-refresh / first-boot), `refresh_wps_jwt`, `ensure_identity`.
  15 run on Windows; 11 identity-touching tests skip on Windows
  (`os.O_NOFOLLOW`), matching the existing `test_bootstrap_identity.py`
  pattern.
- `tests/test_bootstrap_v2_service.py` (**new**, 9) — `_bootstrap_v2_enabled`,
  `_mint_wps_credentials_v2` (happy / bad hex / session cleanup on mint
  failure), `_connect_and_run` routing (v2 wps / legacy wps / direct),
  fresh `poll_cancel` event per connect.
- `tests/test_cms_client_transport.py` (**+2**) — pre-minted short-circuit:
  legacy `_request_connect_token` is NOT called, URL used verbatim, and
  `access_token` is not double-appended when already present.

Local: `565 passed, 25 skipped` (full suite on Windows, excluding two
pre-existing environment-broken modules).

## Safety / rollout

- Default OFF. No device runs the new code until `AGORA_BOOTSTRAP_V2=true`
  is set in its config.
- Direct mode untouched (`mode="direct"` path in `open_transport` is
  pre-v2 code).
- Legacy WPS path (api-key mint) still exercised by existing tests and
  is the default when `bootstrap_v2=false`.
- No firmware OTA required — this is behind a flag. We'll ship an OTA
  only when ready to enable it per-device.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
