### PR TITLE
feat(image): bootstrap v2 fleet provisioning for Pi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ On first boot:
 - **WiFi boards (Zero 2 W, Pi 4):** Start a Wi-Fi access point (**Agora-XXXX**) with a captive-portal web UI for configuring Wi-Fi, device name, and CMS connection.
 - **Ethernet boards (Pi 4, Pi 5/CM5):** If connected via Ethernet, skip the WiFi setup and go straight online. The IP address and mDNS hostname are shown on the HDMI display.
 
+### Fleet provisioning (bootstrap v2)
+
+Devices that talk to a hosted CMS identify themselves via a fleet-scoped
+HMAC on the first `/register` call. The fleet secret is **not** baked into
+the image. To provision a new device for a fleet:
+
+1. Flash the stock image with Raspberry Pi Imager (no customisation
+   beyond Wi-Fi / hostname / SSH needed).
+2. Before ejecting the SD card, open the **bootfs** partition (visible as
+   a FAT volume on Windows / macOS / Linux) and create
+   `agora-fleet.env` with two lines:
+
+   ```
+   AGORA_FLEET_ID=<your-fleet-id>
+   AGORA_FLEET_SECRET_HEX=<64-hex-char fleet secret>
+   ```
+
+3. Eject the card and boot the Pi. On first boot a oneshot service
+   (`agora-fleet-provision.service`) installs the values into
+   `/etc/agora/environment` (root, 0600) and **shreds** the copy on the
+   boot partition so a lost SD card cannot leak the secret.
+
+Operators who forget to drop the file can SSH in and run
+`sudo /opt/agora/src/scripts/agora-fleet-provision.sh` after creating
+the file manually (or just edit `/etc/agora/environment` directly and
+restart `agora-cms-client`). The helper is idempotent.
+
 ### Option 2: Install on Existing Raspberry Pi OS
 
 Start with **Raspberry Pi OS 64-bit Lite**. In Imager settings, enable SSH and configure Wi-Fi, then:

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -977,7 +977,7 @@ class CMSClient:
         schedules = sync_data.get("schedules", [])
         default_asset = sync_data.get("default_asset")
         tz_name = sync_data.get("timezone", "UTC")
-        logger.info("EVAL: default_asset=%s, schedules=%d, last_state=%s",
+        logger.debug("EVAL: default_asset=%s, schedules=%d, last_state=%s",
                      default_asset, len(schedules), self._last_eval_state)
 
         # Check if the player is in an error state — if so, clear the cache

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -75,6 +75,7 @@ cp "${REPO_ROOT}/systemd/agora-api.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-player.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-cms-client.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-provision.service" "${BUILD_DIR}/etc/systemd/system/"
+cp "${REPO_ROOT}/systemd/agora-fleet-provision.service" "${BUILD_DIR}/etc/systemd/system/"
 
 # ── Plymouth theme ──
 if [[ -f "${REPO_ROOT}/config/boot-splash.png" ]]; then

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -13,8 +13,15 @@ fi
 usermod -aG netdev "${AGORA_USER}" 2>/dev/null || true
 
 # ── Create persist directory (flash-backed, survives reboots) ──
+# Bootstrap v2 requires the persist dir to be owned by the uid that
+# runs agora-cms-client (root — no User= directive). Other services
+# (agora-api, agora-player) run as user 'agora' and read files inside
+# persist (e.g. api_key, mode 0644) through the 0755 dir mode.
+# Files written by bootstrap v2 (device_key, pairing_secret,
+# bootstrap_state.json) are mode 0600 root:root and remain private.
 mkdir -p "${AGORA_BASE}/persist"
-chown "${AGORA_USER}:${AGORA_USER}" "${AGORA_BASE}/persist"
+chown -R root:root "${AGORA_BASE}/persist"
+chmod 0755 "${AGORA_BASE}/persist"
 
 # ── Migrate persistent files from old state dir if needed ──
 for file in cms_auth_token cms_config.json splash api_key; do
@@ -219,9 +226,15 @@ systemctl restart NetworkManager 2>/dev/null || true
 chmod +x "${AGORA_BASE}/src/scripts/configure-ntp.sh"
 bash "${AGORA_BASE}/src/scripts/configure-ntp.sh" || true
 
+# ── Install fleet-provision helper script ──
+FLEET_SCRIPT="${AGORA_BASE}/src/scripts/agora-fleet-provision.sh"
+if [ -f "${FLEET_SCRIPT}" ]; then
+    chmod 0755 "${FLEET_SCRIPT}"
+fi
+
 # ── Enable and restart services ──
 systemctl daemon-reload
-systemctl enable agora-player agora-api agora-cms-client agora-provision
+systemctl enable agora-player agora-api agora-cms-client agora-provision agora-fleet-provision
 
 # ── Ensure dnsmasq does not start by default (managed by provision service) ──
 systemctl disable dnsmasq 2>/dev/null || true

--- a/packaging/smoke-test-deb.sh
+++ b/packaging/smoke-test-deb.sh
@@ -42,6 +42,8 @@ REQUIRED_FILES=(
     "$STAGE/etc/systemd/system/agora-api.service"
     "$STAGE/etc/systemd/system/agora-cms-client.service"
     "$STAGE/etc/systemd/system/agora-provision.service"
+    "$STAGE/etc/systemd/system/agora-fleet-provision.service"
+    "$SRC/scripts/agora-fleet-provision.sh"
     "$STAGE/DEBIAN/control"
     "$STAGE/DEBIAN/postinst"
 )

--- a/scripts/agora-fleet-provision.sh
+++ b/scripts/agora-fleet-provision.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────────────────
+# agora-fleet-provision.sh
+#
+# First-boot fleet provisioning for bootstrap v2.
+#
+# Run as root by agora-fleet-provision.service, before agora-cms-client.
+# Idempotent: safe to re-run on every boot.
+#
+# Responsibilities:
+#   1. Ensure /etc/agora/environment exists with AGORA_BOOTSTRAP_V2=1 default.
+#   2. If /boot/firmware/agora-fleet.env (or /boot/agora-fleet.env on older
+#      Pi OS) is present, install its AGORA_FLEET_ID / AGORA_FLEET_SECRET_HEX
+#      values into /etc/agora/environment (0600 root), then shred the source
+#      so a lost SD card cannot leak the fleet secret.
+#   3. Ensure /opt/agora/persist is owned by root:root (bootstrap v2 files
+#      require it; other persist files are mode 0644 and remain readable
+#      by agora-api / agora-player running as user agora).
+#
+# Operators wanting to re-provision a device with a different fleet id
+# can drop a fresh agora-fleet.env on the boot partition and reboot.
+# ──────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ENV_FILE="/etc/agora/environment"
+BOOT_FLEET_FILE="/boot/firmware/agora-fleet.env"
+LEGACY_BOOT_FLEET_FILE="/boot/agora-fleet.env"
+PERSIST_DIR="/opt/agora/persist"
+
+mkdir -p /etc/agora
+chmod 0755 /etc/agora 2>/dev/null || true
+chown root:root /etc/agora 2>/dev/null || true
+
+# ── Seed env file with bootstrap v2 default ──
+if [ ! -f "$ENV_FILE" ]; then
+    touch "$ENV_FILE"
+fi
+chmod 0600 "$ENV_FILE" 2>/dev/null || true
+chown root:root "$ENV_FILE" 2>/dev/null || true
+
+if ! grep -q '^AGORA_BOOTSTRAP_V2=' "$ENV_FILE"; then
+    echo "AGORA_BOOTSTRAP_V2=1" >> "$ENV_FILE"
+    echo "agora-fleet-provision: enabled bootstrap v2 default"
+fi
+
+# ── Pick up fleet config drop-in from boot partition ──
+src=""
+if [ -f "$BOOT_FLEET_FILE" ]; then
+    src="$BOOT_FLEET_FILE"
+elif [ -f "$LEGACY_BOOT_FLEET_FILE" ]; then
+    src="$LEGACY_BOOT_FLEET_FILE"
+fi
+
+if [ -n "$src" ]; then
+    echo "agora-fleet-provision: installing fleet config from $src"
+    # Allow-listed keys only; ignore anything else in the drop-in to
+    # keep the attack surface tight (no arbitrary env vars).
+    while IFS='=' read -r key val; do
+        # skip blanks and comments
+        case "$key" in
+            ''|\#*) continue ;;
+        esac
+        # strip Windows CRLF if present
+        val="${val%$'\r'}"
+        # strip surrounding quotes
+        val="${val%\"}"
+        val="${val#\"}"
+        case "$key" in
+            AGORA_FLEET_ID|AGORA_FLEET_SECRET_HEX|AGORA_BOOTSTRAP_V2)
+                sed -i "/^${key}=/d" "$ENV_FILE"
+                echo "${key}=${val}" >> "$ENV_FILE"
+                echo "agora-fleet-provision: set ${key}"
+                ;;
+        esac
+    done < "$src"
+    chmod 0600 "$ENV_FILE" 2>/dev/null || true
+    chown root:root "$ENV_FILE" 2>/dev/null || true
+    # Shred the boot-partition copy so a stolen SD card doesn't leak
+    # the fleet secret. shred is a no-op on FAT (no overwrite possible),
+    # but it still unlinks the file.
+    if command -v shred >/dev/null 2>&1; then
+        shred -u "$src" 2>/dev/null || rm -f "$src"
+    else
+        rm -f "$src"
+    fi
+    echo "agora-fleet-provision: fleet config installed; boot drop-in removed"
+fi
+
+# ── Ensure persist dir is root-owned (bootstrap v2 requirement) ──
+# Mode 0755 lets agora-api / agora-player (user agora) read files like
+# api_key (which atomic_write creates 0644). Bootstrap v2 files are
+# mode 0600 root:root and remain private.
+if [ -d "$PERSIST_DIR" ]; then
+    chown -R root:root "$PERSIST_DIR" 2>/dev/null || true
+    chmod 0755 "$PERSIST_DIR" 2>/dev/null || true
+fi
+
+exit 0

--- a/systemd/agora-cms-client.service
+++ b/systemd/agora-cms-client.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Agora CMS Client
-After=network-online.target agora-api.service
+After=network-online.target agora-api.service agora-fleet-provision.service
 Wants=network-online.target
+Requires=agora-fleet-provision.service
 
 [Service]
 Type=simple
@@ -9,6 +10,11 @@ ExecStart=/usr/bin/python3 -m cms_client.main
 WorkingDirectory=/opt/agora/src
 Environment=PYTHONPATH=/opt/agora/src
 Environment=AGORA_BASE=/opt/agora
+# Fleet provisioning env (AGORA_BOOTSTRAP_V2, AGORA_FLEET_ID,
+# AGORA_FLEET_SECRET_HEX). Installed by agora-fleet-provision.service.
+# The '-' prefix means the file is optional so the unit still starts
+# on a fresh install that hasn't been provisioned yet.
+EnvironmentFile=-/etc/agora/environment
 Restart=always
 RestartSec=10
 

--- a/systemd/agora-fleet-provision.service
+++ b/systemd/agora-fleet-provision.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Agora Fleet Provisioning (first-boot env installer)
+DefaultDependencies=no
+After=local-fs.target
+Before=agora-cms-client.service agora-api.service agora-player.service
+# This unit must not block the cms-client even on unusual hosts;
+# the script itself creates /etc/agora if missing, so we deliberately
+# do not gate on ConditionPathIsDirectory.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/opt/agora/src/scripts/agora-fleet-provision.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What

Makes a freshly-flashed Pi image onboard onto bootstrap v2 without any manual staging, while keeping the fleet HMAC secret **out of the image** (this repo is open source).

## How (operator workflow)

1. Flash stock image via Raspberry Pi Imager.
2. Before ejecting the SD card, drop `agora-fleet.env` on the FAT boot partition with two lines:
   ```n   AGORA_FLEET_ID=<fleet-id>
   AGORA_FLEET_SECRET_HEX=<64-hex fleet secret>
   ```n3. Boot. A new oneshot (`agora-fleet-provision.service`) installs the values into `/etc/agora/environment` (root, 0600), chowns `/opt/agora/persist` to root, and **shreds** the boot-partition copy so a lost SD card cannot leak the secret.

Operators who forget the drop-in can SSH in and either edit `/etc/agora/environment` directly + `systemctl restart agora-cms-client`, or create the drop-in and run the helper script manually.

## Changes

* **New** `systemd/agora-fleet-provision.service` — oneshot, ordered `Before=agora-cms-client.service` and required by it.
* **New** `scripts/agora-fleet-provision.sh` — idempotent helper. Seeds `AGORA_BOOTSTRAP_V2=1`, allow-lists only `AGORA_FLEET_ID` / `AGORA_FLEET_SECRET_HEX` / `AGORA_BOOTSTRAP_V2` from the drop-in, strips CRLF, shreds the source.
* `systemd/agora-cms-client.service` — `Requires=` + `After=` the provision unit; optional `EnvironmentFile=-/etc/agora/environment`.
* `packaging/debian/postinst` — chown `/opt/agora/persist` to root:root mode 0755 (fixes #134); enable the new service. Persist mode stays 0755 so agora-api/agora-player (user agora) can still read 0644 files like `api_key`; bootstrap files remain 0600 root:root.
* `packaging/build-deb.sh` — ship the new unit.
* `packaging/smoke-test-deb.sh` — assert the unit + helper script are in the .deb.
* `cms_client/service.py` — demote noisy per-tick `EVAL: default_asset=...` line from info to debug.
* `README.md` — Fleet provisioning section.

## Validation

* Sandbox dry-run (rewiring paths to /tmp) — confirms env seeding, allow-list filtering (malicious keys ignored), boot-partition file removed, idempotent on second run.
* `bash -n` and `python3 -m ast` clean.
* Existing Desk Pi (already manually provisioned in this state) will pick up the package on next upgrade without needing re-provisioning — the script is idempotent and the env file it would produce matches what's already there.

Closes #134.