### PR TITLE
fix(postinst): resolve PEP 668 + cryptography RECORD issues on bookworm

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -70,12 +70,20 @@ EOF
 fi
 
 # ── Install Python packages ──
-pip3 install --break-system-packages -q \
-    -r "${AGORA_BASE}/src/requirements-api.txt" \
-    -r "${AGORA_BASE}/src/requirements-player.txt" \
-    -r "${AGORA_BASE}/src/requirements-cms-client.txt" \
-    qrcode 2>/dev/null \
-|| pip3 install -q \
+# On bookworm, pip3 refuses system-wide installs by default (PEP 668).
+# PIP_BREAK_SYSTEM_PACKAGES=1 opts in; older pip that predates the env var
+# ignores it harmlessly.
+export PIP_BREAK_SYSTEM_PACKAGES=1
+
+# The debian-packaged python3-cryptography lacks a pip RECORD file, so
+# a plain `pip3 install cryptography>=44` fails with "uninstall-no-record-file"
+# whenever pip needs to replace it. --ignore-installed makes pip install to
+# /usr/local alongside the apt copy (pip's path takes precedence on import).
+# We pin from requirements-cms-client.txt so both stay in sync.
+CRYPTO_REQ=$(grep -E '^cryptography' "${AGORA_BASE}/src/requirements-cms-client.txt" || echo "cryptography")
+pip3 install -q --ignore-installed --no-deps "${CRYPTO_REQ}"
+
+pip3 install -q \
     -r "${AGORA_BASE}/src/requirements-api.txt" \
     -r "${AGORA_BASE}/src/requirements-player.txt" \
     -r "${AGORA_BASE}/src/requirements-cms-client.txt" \


### PR DESCRIPTION
The pip install step in `postinst` had two bugs that made every upgrade on a fresh bookworm Pi fail:

1. **PEP 668**: the primary invocation used `--break-system-packages` but swallowed its errors with `2>/dev/null`, then fell back to a second invocation WITHOUT `--break-system-packages`, which always fails on bookworm due to the externally-managed-environment marker.
2. **cryptography**: the debian `python3-cryptography` package lacks a pip RECORD file, so `pip install 'cryptography>=44'` dies with `uninstall-no-record-file` when it needs to replace it.

### Fix

- Use `PIP_BREAK_SYSTEM_PACKAGES=1` env var (opts in cleanly; older pip that predates it ignores it harmlessly).
- Install cryptography separately with `--ignore-installed --no-deps` so pip installs to `/usr/local` alongside the apt copy (import precedence favors `/usr/local`).
- Pin from `requirements-cms-client.txt` so the two stay in sync.
- Drop the `|| fallback` and `2>/dev/null` so real errors surface.

### Verified

These are the exact steps that unblocked a broken Pi running 1.11.16 manually today.