### PR TITLE
Decouple fetch_asset from WS read loop (#136)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -289,6 +289,12 @@ class CMSClient:
         self._current_asset: str | None = None
         self._eval_wake = asyncio.Event()      # triggers immediate schedule re-eval
         self._last_player_mode: str | None = None
+        # In-flight asset fetch tasks, keyed by asset_name. Fetch handlers run
+        # as background tasks so the WS read loop isn't blocked by multi-minute
+        # downloads (tracked in agora#136). Downloads are serialized by
+        # ``_fetch_lock`` so AssetManager eviction math stays correct.
+        self._fetch_tasks: dict[str, asyncio.Task] = {}
+        self._fetch_lock = asyncio.Lock()
         # Bootstrap v2 state (only populated when settings.bootstrap_v2 is true)
         self._bootstrap_identity = None  # shared.bootstrap_identity.DeviceIdentity
         self._bootstrap_pairing_secret: str | None = None
@@ -659,8 +665,9 @@ class CMSClient:
                     elif msg_type == "stop":
                         await self._handle_stop()
                     elif msg_type == "fetch_asset":
-                        await self._handle_fetch_asset(msg, ws)
+                        self._spawn_fetch_asset(msg, ws)
                     elif msg_type == "delete_asset":
+                        await self._cancel_fetch(msg.get("asset_name", ""))
                         await self._handle_delete_asset(msg, ws)
                     elif msg_type == "config":
                         await self._handle_config(msg)
@@ -671,6 +678,7 @@ class CMSClient:
                     elif msg_type == "factory_reset":
                         await self._handle_factory_reset(ws)
                     elif msg_type == "wipe_assets":
+                        await self._cancel_all_fetches()
                         await self._handle_wipe_assets(msg, ws)
                     elif msg_type == "request_logs":
                         await self._handle_request_logs(msg, ws)
@@ -707,6 +715,7 @@ class CMSClient:
                     else:
                         logger.warning("Unknown CMS message type: %s", msg_type)
             finally:
+                await self._cancel_all_fetches()
                 status_task.cancel()
                 try:
                     await status_task
@@ -1433,6 +1442,61 @@ class CMSClient:
             return key_path.read_text().strip()
         except FileNotFoundError:
             return ""
+
+    def _spawn_fetch_asset(self, msg: dict, ws) -> None:
+        """Dispatch ``fetch_asset`` as a background task.
+
+        The WS read loop must stay responsive while large assets download
+        (agora#136). Duplicate fetches for the same asset supersede the prior
+        one. Actual download work is serialized by ``self._fetch_lock`` so
+        AssetManager eviction accounting remains correct.
+        """
+        asset_name = msg.get("asset_name", "")
+        if not asset_name:
+            logger.warning("Invalid fetch_asset message: missing asset_name")
+            return
+        prior = self._fetch_tasks.get(asset_name)
+        if prior is not None and not prior.done():
+            prior.cancel()
+        task = asyncio.create_task(self._fetch_asset_locked(msg, ws))
+        self._fetch_tasks[asset_name] = task
+
+        def _cleanup(t: asyncio.Task, name: str = asset_name) -> None:
+            if self._fetch_tasks.get(name) is t:
+                self._fetch_tasks.pop(name, None)
+
+        task.add_done_callback(_cleanup)
+
+    async def _fetch_asset_locked(self, msg: dict, ws) -> None:
+        try:
+            async with self._fetch_lock:
+                await self._handle_fetch_asset(msg, ws)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Background fetch_asset task failed")
+
+    async def _cancel_fetch(self, asset_name: str) -> None:
+        if not asset_name:
+            return
+        task = self._fetch_tasks.get(asset_name)
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _cancel_all_fetches(self) -> None:
+        tasks = [t for t in self._fetch_tasks.values() if not t.done()]
+        if not tasks:
+            self._fetch_tasks.clear()
+            return
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._fetch_tasks.clear()
 
     async def _handle_fetch_asset(self, msg: dict, ws) -> None:
         """CMS tells us to download an asset — with budget-aware eviction."""

--- a/tests/test_fetch_background.py
+++ b/tests/test_fetch_background.py
@@ -1,0 +1,172 @@
+"""Tests for agora#136: fetch_asset runs in background, not on the WS read path.
+
+The CMS websocket read loop must stay responsive while large asset downloads
+are in flight. Fetches are:
+
+* dispatched as background tasks (``_spawn_fetch_asset``),
+* serialized by ``_fetch_lock`` so AssetManager eviction math is correct,
+* superseded when a new fetch for the same asset arrives,
+* cancelled when ``delete_asset``/``wipe_assets`` races them, and
+* cancelled on WS disconnect.
+"""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("websockets.asyncio", MagicMock())
+sys.modules.setdefault("websockets.asyncio.client", MagicMock())
+
+from cms_client.service import CMSClient  # noqa: E402
+
+
+@pytest.fixture
+def client(tmp_path):
+    settings = MagicMock()
+    settings.assets_dir = tmp_path
+    settings.manifest_path = tmp_path / "assets.json"
+    settings.asset_budget_mb = 100
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        c = CMSClient(settings)
+    c.settings = settings
+    c.device_id = "d1"
+    c.asset_manager = MagicMock()
+    c._fetch_tasks = {}
+    c._fetch_lock = asyncio.Lock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_spawn_fetch_runs_in_background(client):
+    """Spawning does not block the caller even on a slow fetch."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_fetch(msg, ws):
+        started.set()
+        await release.wait()
+
+    with patch.object(client, "_handle_fetch_asset", side_effect=slow_fetch):
+        client._spawn_fetch_asset({"asset_name": "a.mp4"}, ws=AsyncMock())
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        # Caller returned immediately; task is running.
+        assert "a.mp4" in client._fetch_tasks
+        assert not client._fetch_tasks["a.mp4"].done()
+        release.set()
+        await client._fetch_tasks["a.mp4"] if "a.mp4" in client._fetch_tasks else None
+    # Cleanup callback pops when the task finishes.
+    await asyncio.sleep(0)
+    assert "a.mp4" not in client._fetch_tasks
+
+
+@pytest.mark.asyncio
+async def test_spawn_with_missing_asset_name_is_noop(client):
+    client._spawn_fetch_asset({}, ws=AsyncMock())
+    assert client._fetch_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_fetch_supersedes(client):
+    """A second fetch for the same asset cancels the first."""
+    first_cancelled = asyncio.Event()
+    first_started = asyncio.Event()
+    calls = []
+
+    async def fake_fetch(msg, ws):
+        calls.append(msg.get("tag"))
+        if msg.get("tag") == "first":
+            first_started.set()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                first_cancelled.set()
+                raise
+
+    with patch.object(client, "_handle_fetch_asset", side_effect=fake_fetch):
+        client._spawn_fetch_asset({"asset_name": "a.mp4", "tag": "first"}, ws=AsyncMock())
+        await asyncio.wait_for(first_started.wait(), timeout=1.0)
+        client._spawn_fetch_asset({"asset_name": "a.mp4", "tag": "second"}, ws=AsyncMock())
+        await asyncio.wait_for(first_cancelled.wait(), timeout=1.0)
+        # Second task should be the one we track now.
+        t = client._fetch_tasks.get("a.mp4")
+        assert t is not None
+        # Let the second run.
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_fetches_are_serialized_by_lock(client):
+    """Two different-asset fetches execute one at a time under ``_fetch_lock``."""
+    active = 0
+    peak = 0
+    gate = asyncio.Event()
+
+    async def fake_fetch(msg, ws):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await gate.wait()
+        active -= 1
+
+    with patch.object(client, "_handle_fetch_asset", side_effect=fake_fetch):
+        client._spawn_fetch_asset({"asset_name": "a.mp4"}, ws=AsyncMock())
+        client._spawn_fetch_asset({"asset_name": "b.mp4"}, ws=AsyncMock())
+        await asyncio.sleep(0.05)
+        gate.set()
+        for t in list(client._fetch_tasks.values()):
+            await asyncio.wait_for(t, timeout=1.0)
+    assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_fetch_by_name_cancels_in_flight(client):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def slow_fetch(msg, ws):
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    with patch.object(client, "_handle_fetch_asset", side_effect=slow_fetch):
+        client._spawn_fetch_asset({"asset_name": "a.mp4"}, ws=AsyncMock())
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await client._cancel_fetch("a.mp4")
+        assert cancelled.is_set()
+        assert "a.mp4" not in client._fetch_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancel_fetch_unknown_name_is_noop(client):
+    await client._cancel_fetch("")
+    await client._cancel_fetch("never-started")  # no crash
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_fetches(client):
+    cancelled = {"a.mp4": False, "b.mp4": False}
+    started = {"a.mp4": asyncio.Event(), "b.mp4": asyncio.Event()}
+
+    async def slow_fetch(msg, ws):
+        name = msg["asset_name"]
+        started[name].set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled[name] = True
+            raise
+
+    with patch.object(client, "_handle_fetch_asset", side_effect=slow_fetch):
+        client._spawn_fetch_asset({"asset_name": "a.mp4"}, ws=AsyncMock())
+        client._spawn_fetch_asset({"asset_name": "b.mp4"}, ws=AsyncMock())
+        await asyncio.wait_for(started["a.mp4"].wait(), timeout=1.0)
+        # b is queued behind the lock, but _cancel_all still cancels it.
+        await client._cancel_all_fetches()
+    assert cancelled["a.mp4"]
+    assert client._fetch_tasks == {}


### PR DESCRIPTION
# Unblock sync handling from asset downloads (#136)

## Problem

The CMS websocket read loop (`cms_client/service.py`) awaits every handler inline.
`_handle_fetch_asset` does an `aiohttp` download that can take minutes for large
videos, during which `sync`, `play`, `stop`, `config`, `request_logs`, `reboot`,
etc. all queue behind it. User-visible symptom: CMS schedule/config edits take
minutes to land while a large asset is downloading.

## Fix

Dispatch `fetch_asset` into a background task so the read loop stays responsive.

* `_spawn_fetch_asset()` — non-blocking dispatch; tracks tasks in
  `self._fetch_tasks` keyed by `asset_name`.
* Downloads run under `self._fetch_lock` (serialized). Without this, two
  concurrent fetches would both pass `AssetManager.evict_for()` (which only
  reads the manifest, and the manifest is only updated **after** a successful
  download), letting them overcommit disk budget.
* Duplicate fetches for the same `asset_name` supersede the prior task.
* `delete_asset` and `wipe_assets` cancel the corresponding fetch before
  executing — otherwise a late download would re-create the asset the CMS just
  deleted/wiped.
* WS read loop `finally:` cancels all in-flight fetches on disconnect.

## Tests

New `tests/test_fetch_background.py` (7 tests):

* spawn is non-blocking even while the fetch is in flight
* missing `asset_name` is a no-op
* duplicate fetch supersedes the prior task
* two different-asset fetches serialize through the lock (peak concurrency = 1)
* `_cancel_fetch(name)` cancels the in-flight task and removes it from the dict
- `_cancel_fetch` on unknown / empty name is a no-op
* `_cancel_all_fetches` cancels every in-flight task

55 existing `cms_client`/bootstrap tests still pass.

Tracks: #136
