### PR TITLE
ci: drop redundant push-to-main triggers

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -13,8 +13,6 @@ name: Package Smoke
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   package-smoke:

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,14 +1,16 @@
 name: Secrets Scan
 
 # Scans the repo (including git history) for leaked credentials on
-# every PR and on pushes to main. Required in branch protection —
-# a leak should block the merge. False positives can be allowlisted
-# in .gitleaks.toml.
+# every PR, plus a weekly sweep that catches anything that bypassed the
+# PR gate (force-push, history rewrite, branch protection gap). The
+# weekly cron is what actually defends the main branch over time — a
+# push-to-main trigger would just re-scan the same content the PR
+# gate already approved, since PRs land via squash-merge one at a time.
+# Required in branch protection — a leak on a PR should block the merge.
+# False positives can be allowlisted in .gitleaks.toml.
 
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
   schedule:
     - cron: "37 6 * * 1"  # weekly Monday sweep

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
# Drop redundant push-to-main triggers

On every merge to main, four workflows fan out in parallel: **Tests, Package Smoke, Build & Release, Secrets Scan**. Three of those re-run identical content the PR workflows already approved.

## Why they're redundant

* agora squash-merges one PR at a time (no merge queue), and PRs are rebased before merge → the post-merge main commit matches the content the PR workflows gated.
* `Build & Release` has its own `Smoke-test .deb before publishing` step that runs against the exact artifact it's about to publish → `Package Smoke` on push adds nothing.
* `Secrets Scan` on push re-scans the same content the PR scan already approved; the **weekly Monday cron** is the real defense-in-depth (catches force-push, history rewrite, branch-protection gaps).

## Changes

| Workflow | PR | Push to main | Schedule |
|---|---|---|---|
| Tests | ✅ | ❌ (drop) | — |
| Package Smoke | ✅ | ❌ (drop) | — |
| Secrets Scan | ✅ | ❌ (drop) | ✅ keep weekly |
| Build & Release | — | ✅ (unchanged) | — |

PR gates remain required in branch protection.

## Risk

If you ever adopt a merge queue where multiple PRs can land in one batch, the post-merge commit content may differ from what any single PR tested. At that point re-add `push: branches: [main]` on Tests.
