### PR TITLE
feat(bootstrap-v2): include local_ip in registration metadata (#436)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -531,6 +531,7 @@ class CMSClient:
             "firmware_version": self._get_version(),
             "device_type": _get_device_type(),
             "device_name": self.settings.device_name,
+            "local_ip": _get_local_ip(),
         }
 
         session = aiohttp.ClientSession()


### PR DESCRIPTION
Adds `local_ip` (from `_get_local_ip()`) to the bootstrap-v2 metadata
dict that the firmware sends on register. This is the firmware side
of agora-cms#436.

## Why

When CMS is fronted by a load balancer / Container Apps ingress, the
origin IP CMS observes on the HTTPS register call is the egress IP
the request came from — not the device's LAN IP. Adopters then can't
SSH into the Pi from the operator console without guessing.

The legacy v1 register-once payload already includes `ip_address`
(see `service.py:637`). Bootstrap-v2 dropped it. This restores
parity by sending it as `local_ip` in `metadata` so CMS can render
both — the LAN IP and the origin (NAT) IP — on the device card.

## CMS side

Lands separately as agora-cms#442. The CMS pending list JS already
prefers `metadata.local_ip` when present and falls back to origin
otherwise, so this change is forward-compatible: shipping firmware
first is fine.

## Test

Existing simulator integration tests in agora-device-simulator
exercise the bootstrap-v2 path and parse the metadata blob; once
this lands and the submodule is bumped they'll see the new field.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
