### PR TITLE
feat(provision): show pairing QR during OOBE adoption

### DIFF
--- a/provision/display.py
+++ b/provision/display.py
@@ -16,6 +16,7 @@ thread when used alongside asyncio.
 """
 
 import ctypes
+import json
 import logging
 import math
 import pathlib
@@ -581,6 +582,78 @@ class ProvisionDisplay:
             bw, bh = _draw_badge(ctx, cx, y, url, "Monospace Bold 28",
                         bg_color=(0.3, 0.3, 0.4))
             y += bh + 90
+        _draw_progress_dots(ctx, cx, h, 5)
+        self._blit()
+
+    def show_pairing_qr(
+        self,
+        *,
+        secret: str,
+        cms_host: str = "",
+        ip: str = "",
+        hostname: str = "",
+    ) -> None:
+        """Screen: show pairing QR for CMS scanner to adopt this device.
+
+        The QR encodes a compact JSON payload ``{"v":1,"secret":<secret>}``
+        which the CMS adoption scanner (`cms/static/app.js:_parsePairingQr`)
+        accepts directly.  The raw secret is also rendered below the QR as
+        a manual-entry fallback.
+        """
+        if not self.available:
+            return
+        ctx = self._ctx()
+        w, h = self._width, self._height
+        cx = w / 2
+        _draw_bg(ctx, w, h)
+
+        y = h * 0.06
+        y = _draw_logo(ctx, cx, y) + 10
+        th = _draw_text(ctx, cx, y, "Adopt this device", "Sans Bold 38", AMBER)
+        y += th + 18
+        th = _draw_text(
+            ctx, cx, y,
+            "Scan with the CMS Adopt button or your phone's camera.",
+            "Sans 22", WHITE, alpha=0.7, wrap_width=900,
+        )
+        y += th + 14
+
+        payload = json.dumps(
+            {"v": 1, "secret": secret}, separators=(",", ":"),
+        )
+        qr_center_y = y + 145
+        drawn = _draw_qr_code(ctx, cx, qr_center_y, payload, module_size=5)
+        if drawn:
+            y = qr_center_y + 165
+        else:
+            y += 30
+
+        # Manual-entry fallback: print the raw secret in monospace.
+        _draw_text(
+            ctx, cx, y,
+            "Or enter this code manually:",
+            "Sans 20", WHITE, alpha=0.5,
+        )
+        y += 30
+        bw, bh = _draw_badge(
+            ctx, cx, y, secret, "Monospace Bold 26",
+            bg_color=(0.3, 0.3, 0.4),
+        )
+        y += bh + 18
+
+        # LAN context: IP / hostname / cms_host badges (compact row).
+        for label, value, font in (
+            ("IP", ip, "Monospace Bold 22"),
+            ("mDNS", hostname, "Monospace Bold 22"),
+            ("CMS", cms_host, "Monospace Bold 22"),
+        ):
+            if not value:
+                continue
+            th = _draw_text(
+                ctx, cx, y, f"{label}: {value}", font, WHITE, alpha=0.55,
+            )
+            y += th + 4
+
         _draw_progress_dots(ctx, cx, h, 5)
         self._blit()
 

--- a/provision/pairing.py
+++ b/provision/pairing.py
@@ -1,0 +1,47 @@
+"""Provisioning helpers that are independent of the cairo display stack.
+
+Living here (rather than in :mod:`provision.service`) lets tests exercise
+the validation logic in CI environments where ``cairo`` and
+``gobject-introspection`` are not installed.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+logger = logging.getLogger("agora.provision")
+
+# Default location of the bootstrap-v2 pairing secret file.  The
+# canonical creator/owner is :mod:`cms_client.bootstrap_boot`; the
+# provisioning service only ever *reads* this file.
+PERSIST_DIR = Path("/opt/agora/persist")
+PAIRING_SECRET_PATH = PERSIST_DIR / "pairing_secret"
+
+# RFC-4648 base32 alphabet (uppercase, no padding).  The pairing secret
+# must be exactly 26 chars from this alphabet.  See
+# ``shared/bootstrap_identity.py:PAIRING_SECRET_TEXT_LEN``.
+_PAIRING_SECRET_RE = re.compile(r"^[A-Z2-7]{26}$")
+
+
+def read_pairing_secret(path: Path = PAIRING_SECRET_PATH) -> str | None:
+    """Read the pairing secret from disk if present and valid.
+
+    Returns ``None`` if the file is missing, unreadable, or does not
+    contain a 26-char RFC-4648 base32 string.  Never creates the file —
+    creation is owned by ``cms_client.bootstrap_boot``.
+
+    Logs a warning (without echoing the value) on malformed contents so
+    the OOBE display can fall back to the non-QR screen.
+    """
+    try:
+        text = path.read_text(encoding="ascii", errors="replace").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not _PAIRING_SECRET_RE.fullmatch(text):
+        logger.warning(
+            "Pairing secret at %s is malformed (len=%d); falling back to "
+            "non-QR adoption screen", path, len(text),
+        )
+        return None
+    return text

--- a/provision/service.py
+++ b/provision/service.py
@@ -72,6 +72,7 @@ PERSIST_DIR = Path("/opt/agora/persist")
 STATE_DIR = Path("/opt/agora/state")
 PROVISION_FLAG = PERSIST_DIR / "provisioned"
 WIFI_DISABLED_FLAG = PERSIST_DIR / "wifi_disabled"
+PAIRING_SECRET_PATH = PERSIST_DIR / "pairing_secret"
 CMS_STATUS_PATH = STATE_DIR / "cms_status.json"
 
 WIFI_CONNECT_TIMEOUT = 60   # seconds to wait for Wi-Fi on boot
@@ -88,6 +89,8 @@ CMS_MDNS_HOST = "agora-cms.local"
 CMS_MDNS_PORT = 8080
 
 OOBE_DISPLAY_HOLD = 1       # seconds to hold static screens before advancing
+
+from provision.pairing import read_pairing_secret as _read_pairing_secret  # noqa: E402,F401
 
 
 def is_provisioned() -> bool:
@@ -360,6 +363,9 @@ async def _try_wifi_connect(
 async def _wait_for_cms_adoption(
     display: ProvisionDisplay | None,
     shutdown_event: asyncio.Event,
+    *,
+    ip: str = "",
+    hostname: str = "",
 ) -> str:
     """Monitor CMS status after provisioning.
 
@@ -376,7 +382,12 @@ async def _wait_for_cms_adoption(
         return "no_cms"
 
     shown_connecting = False
-    shown_pending = False
+    # ``pending_mode`` tracks which "waiting for adoption" screen is on
+    # the framebuffer so we don't redraw every poll.  Transitions:
+    #   None -> "fallback" (secret not yet present)
+    #   None -> "qr"       (secret present at first pending poll)
+    #   "fallback" -> "qr" (secret appeared after cms-client started)
+    pending_mode: str | None = None
     spinner_stop = threading.Event()
     spinner_thread = None
     consecutive_errors = 0
@@ -396,10 +407,29 @@ async def _wait_for_cms_adoption(
             if state == "connected" and registration == "pending":
                 _stop_spinner(spinner_stop, spinner_thread)
                 consecutive_errors = 0
-                if not shown_pending and display and display.available:
-                    display.show_cms_connected_pending(cms_host)
-                    shown_pending = True
-                    logger.info("CMS connected — waiting for adoption")
+                if pending_mode != "qr" and display and display.available:
+                    # Try to upgrade to the QR screen as soon as the
+                    # pairing secret is on disk (cms-client may have
+                    # started after us, especially on the ethernet path).
+                    secret = _read_pairing_secret()
+                    if secret:
+                        display.show_pairing_qr(
+                            secret=secret,
+                            cms_host=cms_host,
+                            ip=ip or get_device_ip() or "",
+                            hostname=hostname,
+                        )
+                        pending_mode = "qr"
+                        logger.info(
+                            "CMS connected — showing pairing QR for adoption",
+                        )
+                    elif pending_mode is None:
+                        display.show_cms_connected_pending(cms_host)
+                        pending_mode = "fallback"
+                        logger.info(
+                            "CMS connected — waiting for adoption "
+                            "(pairing secret not yet available)",
+                        )
 
             elif state == "error" or (state == "disconnected" and status.get("error")):
                 _stop_spinner(spinner_stop, spinner_thread)
@@ -591,7 +621,9 @@ async def run_service(force_oobe: bool = False) -> None:
         # Wait for CMS adoption (same as Phase 2 of WiFi OOBE)
         adoption_success = False
         while not shutdown_event.is_set():
-            result = await _wait_for_cms_adoption(display, shutdown_event)
+            result = await _wait_for_cms_adoption(
+                display, shutdown_event, ip=device_ip or "", hostname=hostname,
+            )
             logger.info("CMS adoption result: %s", result)
 
             if result == "adopted":
@@ -805,9 +837,14 @@ async def run_service(force_oobe: bool = False) -> None:
 
         # ── Phase 2: CMS adoption (loops with reconfigure) ──────────
         logger.info("Entering CMS adoption phase")
+        wifi_suffix = get_device_serial_suffix()
+        wifi_hostname = f"agora-{wifi_suffix}.local" if wifi_suffix else ""
         adoption_success = False
         while not shutdown_event.is_set():
-            result = await _wait_for_cms_adoption(display, shutdown_event)
+            result = await _wait_for_cms_adoption(
+                display, shutdown_event,
+                ip=get_device_ip() or "", hostname=wifi_hostname,
+            )
             logger.info("CMS adoption result: %s", result)
 
             if result == "adopted":

--- a/tests/test_provision_pairing.py
+++ b/tests/test_provision_pairing.py
@@ -1,0 +1,67 @@
+"""Tests for :mod:`provision.pairing` — the pairing-secret reader.
+
+These tests are pure-Python and run in CI without cairo /
+gobject-introspection.  Behavioral tests for the OOBE display flow that
+consume this helper live in :mod:`tests.test_provision_qr_display`,
+which is gated on ``cairo`` being importable.
+"""
+from __future__ import annotations
+
+from provision.pairing import read_pairing_secret
+
+# 26-char RFC-4648 base32 — every char is in the alphabet ([A-Z2-7]).
+SAMPLE_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def test_missing_file_returns_none(tmp_path):
+    assert read_pairing_secret(tmp_path / "nope") is None
+
+
+def test_valid_secret(tmp_path):
+    p = tmp_path / "pairing_secret"
+    p.write_text(SAMPLE_SECRET)
+    assert read_pairing_secret(p) == SAMPLE_SECRET
+
+
+def test_strips_trailing_newline(tmp_path):
+    p = tmp_path / "pairing_secret"
+    p.write_text(SAMPLE_SECRET + "\n")
+    assert read_pairing_secret(p) == SAMPLE_SECRET
+
+
+def test_wrong_length_returns_none(tmp_path):
+    p = tmp_path / "pairing_secret"
+    p.write_text("ABCDEFGHIJ")
+    assert read_pairing_secret(p) is None
+
+
+def test_invalid_chars_returns_none(tmp_path):
+    p = tmp_path / "pairing_secret"
+    # "1" and "8" are NOT in the RFC-4648 base32 alphabet (A-Z + 2-7).
+    p.write_text("1BCDEFGHIJKLMNOPQRSTUVWXY8")
+    assert read_pairing_secret(p) is None
+
+
+def test_lowercase_rejected(tmp_path):
+    p = tmp_path / "pairing_secret"
+    p.write_text(SAMPLE_SECRET.lower())
+    assert read_pairing_secret(p) is None
+
+
+def test_internal_whitespace_rejected(tmp_path):
+    p = tmp_path / "pairing_secret"
+    p.write_text("ABCDEFGHIJKL MNOPQRSTUVWXY")  # space in middle
+    assert read_pairing_secret(p) is None
+
+
+def test_does_not_create_file(tmp_path):
+    """Provision must never write the secret — cms-client owns that file."""
+    p = tmp_path / "pairing_secret"
+    read_pairing_secret(p)
+    assert not p.exists()
+
+
+def test_unreadable_directory_returns_none(tmp_path):
+    """A path whose parent doesn't exist is treated as 'no secret'."""
+    p = tmp_path / "no_such_dir" / "pairing_secret"
+    assert read_pairing_secret(p) is None

--- a/tests/test_provision_qr_display.py
+++ b/tests/test_provision_qr_display.py
@@ -1,0 +1,175 @@
+"""Behavioral tests for OOBE pairing-QR display flow.
+
+CI does not install ``cairo`` / ``gobject-introspection`` / ``qrcode``,
+so we mock them in ``sys.modules`` *before* importing provision modules
+(matching the pattern in ``test_oobe_flow.py``).  Tests that exercise
+the actual draw path patch out the cairo-dependent helpers, so the
+underlying mocked cairo is never called.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault("cairo", MagicMock())
+sys.modules.setdefault("gi", MagicMock())
+sys.modules.setdefault("gi.repository", MagicMock())
+sys.modules.setdefault("qrcode", MagicMock())
+sys.modules.setdefault("qrcode.constants", MagicMock())
+
+from provision import service as provision_service  # noqa: E402
+from provision import display as display_mod  # noqa: E402
+
+
+SAMPLE_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _make_display():
+    display = MagicMock()
+    display.available = True
+    return display
+
+
+def _run_adoption(display, *, status_sequence, secret_sequence, **kwargs):
+    """Drive ``_wait_for_cms_adoption`` with scripted status + secret feeds."""
+    status_iter = iter(status_sequence)
+    secret_iter = iter(secret_sequence)
+    shutdown = asyncio.Event()
+
+    async def fake_sleep(_seconds):
+        return None
+
+    with patch.object(provision_service, "_read_cms_status",
+                      side_effect=lambda: next(status_iter)), \
+         patch.object(provision_service, "_read_pairing_secret",
+                      side_effect=lambda *a, **kw: next(secret_iter)), \
+         patch.object(provision_service, "_get_cms_host",
+                      return_value="cms.example"), \
+         patch.object(provision_service, "get_device_ip",
+                      return_value="192.168.1.50"), \
+         patch.object(provision_service.asyncio, "sleep", fake_sleep):
+        result = asyncio.run(
+            provision_service._wait_for_cms_adoption(
+                display, shutdown, **kwargs,
+            ),
+        )
+    return result
+
+
+def test_pending_with_secret_immediately_shows_qr():
+    display = _make_display()
+    result = _run_adoption(
+        display,
+        status_sequence=[
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "registered"},
+        ],
+        secret_sequence=[SAMPLE_SECRET],
+        ip="10.0.0.5", hostname="agora-abcd.local",
+    )
+    assert result == "adopted"
+    display.show_pairing_qr.assert_called_once_with(
+        secret=SAMPLE_SECRET,
+        cms_host="cms.example",
+        ip="10.0.0.5",
+        hostname="agora-abcd.local",
+    )
+    display.show_cms_connected_pending.assert_not_called()
+
+
+def test_pending_without_secret_falls_back_then_upgrades():
+    """Race fix: ethernet path reaches 'pending' before cms-client has
+    written the pairing secret.  We must show the legacy screen, then
+    upgrade to the QR screen as soon as the secret appears."""
+    display = _make_display()
+    result = _run_adoption(
+        display,
+        status_sequence=[
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "registered"},
+        ],
+        # Secret appears on the second pending poll.
+        secret_sequence=[None, SAMPLE_SECRET, "ignored-after-qr"],
+    )
+    assert result == "adopted"
+    display.show_cms_connected_pending.assert_called_once_with("cms.example")
+    display.show_pairing_qr.assert_called_once()
+    _, kwargs = display.show_pairing_qr.call_args
+    assert kwargs["secret"] == SAMPLE_SECRET
+
+
+def test_pending_with_secret_renders_qr_only_once():
+    """No flicker: the QR screen must be drawn once, not on every poll."""
+    display = _make_display()
+    _run_adoption(
+        display,
+        status_sequence=[
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "pending"},
+            {"state": "connected", "registration": "registered"},
+        ],
+        secret_sequence=[SAMPLE_SECRET, SAMPLE_SECRET, SAMPLE_SECRET],
+    )
+    assert display.show_pairing_qr.call_count == 1
+
+
+def test_show_pairing_qr_encodes_canonical_payload(monkeypatch):
+    """The QR payload must match what the CMS scanner accepts:
+    ``{"v":1,"secret":<26-char base32>}`` with no whitespace.
+    See ``cms/static/app.js:_parsePairingQr``.
+    """
+    captured = {}
+
+    def fake_draw_qr(ctx, cx, cy, data, module_size=6, quiet_zone=2):
+        captured["data"] = data
+        return True
+
+    monkeypatch.setattr(display_mod, "_draw_qr_code", fake_draw_qr)
+    monkeypatch.setattr(display_mod, "_draw_bg", lambda *a, **kw: None)
+    monkeypatch.setattr(display_mod, "_draw_logo", lambda *a, **kw: 60)
+    monkeypatch.setattr(display_mod, "_draw_text", lambda *a, **kw: 30)
+    monkeypatch.setattr(
+        display_mod, "_draw_badge", lambda *a, **kw: (200, 50),
+    )
+    monkeypatch.setattr(
+        display_mod, "_draw_progress_dots", lambda *a, **kw: None,
+    )
+
+    pd = display_mod.ProvisionDisplay.__new__(display_mod.ProvisionDisplay)
+    pd._width = 1920
+    pd._height = 1080
+    pd._surface = MagicMock()
+    pd._fb_path = "/dev/null"
+    pd._bpp = 32
+    pd._frame = 0
+    pd._rgb565_lib = None
+    pd._ctx = lambda: MagicMock()
+    pd._blit = lambda: None
+
+    pd.show_pairing_qr(
+        secret=SAMPLE_SECRET,
+        cms_host="cms.example",
+        ip="10.0.0.5",
+        hostname="agora-abcd.local",
+    )
+
+    expected = json.dumps(
+        {"v": 1, "secret": SAMPLE_SECRET}, separators=(",", ":"),
+    )
+    assert captured["data"] == expected
+    # Sanity: round-trip parse — proves it's valid JSON the scanner can read.
+    assert json.loads(captured["data"]) == {"v": 1, "secret": SAMPLE_SECRET}
+
+
+def test_show_pairing_qr_noop_when_unavailable():
+    pd = display_mod.ProvisionDisplay.__new__(display_mod.ProvisionDisplay)
+    pd._surface = None  # `available` property returns False
+    # Should silently return without raising or trying to draw anything.
+    pd.show_pairing_qr(secret=SAMPLE_SECRET)


### PR DESCRIPTION
## Summary

Adds a pairing-QR adoption screen to the existing OOBE flow so that the CMS
"Adopt" button (which already has a QR scanner) can scan the device directly,
instead of operators typing the 26-character pairing secret by hand.

This is the device-side counterpart to the already-shipped CMS scanner in
`cms/static/app.js:_parsePairingQr`.

## What changed

- New `show_pairing_qr` screen in `provision/display.py`. Renders the QR plus
  the raw secret (fallback for manual entry) plus IP / mDNS / CMS labels.
- QR payload is `{"v":1,"secret":"<26-char base32>"}` (compact JSON), the format
  the CMS scanner accepts directly.
- `_wait_for_cms_adoption` now picks the pending screen based on whether
  `/opt/agora/persist/pairing_secret` is on disk yet. Tracks
  `pending_mode = None | "fallback" | "qr"` to avoid flicker and to handle
  the race where ethernet OOBE reaches `pending` before `cms-client` has
  written the secret.
- New `provision/pairing.py` module with `read_pairing_secret(path)` and
  strict regex validation (`^[A-Z2-7]{26}$`). Standalone so CI can unit-test
  it without pycairo / PyGObject.

## OOBE flow coverage

Both code paths funnel through the same `_wait_for_cms_adoption` loop, so a
single change covers both:

- **Hardwired** (per request — these previously had a sparse OOBE):
  `show_ethernet_connected` → `_wait_for_cms_adoption` → QR.
- **Wifi**: `show_cms_connected_pending` → `_wait_for_cms_adoption` → QR.

## Tests

- `tests/test_provision_pairing.py` — 9 tests for the validator
  (CI-runnable, no cairo).
- `tests/test_provision_qr_display.py` — 5 behavioral tests:
  pending+secret → QR immediately, fallback→QR transition, no-flicker
  guarantee, canonical payload, no-op when display unavailable.
  Mocks cairo/gi/qrcode in `sys.modules` (same pattern as
  `test_oobe_flow.py`).
- Full local suite: 611 passed, 25 skipped.

## Manual validation plan (post-merge)

1. Cut a new firmware tag.
2. OTA-upgrade test Pi `192.168.1.53`.
3. Factory-reset / re-provision and confirm the QR screen renders during
   adoption.
4. Scan from the CMS Adopt button → device adopts.
