### PR TITLE
fix(provision): make Use TLS a slider toggle in captive portal

### DIFF
--- a/provision/static/setup.css
+++ b/provision/static/setup.css
@@ -177,6 +177,50 @@ button:disabled:hover { background: var(--primary); }
     color: var(--warning);
 }
 
+/* Toggle switch (used for "Use TLS") — matches CMS asset stream toggle. */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+    user-select: none;
+}
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+    flex-shrink: 0;
+}
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+.toggle-switch .slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: #555;
+    border-radius: 20px;
+    transition: background 0.2s;
+}
+.toggle-switch .slider::before {
+    content: "";
+    position: absolute;
+    height: 14px;
+    width: 14px;
+    left: 3px;
+    bottom: 3px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 0.2s;
+}
+.toggle-switch input:checked + .slider { background: var(--success, #2ecc71); }
+.toggle-switch input:checked + .slider::before { transform: translateX(16px); }
+
 /* Spinner */
 .spinner {
     display: inline-block;

--- a/provision/templates/reconfigure.html
+++ b/provision/templates/reconfigure.html
@@ -30,8 +30,11 @@
                         <input type="number" id="cms-port" placeholder="8080" min="1" max="65535">
                     </div>
                 </div>
-                <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem; cursor: pointer; font-size: 0.9rem;">
-                    <input type="checkbox" id="cms-tls" onchange="onTlsToggle(this.checked)">
+                <label class="toggle-row">
+                    <span class="toggle-switch">
+                        <input type="checkbox" id="cms-tls" onchange="onTlsToggle(this.checked)">
+                        <span class="slider"></span>
+                    </span>
                     <span>Use TLS (wss://)</span>
                 </label>
                 <span class="form-hint">Enter the hostname or IP address of your CMS server. Enable TLS for cloud-hosted servers.</span>

--- a/provision/templates/setup.html
+++ b/provision/templates/setup.html
@@ -44,8 +44,11 @@
                         <input type="text" id="cms-port" placeholder="8080">
                     </div>
                 </div>
-                <label style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem; cursor: pointer; font-size: 0.9rem;">
-                    <input type="checkbox" id="cms-tls" onchange="onTlsToggle(this.checked)">
+                <label class="toggle-row">
+                    <span class="toggle-switch">
+                        <input type="checkbox" id="cms-tls" onchange="onTlsToggle(this.checked)">
+                        <span class="slider"></span>
+                    </span>
                     <span>Use TLS (wss://)</span>
                 </label>
                 <span class="form-hint">Leave blank to auto-discover via mDNS (agora-cms.local), or enter an address manually. Enable TLS for cloud-hosted servers.</span>

--- a/tests/test_wss_e2e.py
+++ b/tests/test_wss_e2e.py
@@ -20,6 +20,21 @@ import pytest
 import uvicorn
 
 
+def _set_tls(page, checked: bool) -> None:
+    """Toggle the TLS checkbox by clicking its visible slider wrapper.
+
+    The native <input id="cms-tls"> is visually hidden (opacity:0) by the
+    slider CSS, so Playwright's check()/uncheck() report it as outside
+    the viewport. The wrapping <label class="toggle-row"> is the actual
+    click target for users; clicking it (when state needs to change)
+    flips the input and fires the change handler.
+    """
+    current = page.evaluate("document.getElementById('cms-tls').checked")
+    if current == checked:
+        return
+    page.locator("label.toggle-row").filter(has=page.locator("#cms-tls")).click()
+
+
 # ── Server fixtures ──────────────────────────────────────────────────────────
 
 
@@ -119,24 +134,22 @@ class TestSetupPageTlsToggle:
         """Enabling TLS should auto-switch port from 8080 to 443."""
         page.goto(provision_server)
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
         port.fill("8080")
         assert port.input_value() == "8080"
 
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "443"
 
     def test_disable_tls_clears_port(self, page, provision_server):
         """Disabling TLS should clear port back to empty (placeholder 8080)."""
         page.goto(provision_server)
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "443"
 
-        tls.uncheck(force=True)
+        _set_tls(page, False)
         assert port.input_value() == ""
         assert port.get_attribute("placeholder") == "8080"
 
@@ -144,20 +157,18 @@ class TestSetupPageTlsToggle:
         """A custom port (not 8080/443) should NOT be auto-switched."""
         page.goto(provision_server)
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
         port.fill("9443")
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "9443"
 
     def test_empty_port_becomes_443_on_tls(self, page, provision_server):
         """Empty port should become 443 when TLS is enabled."""
         page.goto(provision_server)
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
         port.fill("")
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "443"
 
 
@@ -176,28 +187,26 @@ class TestReconfigurePageTlsToggle:
     def test_enable_tls_switches_port(self, page, provision_server):
         page.goto(f"{provision_server}/reconfigure")
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
         port.fill("8080")
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "443"
 
     def test_disable_tls_clears_port(self, page, provision_server):
         page.goto(f"{provision_server}/reconfigure")
         port = page.locator("#cms-port")
-        tls = page.locator("#cms-tls")
 
-        tls.check(force=True)
+        _set_tls(page, True)
         assert port.input_value() == "443"
 
-        tls.uncheck(force=True)
+        _set_tls(page, False)
         assert port.input_value() == ""
 
     def test_form_submits_tls_flag(self, page, provision_server):
         """Submitting the reconfigure form should include cms_tls in the payload."""
         page.goto(f"{provision_server}/reconfigure")
         page.fill("#cms-host", "cms.example.com")
-        page.check("#cms-tls", force=True)
+        _set_tls(page, True)
 
         with page.expect_request("**/api/reconfigure") as req_info:
             page.click("#submit-btn")

--- a/tests/test_wss_e2e.py
+++ b/tests/test_wss_e2e.py
@@ -110,7 +110,9 @@ class TestSetupPageTlsToggle:
     def test_tls_checkbox_present_and_unchecked(self, page, provision_server):
         page.goto(provision_server)
         checkbox = page.locator("#cms-tls")
-        assert checkbox.is_visible()
+        # Native input is visually hidden by the slider CSS — assert the
+        # slider wrapper is visible instead.
+        assert page.locator(".toggle-switch").first.is_visible()
         assert not checkbox.is_checked()
 
     def test_enable_tls_switches_port_to_443(self, page, provision_server):
@@ -122,7 +124,7 @@ class TestSetupPageTlsToggle:
         port.fill("8080")
         assert port.input_value() == "8080"
 
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "443"
 
     def test_disable_tls_clears_port(self, page, provision_server):
@@ -131,10 +133,10 @@ class TestSetupPageTlsToggle:
         port = page.locator("#cms-port")
         tls = page.locator("#cms-tls")
 
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "443"
 
-        tls.uncheck()
+        tls.uncheck(force=True)
         assert port.input_value() == ""
         assert port.get_attribute("placeholder") == "8080"
 
@@ -145,7 +147,7 @@ class TestSetupPageTlsToggle:
         tls = page.locator("#cms-tls")
 
         port.fill("9443")
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "9443"
 
     def test_empty_port_becomes_443_on_tls(self, page, provision_server):
@@ -155,7 +157,7 @@ class TestSetupPageTlsToggle:
         tls = page.locator("#cms-tls")
 
         port.fill("")
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "443"
 
 
@@ -168,7 +170,7 @@ class TestReconfigurePageTlsToggle:
     def test_tls_checkbox_present_and_unchecked(self, page, provision_server):
         page.goto(f"{provision_server}/reconfigure")
         checkbox = page.locator("#cms-tls")
-        assert checkbox.is_visible()
+        assert page.locator(".toggle-switch").first.is_visible()
         assert not checkbox.is_checked()
 
     def test_enable_tls_switches_port(self, page, provision_server):
@@ -177,7 +179,7 @@ class TestReconfigurePageTlsToggle:
         tls = page.locator("#cms-tls")
 
         port.fill("8080")
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "443"
 
     def test_disable_tls_clears_port(self, page, provision_server):
@@ -185,17 +187,17 @@ class TestReconfigurePageTlsToggle:
         port = page.locator("#cms-port")
         tls = page.locator("#cms-tls")
 
-        tls.check()
+        tls.check(force=True)
         assert port.input_value() == "443"
 
-        tls.uncheck()
+        tls.uncheck(force=True)
         assert port.input_value() == ""
 
     def test_form_submits_tls_flag(self, page, provision_server):
         """Submitting the reconfigure form should include cms_tls in the payload."""
         page.goto(f"{provision_server}/reconfigure")
         page.fill("#cms-host", "cms.example.com")
-        page.check("#cms-tls")
+        page.check("#cms-tls", force=True)
 
         with page.expect_request("**/api/reconfigure") as req_info:
             page.click("#submit-btn")


### PR DESCRIPTION
## Summary

User reported during OOBE that the captive portal **Use TLS** label was way off to one side from its checkbox, and asked for the fancier slider-style toggle used on the CMS Stream Asset "Save locally" control.

## What changed

- `provision/static/setup.css` — new `.toggle-switch` / `.slider` rules, copied verbatim from `cms/static/style.css` so visual style matches across CMS + captive portal.
- `provision/templates/setup.html` and `provision/templates/reconfigure.html` — replace the inline-styled `<label>` + plain checkbox with `.toggle-row` + `.toggle-switch` markup. `onchange` still fires `onTlsToggle(this.checked)` so all existing JS keeps working.

## Test

- 69 relevant unit tests pass locally (provision/oobe/wss_support).
- Visual change only; will verify on test Pi after merge.
