### PR TITLE
provision: harden captive portal (smart-quote IDN, port-80 race, wifi-up shortcut)

### DIFF
--- a/provision/app.py
+++ b/provision/app.py
@@ -15,13 +15,14 @@ provision submitted, CMS reconfigured).
 import asyncio
 import json
 import logging
+import re
 import socket
 import time
 from dataclasses import asdict
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from provision.network import (
@@ -37,6 +38,82 @@ PERSIST_DIR = Path("/opt/agora/persist")
 STATE_DIR = Path("/opt/agora/state")
 CMS_MDNS_HOST = "agora-cms.local"
 CMS_DEFAULT_PORT = 8080
+
+# ── Hostname normalization ──────────────────────────────────────────────────
+#
+# Mobile keyboards routinely autocorrect ``'`` to a curly apostrophe (U+2019)
+# and ``"`` to curly quotes; if those make it into the CMS host field, Python
+# / aiohttp will silently IDN-encode the result (e.g. ``Kennan’s.com`` →
+# ``xn--kennans-d36c.com``) and DNS lookups will fail in confusing ways.
+# Strip them defensively and validate the result against RFC 1123.
+
+_SMART_QUOTE_TRANS = str.maketrans({
+    "\u2018": "",  # left single
+    "\u2019": "",  # right single (typical autocorrect target)
+    "\u201A": "",  # single low-9
+    "\u201B": "",  # high-reversed-9
+    "\u201C": "",  # left double
+    "\u201D": "",  # right double
+    "\u201E": "",  # double low-9
+    "\u2032": "",  # prime
+    "\u2033": "",  # double prime
+    "\u00B4": "",  # acute accent
+    "\u02BC": "",  # modifier letter apostrophe
+})
+
+_HOSTNAME_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+_HOSTNAME_RE = re.compile(rf"^{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*$")
+
+
+def _normalize_cms_host(
+    raw: str, cms_tls: bool, cms_port: int,
+) -> tuple[str, int, bool, str | None]:
+    """Strip URL prefixes, smart quotes, and validate the CMS host.
+
+    Returns ``(host, port, tls, error)``. If ``error`` is non-None, the
+    host failed RFC 1123 validation and the caller should reject the
+    request. Empty input falls back to ``CMS_MDNS_HOST`` with no error.
+    """
+    host = (raw or "").strip().translate(_SMART_QUOTE_TRANS)
+    if not host:
+        return CMS_MDNS_HOST, cms_port, cms_tls, None
+
+    lower = host.lower()
+    for prefix in ("wss://", "https://", "ws://", "http://"):
+        if lower.startswith(prefix):
+            if prefix in ("wss://", "https://"):
+                cms_tls = True
+            host = host[len(prefix):]
+            break
+
+    for sep in ("/", "?", "#"):
+        host = host.split(sep, 1)[0]
+
+    if host.count(":") == 1:
+        h, _, p = host.rpartition(":")
+        try:
+            cms_port = int(p)
+            host = h
+        except ValueError:
+            pass
+
+    if not _HOSTNAME_RE.match(host):
+        return host, cms_port, cms_tls, (
+            f"Invalid CMS host '{host}'. Use letters, digits, dots, and "
+            "hyphens only (e.g. agora-cms.local)."
+        )
+
+    return host, cms_port, cms_tls, None
+
+
+def _build_cms_url(host: str, port: int, tls: bool) -> str:
+    """Build the wss/ws URL for the device websocket endpoint."""
+    scheme = "wss" if tls else "ws"
+    if tls and port == 443:
+        return f"{scheme}://{host}/ws/device"
+    if not tls and port == 80:
+        return f"{scheme}://{host}/ws/device"
+    return f"{scheme}://{host}:{port}/ws/device"
 
 # ── Event queues (consumed by provision/service.py) ──────────────────────────
 
@@ -169,7 +246,7 @@ async def provision(request: Request):
 
     wifi_ssid = body.get("wifi_ssid", "").strip()
     wifi_password = body.get("wifi_password", "")
-    cms_host = body.get("cms_host", "").strip() or CMS_MDNS_HOST
+    raw_cms_host = body.get("cms_host", "")
     cms_port = int(body.get("cms_port", CMS_DEFAULT_PORT))
     cms_tls = bool(body.get("cms_tls", False))
     device_name = body.get("device_name", "").strip()
@@ -177,44 +254,31 @@ async def provision(request: Request):
     if not wifi_ssid:
         return {"success": False, "error": "Wi-Fi network is required"}
 
-    # Save CMS config (defaults to mDNS host if not provided)
-    if cms_host:
-        # Strip protocol prefixes
-        for prefix in ("ws://", "wss://", "http://", "https://"):
-            if cms_host.startswith(prefix):
-                if prefix in ("wss://", "https://"):
-                    cms_tls = True
-                cms_host = cms_host[len(prefix):]
-        cms_host = cms_host.split("/")[0]
-        if ":" in cms_host:
-            parts = cms_host.rsplit(":", 1)
-            cms_host = parts[0]
-            try:
-                cms_port = int(parts[1])
-            except ValueError:
-                pass
+    cms_host, cms_port, cms_tls, host_error = _normalize_cms_host(
+        raw_cms_host, cms_tls, cms_port,
+    )
+    if host_error:
+        return JSONResponse(
+            {"success": False, "error": host_error}, status_code=400,
+        )
 
-        # Default port based on TLS
-        if cms_tls and cms_port == CMS_DEFAULT_PORT:
-            cms_port = 443
+    # Default port based on TLS
+    if cms_tls and cms_port == CMS_DEFAULT_PORT:
+        cms_port = 443
 
-        scheme = "wss" if cms_tls else "ws"
-        if cms_tls and cms_port == 443:
-            cms_url = f"{scheme}://{cms_host}/ws/device"
-        else:
-            cms_url = f"{scheme}://{cms_host}:{cms_port}/ws/device"
+    cms_url = _build_cms_url(cms_host, cms_port, cms_tls)
 
-        cms_config = {
-            "cms_host": cms_host,
-            "cms_port": cms_port,
-            "cms_tls": cms_tls,
-            "cms_url": cms_url,
-        }
-        cms_config_path = PERSIST_DIR / "cms_config.json"
-        cms_config_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = cms_config_path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(cms_config, indent=2))
-        tmp.replace(cms_config_path)
+    cms_config = {
+        "cms_host": cms_host,
+        "cms_port": cms_port,
+        "cms_tls": cms_tls,
+        "cms_url": cms_url,
+    }
+    cms_config_path = PERSIST_DIR / "cms_config.json"
+    cms_config_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = cms_config_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(cms_config, indent=2))
+    tmp.replace(cms_config_path)
 
     # Save device name if provided
     if device_name:
@@ -279,37 +343,23 @@ async def get_cms_config():
 async def reconfigure(request: Request):
     """Update CMS configuration (called from reconfigure page)."""
     body = await request.json()
-    cms_host = body.get("cms_host", "").strip()
+    raw_cms_host = body.get("cms_host", "")
     cms_port = int(body.get("cms_port", CMS_DEFAULT_PORT))
     cms_tls = bool(body.get("cms_tls", False))
 
-    if not cms_host:
-        cms_host = CMS_MDNS_HOST
-
-    # Strip protocol prefixes
-    for prefix in ("ws://", "wss://", "http://", "https://"):
-        if cms_host.startswith(prefix):
-            if prefix in ("wss://", "https://"):
-                cms_tls = True
-            cms_host = cms_host[len(prefix):]
-    cms_host = cms_host.split("/")[0]
-    if ":" in cms_host:
-        parts = cms_host.rsplit(":", 1)
-        cms_host = parts[0]
-        try:
-            cms_port = int(parts[1])
-        except ValueError:
-            pass
+    cms_host, cms_port, cms_tls, host_error = _normalize_cms_host(
+        raw_cms_host, cms_tls, cms_port,
+    )
+    if host_error:
+        return JSONResponse(
+            {"success": False, "error": host_error}, status_code=400,
+        )
 
     # Default port based on TLS
     if cms_tls and cms_port == CMS_DEFAULT_PORT:
         cms_port = 443
 
-    scheme = "wss" if cms_tls else "ws"
-    if cms_tls and cms_port == 443:
-        cms_url = f"{scheme}://{cms_host}/ws/device"
-    else:
-        cms_url = f"{scheme}://{cms_host}:{cms_port}/ws/device"
+    cms_url = _build_cms_url(cms_host, cms_port, cms_tls)
 
     cms_config = {
         "cms_host": cms_host,

--- a/provision/service.py
+++ b/provision/service.py
@@ -277,6 +277,28 @@ def _stop_spinner(stop_event: threading.Event, thread: threading.Thread | None) 
         thread.join(timeout=2)
 
 
+async def _wait_port_free(host: str, port: int, timeout: float = 10.0) -> bool:
+    """Wait for the given TCP port to become bindable.
+
+    Used before starting uvicorn for the reconfigure server so we don't
+    crash with ``OSError(EADDRINUSE)`` when a previous reconfigure
+    instance is still tearing down its listening socket. Returns True
+    once the port is free, False on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind((host, port))
+            s.close()
+            return True
+        except OSError:
+            s.close()
+            await asyncio.sleep(0.5)
+    return False
+
+
 def _try_mdns_discovery() -> bool:
     """Try mDNS auto-discovery for CMS and save config if found.
 
@@ -506,6 +528,17 @@ async def _run_reconfigure_server(
         except asyncio.QueueEmpty:
             break
 
+    # Wait for port 80 to be free. A previous reconfigure cycle may still
+    # be releasing its listening socket; without this we'd crash with
+    # OSError(EADDRINUSE), which uvicorn turns into ``sys.exit(1)`` and
+    # kills the entire provisioning service.
+    if not await _wait_port_free("0.0.0.0", PORTAL_PORT, timeout=10):
+        logger.error(
+            "Port %d still in use after 10s — skipping reconfigure server",
+            PORTAL_PORT,
+        )
+        return False
+
     config = uvicorn.Config(
         app, host="0.0.0.0", port=PORTAL_PORT,
         log_level="info", access_log=False,
@@ -533,8 +566,22 @@ async def _run_reconfigure_server(
                 server.should_exit = True
                 return
 
+    async def _serve_safe():
+        # Wrap server.serve() so a late EADDRINUSE (or any uvicorn
+        # bind error that triggers SystemExit) doesn't take down the
+        # whole provisioning service.
+        try:
+            await server.serve()
+        except SystemExit as e:
+            logger.error(
+                "Reconfigure server exited unexpectedly (SystemExit %s) — "
+                "likely port %d collision", e.code, PORTAL_PORT,
+            )
+        except OSError as e:
+            logger.error("Reconfigure server OSError: %s", e)
+
     tasks = [
-        asyncio.create_task(server.serve()),
+        asyncio.create_task(_serve_safe()),
         asyncio.create_task(_watch_shutdown()),
         asyncio.create_task(_watch_reconfigure()),
     ]
@@ -547,7 +594,8 @@ async def _run_reconfigure_server(
             await t
         except asyncio.CancelledError:
             pass
-    # Re-raise any exception from completed tasks
+    # Re-raise any exception from completed tasks (SystemExit/OSError
+    # are already swallowed inside _serve_safe).
     for t in done:
         if t.exception():
             raise t.exception()
@@ -733,6 +781,35 @@ async def run_service(force_oobe: bool = False) -> None:
 
         # ── Phase 1: Wi-Fi provisioning (loops on failure) ───────────
         while not shutdown_event.is_set():
+            # If Wi-Fi is already up — e.g. the provisioning service was
+            # restarted while we were mid-OOBE, or the user pre-configured
+            # NetworkManager — skip AP/portal entirely and go straight to
+            # Phase 2 (CMS adoption). Without this guard, restarting the
+            # service tears down the existing Wi-Fi connection just to
+            # re-establish it.
+            if _wait_for_wifi(timeout=5):
+                logger.info(
+                    "Wi-Fi already connected — skipping AP/portal phase",
+                )
+                _stop_spinner(welcome_spinner_stop, welcome_spinner_thread)
+
+                # Make sure the support services are running. They may
+                # already be up; ``systemctl start`` is idempotent.
+                for svc_name in ("agora-cms-client", "agora-api"):
+                    proc = await asyncio.create_subprocess_exec(
+                        "sudo", "systemctl", "start", svc_name,
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await proc.wait()
+
+                if not _get_cms_host():
+                    _try_mdns_discovery()
+
+                display.show_wifi_connected(get_active_ssid() or "")
+                await asyncio.sleep(OOBE_DISPLAY_HOLD)
+                break
+
             # Prepare the phone-connect spinner (started after AP is up)
             phone_spinner_stop = threading.Event()
             phone_spinner_thread = threading.Thread(

--- a/provision/templates/reconfigure.html
+++ b/provision/templates/reconfigure.html
@@ -23,7 +23,10 @@
                 <div class="form-row">
                     <div class="grow">
                         <label for="cms-host">Server Address</label>
-                        <input type="text" id="cms-host" placeholder="agora-cms.local">
+                        <input type="text" id="cms-host" placeholder="agora-cms.local"
+                               autocapitalize="off" autocorrect="off"
+                               spellcheck="false" inputmode="url"
+                               oninput="stripSmartChars(this)">
                     </div>
                     <div class="port">
                         <label for="cms-port">Port</label>
@@ -47,6 +50,16 @@
     </div>
 
     <script>
+    function stripSmartChars(el) {
+        var v = el.value;
+        var clean = v.replace(/[\u2018\u2019\u201A\u201B\u201C\u201D\u201E\u2032\u2033\u00B4\u02BC]/g, "");
+        if (clean !== v) {
+            var pos = el.selectionStart;
+            el.value = clean;
+            try { el.setSelectionRange(pos, pos); } catch (e) {}
+        }
+    }
+
     function onTlsToggle(checked) {
         var portEl = document.getElementById("cms-port");
         if (checked && (portEl.value === "8080" || portEl.value === "")) {

--- a/provision/templates/setup.html
+++ b/provision/templates/setup.html
@@ -37,7 +37,10 @@
                 <div class="form-row">
                     <div class="grow">
                         <label for="cms-host">Server Address</label>
-                        <input type="text" id="cms-host" placeholder="agora-cms.local">
+                        <input type="text" id="cms-host" placeholder="agora-cms.local"
+                               autocapitalize="off" autocorrect="off"
+                               spellcheck="false" inputmode="url"
+                               oninput="stripSmartChars(this)">
                     </div>
                     <div class="port">
                         <label for="cms-port">Port</label>
@@ -69,6 +72,21 @@
     </div>
 
     <script>
+    /* ── Smart-char stripper ──
+       Mobile keyboards autocorrect ' " etc. into curly Unicode chars
+       (U+2018-U+201D, U+2032/U+2033, U+00B4, U+02BC), which produce
+       invalid IDN-encoded hostnames downstream. Strip them as the user
+       types so the field always contains plain ASCII. */
+    function stripSmartChars(el) {
+        var v = el.value;
+        var clean = v.replace(/[\u2018\u2019\u201A\u201B\u201C\u201D\u201E\u2032\u2033\u00B4\u02BC]/g, "");
+        if (clean !== v) {
+            var pos = el.selectionStart;
+            el.value = clean;
+            try { el.setSelectionRange(pos, pos); } catch (e) {}
+        }
+    }
+
     /* ── TLS toggle ── */
     function onTlsToggle(checked) {
         var portEl = document.getElementById("cms-port");

--- a/tests/test_provision_host_normalize.py
+++ b/tests/test_provision_host_normalize.py
@@ -1,0 +1,236 @@
+"""Unit tests for ``provision.app._normalize_cms_host``.
+
+The captive portal must defensively strip URL prefixes, smart quotes
+(autocorrect victims), and validate the result against RFC 1123 so that
+malformed hostnames don't get silently IDN-encoded into garbage that
+fails DNS in mysterious ways.
+"""
+
+from provision.app import (
+    CMS_DEFAULT_PORT,
+    CMS_MDNS_HOST,
+    _normalize_cms_host,
+)
+
+
+# ── Empty / trivial input ────────────────────────────────────────────────────
+
+
+def test_empty_string_falls_back_to_mdns_default():
+    host, port, tls, err = _normalize_cms_host("", False, CMS_DEFAULT_PORT)
+    assert host == CMS_MDNS_HOST
+    assert port == CMS_DEFAULT_PORT
+    assert tls is False
+    assert err is None
+
+
+def test_whitespace_only_falls_back_to_mdns_default():
+    host, port, tls, err = _normalize_cms_host("   ", False, CMS_DEFAULT_PORT)
+    assert host == CMS_MDNS_HOST
+    assert err is None
+
+
+def test_plain_hostname_passes_through():
+    host, port, tls, err = _normalize_cms_host(
+        "agora-cms.local", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "agora-cms.local"
+    assert port == CMS_DEFAULT_PORT
+    assert tls is False
+    assert err is None
+
+
+# ── Smart-quote stripping ────────────────────────────────────────────────────
+
+
+def test_right_single_quote_is_stripped():
+    """U+2019 is what iOS autocorrects ' into."""
+    host, _, _, err = _normalize_cms_host(
+        "kennan\u2019s.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "kennans.com"
+    assert err is None
+
+
+def test_left_single_quote_is_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "\u2018foo.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "foo.com"
+    assert err is None
+
+
+def test_double_smart_quotes_are_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "\u201Cfoo.com\u201D", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "foo.com"
+    assert err is None
+
+
+def test_acute_accent_is_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "fo\u00B4o.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "foo.com"
+    assert err is None
+
+
+# ── URL prefix stripping ─────────────────────────────────────────────────────
+
+
+def test_https_prefix_implies_tls_and_strips():
+    host, _, tls, err = _normalize_cms_host(
+        "https://cms.example.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert tls is True
+    assert err is None
+
+
+def test_wss_prefix_implies_tls_and_strips():
+    host, _, tls, err = _normalize_cms_host(
+        "wss://cms.example.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert tls is True
+    assert err is None
+
+
+def test_http_prefix_does_not_force_tls():
+    host, _, tls, err = _normalize_cms_host(
+        "http://cms.example.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert tls is False
+    assert err is None
+
+
+def test_ws_prefix_strips_without_changing_tls():
+    host, _, tls, err = _normalize_cms_host(
+        "ws://cms.example.com", True, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    # ws:// does not downgrade an explicit TLS=True setting.
+    assert tls is True
+    assert err is None
+
+
+def test_uppercase_prefix_is_handled():
+    host, _, tls, _ = _normalize_cms_host(
+        "HTTPS://cms.example.com", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert tls is True
+
+
+# ── Path / query / fragment stripping ────────────────────────────────────────
+
+
+def test_path_is_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "cms.example.com/some/path", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert err is None
+
+
+def test_query_is_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "cms.example.com?foo=bar", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert err is None
+
+
+def test_fragment_is_stripped():
+    host, _, _, err = _normalize_cms_host(
+        "cms.example.com#anchor", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert err is None
+
+
+def test_full_url_with_prefix_path_and_query():
+    host, _, tls, err = _normalize_cms_host(
+        "https://cms.example.com/admin?token=x", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert tls is True
+    assert err is None
+
+
+# ── Port parsing ─────────────────────────────────────────────────────────────
+
+
+def test_port_extracted_from_host_string():
+    host, port, _, err = _normalize_cms_host(
+        "cms.example.com:9090", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert port == 9090
+    assert err is None
+
+
+def test_invalid_port_value_falls_back_to_default():
+    host, port, _, err = _normalize_cms_host(
+        "cms.example.com:notaport", False, 1234,
+    )
+    # Bad port suffix should fail validation, not silently work
+    assert err is not None
+
+
+def test_host_with_prefix_and_port():
+    host, port, tls, err = _normalize_cms_host(
+        "https://cms.example.com:8443", False, CMS_DEFAULT_PORT,
+    )
+    assert host == "cms.example.com"
+    assert port == 8443
+    assert tls is True
+    assert err is None
+
+
+# ── Validation rejects garbage ───────────────────────────────────────────────
+
+
+def test_space_in_hostname_rejected():
+    _, _, _, err = _normalize_cms_host(
+        "cms example.com", False, CMS_DEFAULT_PORT,
+    )
+    assert err is not None
+    assert "Invalid CMS host" in err
+
+
+def test_underscore_rejected():
+    _, _, _, err = _normalize_cms_host(
+        "cms_server.local", False, CMS_DEFAULT_PORT,
+    )
+    # Underscores are not valid in RFC 1123 hostnames.
+    assert err is not None
+
+
+def test_leading_hyphen_rejected():
+    _, _, _, err = _normalize_cms_host(
+        "-cms.local", False, CMS_DEFAULT_PORT,
+    )
+    assert err is not None
+
+
+def test_unicode_letters_rejected():
+    _, _, _, err = _normalize_cms_host(
+        "kennan\u00e9.com", False, CMS_DEFAULT_PORT,
+    )
+    assert err is not None
+
+
+def test_smart_quote_only_garbage_after_strip_rejected():
+    """If the string was entirely smart quotes, the post-strip empty
+    string falls back to mDNS default — that's fine. But mixed garbage
+    that survives stripping but isn't a valid hostname must be rejected.
+    """
+    _, _, _, err = _normalize_cms_host(
+        "kennan\u2019s house.com", False, CMS_DEFAULT_PORT,
+    )
+    # After stripping U+2019 we still have "kennans house.com" with a
+    # literal space, which is invalid.
+    assert err is not None


### PR DESCRIPTION
## Summary

Live testing of the QR-OOBE captive portal on a real Pi exposed three real bugs. Bundling all three into one provision/ subsystem PR.

## 1. Smart-quote / IDN trap

iOS autocorrects `'` → `\u2019` and Python silently IDN-encodes any non-ASCII hostname, so `kennan'Ε's.com` becomes `xn--kennans-d36c.com` and DNS lookups fail with no useful error.

- New `_normalize_cms_host()` strips smart quotes (U+2018-U+201E, U+2032/U+2033, U+00B4, U+02BC), URL prefixes (`wss://`, `https://`, `ws://`, `http://`), trailing paths/queries/fragments, and parses the port. Validates the result against an RFC 1123 regex.
- Both `/api/provision` and `/api/reconfigure` use it; on invalid input they return a 400 JSON response instead of accepting garbage.
- `setup.html` and `reconfigure.html` add `inputmode="url"`, `autocorrect="off"`, `spellcheck="false"`, and an `oninput` handler that strips the smart quotes as the user types — so the bad characters never reach the server.
- 24 new unit tests in `tests/test_provision_host_normalize.py`.

## 2. Port-80 EADDRINUSE crashes the entire provisioning service

On consecutive CMS-adoption failures, the outer Phase 2 loop calls `_run_reconfigure_server()` again before the previous uvicorn instance has fully released port 80. uvicorn handles bind failure with `sys.exit(1)`, which propagates up through `asyncio.wait()`'s `done` set and kills `run_service`.

- New `_wait_port_free()` async helper polls the bind for up to 10s before starting uvicorn.
- `server.serve()` is now wrapped in a `_serve_safe()` coroutine that swallows `SystemExit` / `OSError` so a late bind failure logs and returns False instead of taking down the service.

## 3. Restarting `agora-provision` tears down working Wi-Fi

When the service restarts before `is_provisioned()` flips, Phase 1 (AP/portal) runs unconditionally even if Wi-Fi is already up. Reproduced today: I restarted the service to pick up a fix and it knocked the Pi off the network mid-test.

- Added a `_wait_for_wifi(timeout=5)` short-circuit at the top of the Phase 1 OOBE loop. If Wi-Fi is up, we start `agora-cms-client` + `agora-api`, try mDNS if no CMS host is configured, show the wifi-connected screen, and skip straight to Phase 2.

## Test plan

- **Local**: 635 passed, 25 skipped (Windows/Python 3.14 compat — same as previous PRs).
- **New unit tests**: 24/24 pass on `tests/test_provision_host_normalize.py`.
- **Field validation**: will repro all three bugs on test Pi 192.168.1.53 after the firmware tag is cut and OTA'd.
