### PR TITLE
fix(provision,cms_client): publish connected/pending during bootstrap-v2 polling, ignore stale-negative cms_status leftovers

### DIFF
--- a/cms_client/bootstrap_boot.py
+++ b/cms_client/bootstrap_boot.py
@@ -43,7 +43,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from shared.bootstrap_identity import (
     DeviceIdentity,
@@ -254,6 +254,7 @@ async def ensure_wps_credentials(
     fleet_secret: bytes,
     metadata: Optional[dict] = None,
     poll_cancel_event: Optional[asyncio.Event] = None,
+    on_pending_registered: Optional[Callable[[], None]] = None,
     now_unix: Optional[float] = None,
 ) -> BootstrapCredentials:
     """Return a valid ``BootstrapCredentials`` for opening a WPS connection.
@@ -283,6 +284,13 @@ async def ensure_wps_credentials(
     :param poll_cancel_event: optional ``asyncio.Event`` — if set during
         first-boot polling, the loop stops promptly and raises
         :class:`BootstrapCancelledError`.
+    :param on_pending_registered: optional sync callback invoked once
+        ``/register`` has succeeded on the first-boot path (and again
+        if ``_poll_until_adopted`` re-registers after a pending-row
+        reap).  Lets the caller publish a "pending adoption" status
+        before we block in ``_poll_until_adopted``.  Not called on the
+        cached/refresh paths — those don't re-register.  Exceptions
+        from the callback are swallowed.
     :param now_unix: clock override for tests.
 
     :raises BootstrapConfigError: first-boot path entered with empty
@@ -341,6 +349,7 @@ async def ensure_wps_credentials(
         fleet_secret=fleet_secret,
         metadata=metadata,
     )
+    _safe_call(on_pending_registered)
     logger.info("Registered; polling /bootstrap-status until adopted")
 
     await _poll_until_adopted(
@@ -353,6 +362,7 @@ async def ensure_wps_credentials(
         device_id=device_id,
         metadata=metadata,
         poll_cancel_event=poll_cancel_event,
+        on_pending_registered=on_pending_registered,
     )
     # _poll_until_adopted returned without raising → device is adopted
     # and we know the decrypted device_id from the outbox.
@@ -388,6 +398,20 @@ async def ensure_wps_credentials(
     )
 
 
+def _safe_call(cb: Optional[Callable[[], None]]) -> None:
+    """Invoke a sync callback, swallowing/logging any exception.
+
+    Used for the ``on_pending_registered`` hook so a buggy callback
+    cannot break the bootstrap flow.
+    """
+    if cb is None:
+        return
+    try:
+        cb()
+    except Exception:
+        logger.debug("bootstrap callback raised", exc_info=True)
+
+
 async def _poll_until_adopted(
     session: Any,
     *,
@@ -399,6 +423,7 @@ async def _poll_until_adopted(
     device_id: str,
     metadata: Optional[dict],
     poll_cancel_event: Optional[asyncio.Event],
+    on_pending_registered: Optional[Callable[[], None]] = None,
 ) -> None:
     """Poll /bootstrap-status until the operator adopts.
 
@@ -429,6 +454,7 @@ async def _poll_until_adopted(
                     fleet_secret=fleet_secret,
                     metadata=metadata,
                 )
+                _safe_call(on_pending_registered)
             except PubkeyMismatchError:
                 # Extremely unlikely (row just got reaped).  Give up and
                 # let the caller handle it.

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -322,6 +322,19 @@ class CMSClient:
             pass
         return self.settings.cms_url
 
+    def _on_bootstrap_pending_registered(self) -> None:
+        """Bootstrap-v2 callback: pending row registered, awaiting adoption.
+
+        Fired once after ``register_once`` succeeds in
+        ``bootstrap_boot.ensure_wps_credentials`` (and again on
+        re-registration after a pending-row reap).  Publishes
+        ``connected/pending`` so provision's ``_wait_for_cms_adoption``
+        can switch the device's display from the spinner to the
+        pairing-QR adoption screen — even though the WebSocket isn't
+        actually open yet.
+        """
+        self._write_cms_status("connected", registration="pending")
+
     def _write_cms_status(
         self,
         state: str,
@@ -547,6 +560,7 @@ class CMSClient:
                 fleet_secret=fleet_secret,
                 metadata=metadata,
                 poll_cancel_event=self._bootstrap_poll_cancel,
+                on_pending_registered=self._on_bootstrap_pending_registered,
             )
         except Exception:
             await session.close()
@@ -577,6 +591,14 @@ class CMSClient:
             # _config_watch_loop and stop() to interrupt slow first-boot
             # polling when cms_url changes or shutdown is requested.
             self._bootstrap_poll_cancel = asyncio.Event()
+            # Publish a fresh "connecting" status BEFORE the (potentially
+            # slow) bootstrap-v2 HTTPS handshake.  This overwrites any
+            # stale "disconnected/error" entry from a previous run so
+            # provision's _wait_for_cms_adoption doesn't latch onto it.
+            self._write_cms_status(
+                "connecting",
+                message="Registering with CMS\u2026",
+            )
             try:
                 creds, http_session, bootstrap_api_base = (
                     await self._mint_wps_credentials_v2(cms_url)

--- a/provision/service.py
+++ b/provision/service.py
@@ -34,6 +34,7 @@ import socket
 import sys
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import uvicorn
@@ -84,6 +85,16 @@ WIFI_RETRY_DELAY = 5        # seconds between Wi-Fi retries
 
 CMS_ADOPT_TIMEOUT = 300     # 5 minutes waiting for CMS adoption
 CMS_ERROR_THRESHOLD = 5     # consecutive CMS errors → trigger reconfigure
+# Maximum age (seconds) before a NEGATIVE cms_status.json entry
+# (state=error or state=disconnected+error) is treated as stale and
+# ignored.  Bootstrap-v2 polling can block for many minutes between
+# status writes, and a leftover negative entry from a previous run
+# would otherwise make _wait_for_cms_adoption hit CMS_ERROR_THRESHOLD
+# in ~10s and bounce into reconfigure.  Positive states
+# (connected/pending or connected/registered) are NEVER stale-filtered
+# — fresh adoption signals must always be honored, even if their
+# timestamp predates the start of this wait by a few ms.
+CMS_STATUS_STALE_NEG_SEC = 30.0
 
 CMS_MDNS_HOST = "agora-cms.local"
 CMS_MDNS_PORT = 8080
@@ -261,6 +272,42 @@ def _read_cms_status() -> dict:
         return {}
 
 
+def _is_status_negative_stale(status: dict, now: float | None = None) -> bool:
+    """Return True if a NEGATIVE cms_status entry should be ignored as stale.
+
+    A status is "negative" when ``state`` is ``error`` OR
+    ``state == "disconnected"`` AND a non-empty ``error`` is set.
+    Anything else (connected/pending, connected/registered,
+    connecting, plain disconnected with no error) is never considered
+    stale by this function — those are either positive or explicitly
+    transient and must always be honored.
+
+    A negative status is considered stale when its ``timestamp`` is
+    older than :data:`CMS_STATUS_STALE_NEG_SEC` seconds — or, if the
+    timestamp is missing/unparseable during OOBE, conservatively
+    treated as stale so the device doesn't latch onto a corrupt
+    leftover entry from a previous run.
+    """
+    state = status.get("state", "")
+    error = status.get("error", "")
+    is_negative = state == "error" or (state == "disconnected" and bool(error))
+    if not is_negative:
+        return False
+    ts_str = status.get("timestamp", "")
+    if not ts_str:
+        # Missing timestamp on a negative entry — treat as stale.
+        return True
+    try:
+        # Python <3.11 doesn't accept "Z"; normalize.
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return True
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc).timestamp() - ts.timestamp()
+    return age > CMS_STATUS_STALE_NEG_SEC
+
+
 def _get_cms_host() -> str:
     """Read CMS host from the persisted config."""
     try:
@@ -418,6 +465,20 @@ async def _wait_for_cms_adoption(
         deadline = time.monotonic() + CMS_ADOPT_TIMEOUT
         while not shutdown_event.is_set() and time.monotonic() < deadline:
             status = _read_cms_status()
+            # Filter out leftover negative entries from a previous run.
+            # cms-client doesn't write status during the (potentially
+            # multi-minute) bootstrap-v2 polling window, so without
+            # this guard a stale "error"/"disconnected+error" entry
+            # would dominate the loop and bounce us into reconfigure
+            # before the QR screen ever shows.
+            if _is_status_negative_stale(status):
+                status = {
+                    "state": "connecting",
+                    "error": "",
+                    "message": "",
+                    "registration": "",
+                    "timestamp": status.get("timestamp", ""),
+                }
             state = status.get("state", "")
             registration = status.get("registration", "")
 

--- a/tests/test_bootstrap_boot.py
+++ b/tests/test_bootstrap_boot.py
@@ -470,6 +470,227 @@ class TestEnsureWpsCredentialsFirstBoot:
                 poll_cancel_event=cancel,
             )
 
+    @pytest.mark.asyncio
+    async def test_on_pending_registered_fires_after_register(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        """First-boot path: callback fires once after register_once()."""
+        monkeypatch.setattr(
+            bootstrap_boot, "decrypt_adopt_payload",
+            lambda seed, payload_b64: b'{"device_id": "pi-1"}',
+        )
+
+        register_done = asyncio.Event()
+        async def fake_register(session, base, **kw):
+            register_done.set()
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+
+        callback_log: list[bool] = []
+        def on_pending():
+            # Capture whether register has completed by the time the
+            # callback fires — must be True (post-register, pre-poll).
+            callback_log.append(register_done.is_set())
+
+        async def fake_status(session, base, *, pubkey_b64):
+            return BootstrapStatus(status="adopted", payload_b64="x")
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", fake_status,
+        )
+        async def fake_fetch(session, base, *, device_id, seed):
+            return _fresh_token(60)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+        async def no_sleep(*a, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot.asyncio, "sleep", no_sleep)
+
+        await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-abc",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=tmp_path / "s.json",
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+            on_pending_registered=on_pending,
+        )
+        assert callback_log == [True]
+
+    @pytest.mark.asyncio
+    async def test_on_pending_registered_fires_again_on_reregister(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        """Pending row reaped → re-register → callback fires again."""
+        monkeypatch.setattr(
+            bootstrap_boot, "decrypt_adopt_payload",
+            lambda seed, payload_b64: b'{"device_id": "pi-z"}',
+        )
+        async def fake_register(session, base, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+
+        seq = {"n": 0}
+        async def fake_status(session, base, *, pubkey_b64):
+            seq["n"] += 1
+            if seq["n"] == 1:
+                raise PendingNotFoundError(404, "reaped")
+            return BootstrapStatus(status="adopted", payload_b64="x")
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", fake_status,
+        )
+        async def fake_fetch(session, base, *, device_id, seed):
+            return _fresh_token(60)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+        async def no_sleep(*a, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot.asyncio, "sleep", no_sleep)
+
+        calls = {"n": 0}
+        def on_pending():
+            calls["n"] += 1
+
+        await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-abc",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=tmp_path / "s.json",
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+            on_pending_registered=on_pending,
+        )
+        # Once for the initial register, once after the 404 re-register.
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_on_pending_registered_swallows_exceptions(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        """A buggy callback must not break the bootstrap flow."""
+        monkeypatch.setattr(
+            bootstrap_boot, "decrypt_adopt_payload",
+            lambda seed, payload_b64: b'{"device_id": "pi-q"}',
+        )
+        async def fake_register(session, base, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot, "register_once", fake_register)
+        async def fake_status(session, base, *, pubkey_b64):
+            return BootstrapStatus(status="adopted", payload_b64="x")
+        monkeypatch.setattr(
+            bootstrap_boot, "get_bootstrap_status_once", fake_status,
+        )
+        async def fake_fetch(session, base, *, device_id, seed):
+            return _fresh_token(60)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+        async def no_sleep(*a, **kw):
+            return None
+        monkeypatch.setattr(bootstrap_boot.asyncio, "sleep", no_sleep)
+
+        def boom():
+            raise RuntimeError("status writer broken")
+
+        # Must complete normally despite the callback raising.
+        creds = await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-abc",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=tmp_path / "s.json",
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+            on_pending_registered=boom,
+        )
+        assert creds is not None
+
+
+class TestOnPendingRegisteredCachedPath:
+    """Cached-fresh and signed-refresh paths must NOT fire the callback."""
+
+    pytestmark = posix_only
+
+    @pytest.mark.asyncio
+    async def test_cached_path_does_not_fire(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        state_path = tmp_path / "bootstrap_state.json"
+        exp = _rfc3339(datetime.now(timezone.utc) + timedelta(hours=2))
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-1234",
+            "wps_url": "wss://wps/x",
+            "wps_jwt": "cached-jwt",
+            "expires_at": exp,
+        })
+
+        async def boom(*a, **kw):
+            raise AssertionError("should not be called on cached path")
+        monkeypatch.setattr(bootstrap_boot, "register_once", boom)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", boom)
+        monkeypatch.setattr(bootstrap_boot, "get_bootstrap_status_once", boom)
+
+        calls = {"n": 0}
+        def cb():
+            calls["n"] += 1
+
+        await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-1234",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=state_path,
+            fleet_id="",
+            fleet_secret=b"",
+            on_pending_registered=cb,
+        )
+        assert calls["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_signed_refresh_does_not_fire(
+        self, tmp_path, identity, pairing_secret, monkeypatch,
+    ):
+        state_path = tmp_path / "bootstrap_state.json"
+        exp = _rfc3339(datetime.now(timezone.utc) - timedelta(hours=1))
+        bootstrap_boot.save_state(state_path, {
+            "schema_version": bootstrap_boot.STATE_SCHEMA_VERSION,
+            "cms_api_base": "https://cms.example.com",
+            "device_id": "pi-1234",
+            "wps_url": "wss://wps/x",
+            "wps_jwt": "stale-jwt",
+            "expires_at": exp,
+        })
+
+        async def boom_register(*a, **kw):
+            raise AssertionError("register_once must not be called on refresh")
+        monkeypatch.setattr(bootstrap_boot, "register_once", boom_register)
+        async def boom_status(*a, **kw):
+            raise AssertionError("get_bootstrap_status_once must not be called on refresh")
+        monkeypatch.setattr(bootstrap_boot, "get_bootstrap_status_once", boom_status)
+        async def fake_fetch(session, base, *, device_id, seed):
+            return _fresh_token(120)
+        monkeypatch.setattr(bootstrap_boot, "fetch_connect_token", fake_fetch)
+
+        calls = {"n": 0}
+        def cb():
+            calls["n"] += 1
+
+        await bootstrap_boot.ensure_wps_credentials(
+            session=object(),
+            cms_api_base="https://cms.example.com",
+            device_id="pi-1234",
+            identity=identity,
+            pairing_secret=pairing_secret,
+            state_path=state_path,
+            fleet_id="fleet-A",
+            fleet_secret=b"\x00" * 32,
+            on_pending_registered=cb,
+        )
+        assert calls["n"] == 0
+
+
 
 # --------------------------------------------------------------------
 # refresh_wps_jwt

--- a/tests/test_oobe_flow.py
+++ b/tests/test_oobe_flow.py
@@ -60,10 +60,16 @@ class TestWaitForCmsAdoption:
     @pytest.mark.asyncio
     async def test_returns_failed_after_error_threshold(self):
         """Should return 'failed' after CMS_ERROR_THRESHOLD consecutive errors."""
+        from datetime import datetime, timezone
         shutdown = asyncio.Event()
 
         def mock_read_status():
-            return {"state": "error", "error": "Connection refused"}
+            # Fresh timestamp so the stale-negative guard doesn't filter it.
+            return {
+                "state": "error",
+                "error": "Connection refused",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
 
         with patch("provision.service._get_cms_host", return_value="192.168.1.1"), \
              patch("provision.service._read_cms_status", side_effect=mock_read_status), \
@@ -75,10 +81,15 @@ class TestWaitForCmsAdoption:
     async def test_disconnected_with_error_counts_as_failure(self):
         """A 'disconnected' state with an error field should count toward
         the error threshold (e.g. connection timeout)."""
+        from datetime import datetime, timezone
         shutdown = asyncio.Event()
 
         def mock_read_status():
-            return {"state": "disconnected", "error": "timed out during handshake"}
+            return {
+                "state": "disconnected",
+                "error": "timed out during handshake",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
 
         with patch("provision.service._get_cms_host", return_value="192.168.1.1"), \
              patch("provision.service._read_cms_status", side_effect=mock_read_status), \

--- a/tests/test_provision_qr_display.py
+++ b/tests/test_provision_qr_display.py
@@ -173,3 +173,139 @@ def test_show_pairing_qr_noop_when_unavailable():
     pd._surface = None  # `available` property returns False
     # Should silently return without raising or trying to draw anything.
     pd.show_pairing_qr(secret=SAMPLE_SECRET)
+
+
+# ---------------------------------------------------------------------
+# Stale-negative cms_status.json guard (PR #144)
+# ---------------------------------------------------------------------
+# cms-client doesn't update cms_status.json during the multi-minute
+# bootstrap-v2 polling window.  Without the stale-negative guard, a
+# leftover "error"/"disconnected+error" entry from a previous run
+# dominates _wait_for_cms_adoption and bounces the device into
+# reconfigure ~10s after boot.  Positive states (connected/pending,
+# connected/registered) must NEVER be filtered, even if their
+# timestamp predates the start of the wait by milliseconds (race).
+
+
+from datetime import datetime, timedelta, timezone
+
+
+def _ts(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def test_is_status_negative_stale_old_error_is_stale():
+    old = _ts(datetime.now(timezone.utc) - timedelta(minutes=5))
+    assert provision_service._is_status_negative_stale(
+        {"state": "error", "error": "boom", "timestamp": old},
+    ) is True
+
+
+def test_is_status_negative_stale_fresh_error_is_fresh():
+    fresh = _ts(datetime.now(timezone.utc) - timedelta(seconds=2))
+    assert provision_service._is_status_negative_stale(
+        {"state": "error", "error": "boom", "timestamp": fresh},
+    ) is False
+
+
+def test_is_status_negative_stale_disconnected_with_error_is_negative():
+    old = _ts(datetime.now(timezone.utc) - timedelta(minutes=5))
+    assert provision_service._is_status_negative_stale(
+        {"state": "disconnected", "error": "x", "timestamp": old},
+    ) is True
+
+
+def test_is_status_negative_stale_disconnected_without_error_not_negative():
+    """Plain disconnected with no error is transient, not negative."""
+    old = _ts(datetime.now(timezone.utc) - timedelta(minutes=5))
+    assert provision_service._is_status_negative_stale(
+        {"state": "disconnected", "error": "", "timestamp": old},
+    ) is False
+
+
+def test_is_status_negative_stale_positive_states_never_stale():
+    """connected/pending and connected/registered must never be filtered."""
+    long_ago = _ts(datetime.now(timezone.utc) - timedelta(hours=1))
+    assert provision_service._is_status_negative_stale(
+        {"state": "connected", "registration": "pending",
+         "error": "", "timestamp": long_ago},
+    ) is False
+    assert provision_service._is_status_negative_stale(
+        {"state": "connected", "registration": "registered",
+         "error": "", "timestamp": long_ago},
+    ) is False
+
+
+def test_is_status_negative_stale_missing_timestamp_treated_as_stale():
+    """During OOBE we'd rather drop a timestamp-less negative than latch."""
+    assert provision_service._is_status_negative_stale(
+        {"state": "error", "error": "boom"},
+    ) is True
+
+
+def test_is_status_negative_stale_unparseable_timestamp_treated_as_stale():
+    assert provision_service._is_status_negative_stale(
+        {"state": "error", "error": "boom", "timestamp": "not-a-date"},
+    ) is True
+
+
+def test_stale_negative_does_not_increment_error_counter():
+    """Loop should ignore a stale leftover error — no reconfigure trigger."""
+    display = _make_display()
+    old_ts = _ts(datetime.now(timezone.utc) - timedelta(minutes=5))
+    # First several polls return a STALE error from a previous run.
+    # If the stale-guard works, none of these should count toward
+    # CMS_ERROR_THRESHOLD; instead the loop sees them as "connecting",
+    # then a fresh adopted finishes the wait.
+    statuses = [
+        {"state": "error", "error": "old timeout", "timestamp": old_ts},
+    ] * (provision_service.CMS_ERROR_THRESHOLD + 2)
+    statuses.append({"state": "connected", "registration": "registered"})
+
+    result = _run_adoption(
+        display,
+        status_sequence=statuses,
+        secret_sequence=[None] * (len(statuses) + 1),
+    )
+    assert result == "adopted"
+    display.show_cms_failed.assert_not_called()
+
+
+def test_fresh_negative_still_counts():
+    """Genuinely fresh negatives must still trigger reconfigure."""
+    display = _make_display()
+    fresh_ts = _ts(datetime.now(timezone.utc))
+    statuses = [
+        {"state": "error", "error": "fresh failure", "timestamp": fresh_ts},
+    ] * (provision_service.CMS_ERROR_THRESHOLD + 1)
+
+    result = _run_adoption(
+        display,
+        status_sequence=statuses,
+        secret_sequence=[None] * (len(statuses) + 1),
+    )
+    assert result == "failed"
+
+
+def test_fresh_pending_with_old_timestamp_still_shows_qr():
+    """Race test: pending status timestamped slightly before the wait
+    function starts must still trigger the QR screen.  Stale-filter
+    must only target NEGATIVE states."""
+    display = _make_display()
+    # Timestamp older than STALE_NEG_SEC, but state is connected/pending
+    # — never stale, must drive QR display.
+    old_ts = _ts(datetime.now(timezone.utc) - timedelta(minutes=10))
+    result = _run_adoption(
+        display,
+        status_sequence=[
+            {"state": "connected", "registration": "pending",
+             "error": "", "timestamp": old_ts},
+            {"state": "connected", "registration": "registered"},
+        ],
+        secret_sequence=[SAMPLE_SECRET],
+        ip="10.0.0.5", hostname="agora-abcd.local",
+    )
+    assert result == "adopted"
+    display.show_pairing_qr.assert_called_once()
+
+


### PR DESCRIPTION
Fix two related QR-OOBE blockers found field-testing v1.11.23 on a real
Pi: (1) the pairing QR code never rendered during bootstrap-v2 polling,
and (2) the device cycled `connecting` → `failed to connect` every ~5
minutes even though cms-client was perfectly healthy.

## Root cause

`cms_client.service._connect_and_run` only writes
`cms_status.json: {state=connected, registration=pending}` *inside*
`async with transport as ws:` — i.e. after the WebSocket has opened.
With bootstrap-v2 enabled, `_mint_wps_credentials_v2` →
`bootstrap_boot.ensure_wps_credentials` blocks for the entire pre-
adoption window (anywhere from seconds to many minutes while the
operator clicks Adopt in the CMS UI). During that whole stretch, no
positive status is written.

Two consequences for `provision/_wait_for_cms_adoption`:

1. **No QR.** The pairing-QR branch only triggers on
   `state=connected, registration=pending`. With cms-client silent
   during polling, that combination never appears, so the device
   stays on the boring "Connecting to server" splash forever.
2. **False reconfigure trigger.** Any leftover negative entry from a
   previous run (`error` or `disconnected+error`) dominates the
   2 s status poll, hits `CMS_ERROR_THRESHOLD=5` in ~10 s, returns
   `failed`, kicks off the reconfigure server, port-80 race guard
   from PR #143 sleeps it for 5 min, and the cycle repeats.

## Fix

Three coordinated changes:

### `cms_client/bootstrap_boot.py` — new `on_pending_registered` callback

`ensure_wps_credentials` (and `_poll_until_adopted`) take an optional
sync callback that fires once after `register_once()` succeeds — and
again on the `PendingNotFoundError` re-register path. Cached and
signed-refresh paths do **not** fire it (those don't register). The
callback is invoked through a `_safe_call` helper that swallows any
exception (a buggy status writer must not be able to break bootstrap).

This keeps `bootstrap_boot` transport-agnostic: it doesn't know about
`cms_status.json`, just notifies via the callback.

### `cms_client/service.py` — publish `connecting` then `connected/pending`

- Before invoking bootstrap-v2, write
  `_write_cms_status("connecting", message="Registering with CMS…")`.
  Overwrites any stale negative entry from a previous run.
- Pass `on_pending_registered=self._on_bootstrap_pending_registered`
  into `ensure_wps_credentials`. The callback writes
  `_write_cms_status("connected", registration="pending")` so the
  pairing-QR screen lights up immediately, even though the WS hasn't
  opened yet.

Note: this slightly broadens the meaning of `state="connected"`. It
now means "device successfully registered with the CMS HTTPS API"
rather than strictly "WebSocket open". For the provision UI flow this
is the right semantic — the device IS reachable, it's just waiting
for the operator. WebSocket-open is implied by
`registration=registered`.

### `provision/service.py` — stale-NEGATIVE guard

New constant `CMS_STATUS_STALE_NEG_SEC = 30.0` and helper
`_is_status_negative_stale(status)`. Returns `True` only when:
- state is `error`, OR `disconnected` with a non-empty `error`, AND
- the entry's `timestamp` is older than 30 s (or missing /
  unparseable, which during OOBE we conservatively treat as stale).

`_wait_for_cms_adoption` calls this at the top of each poll. If the
file looks like a stale negative leftover, the loop substitutes a
synthetic `state="connecting"` for that iteration so it doesn't count
toward `CMS_ERROR_THRESHOLD`.

**Critically, positive states are NEVER stale-filtered.** A
`connected/pending` or `connected/registered` entry whose timestamp
predates the start of the wait by milliseconds (race: cms-client
writes, provision starts) must always be honored. The rubber-duck
critique flagged the original "filter all stale" idea as causing
exactly this race, hence the negative-only scope.

## Tests

8 new tests in `tests/test_bootstrap_boot.py`:
- callback fires after first-boot register (post-register, not before)
- callback fires twice when pending-row is reaped (initial + re-register)
- callback exceptions are swallowed
- callback does NOT fire on cached-fresh path
- callback does NOT fire on signed-refresh path

10 new tests in `tests/test_provision_qr_display.py`:
- `_is_status_negative_stale` truth table
  (old/fresh error, disconnected+error, plain disconnected, missing
  timestamp, unparseable timestamp, positive states never stale)
- stale negative does not increment error counter (never reaches
  `failed`, eventually adopts)
- fresh negative DOES still count (returns `failed` as before)
- **race test:** positive `pending` with timestamp 10 min in the
  past still triggers QR display

Local: `pytest tests/test_bootstrap_boot.py tests/test_provision_qr_display.py
-p no:timeout` → 30 passed, 16 skipped (posix_only).

## Field validation plan

After release auto-cuts (probably v1.11.24):
1. `gh release download v1.11.24 --repo sslivins/agora --pattern "*.deb"`
2. `scp` to test Pi, `dpkg -i`
3. Provision should reach the pairing-QR screen within seconds of WiFi
   coming up, and stay there until the operator clicks Adopt
4. No more 5-minute `failed → reconfigure → port-80 race → sleep` cycle
