### PR TITLE
feat(bootstrap): shorten pairing code to 8-char Crockford base32

### DIFF
--- a/provision/display.py
+++ b/provision/display.py
@@ -628,15 +628,21 @@ class ProvisionDisplay:
         else:
             y += 30
 
-        # Manual-entry fallback: print the raw secret in monospace.
+        # Manual-entry fallback: print the secret in monospace, formatted
+        # as XXXX-XXXX for readability.  CMS adopt UI normalizes hyphens,
+        # whitespace, case, and I/L→1, O→0 on input.
         _draw_text(
             ctx, cx, y,
             "Or enter this code manually:",
             "Sans 20", WHITE, alpha=0.5,
         )
         y += 30
+        manual_text = (
+            f"{secret[:4]}-{secret[4:]}"
+            if len(secret) == 8 else secret
+        )
         bw, bh = _draw_badge(
-            ctx, cx, y, secret, "Monospace Bold 26",
+            ctx, cx, y, manual_text, "Monospace Bold 26",
             bg_color=(0.3, 0.3, 0.4),
         )
         y += bh + 18

--- a/provision/pairing.py
+++ b/provision/pairing.py
@@ -18,17 +18,17 @@ logger = logging.getLogger("agora.provision")
 PERSIST_DIR = Path("/opt/agora/persist")
 PAIRING_SECRET_PATH = PERSIST_DIR / "pairing_secret"
 
-# RFC-4648 base32 alphabet (uppercase, no padding).  The pairing secret
-# must be exactly 26 chars from this alphabet.  See
+# Crockford base32 alphabet (uppercase, no I/L/O/U).  The pairing secret
+# must be exactly 8 chars from this alphabet.  See
 # ``shared/bootstrap_identity.py:PAIRING_SECRET_TEXT_LEN``.
-_PAIRING_SECRET_RE = re.compile(r"^[A-Z2-7]{26}$")
+_PAIRING_SECRET_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{8}$")
 
 
 def read_pairing_secret(path: Path = PAIRING_SECRET_PATH) -> str | None:
     """Read the pairing secret from disk if present and valid.
 
     Returns ``None`` if the file is missing, unreadable, or does not
-    contain a 26-char RFC-4648 base32 string.  Never creates the file —
+    contain an 8-char Crockford-base32 string.  Never creates the file —
     creation is owned by ``cms_client.bootstrap_boot``.
 
     Logs a warning (without echoing the value) on malformed contents so

--- a/shared/bootstrap_identity.py
+++ b/shared/bootstrap_identity.py
@@ -21,9 +21,11 @@ Wire-format invariants that MUST stay in lockstep with CMS:
 - ECIES wire format is base64 of
   ``eph_x25519_pubkey(32) || aesgcm_nonce(12) || ciphertext || tag(16)``,
   HKDF-SHA256 with salt=None and info=``agora-bootstrap-ecies-v1``.
-- Pairing secret is 26 chars of RFC-4648 base32 (uppercase, no padding),
+- Pairing secret is 8 chars of Crockford base32 (uppercase, no I/L/O/U),
   hashed as ``sha256(secret.encode("utf-8")).hexdigest()`` — the admin in
-  CMS types/pastes that exact string into the adopt modal.
+  CMS types/pastes that exact string into the adopt modal (formatted
+  ``XXXX-XXXX`` on-screen for readability; the adopt UI normalizes
+  hyphens, whitespace, case, and the I/L→1, O→0 substitutions).
 
 File-system contract (both files):
 
@@ -69,16 +71,19 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 # Constants
 # ---------------------------------------------------------------------
 
-PAIRING_SECRET_LEN_BYTES = 16  # 128 bits of entropy
-PAIRING_SECRET_TEXT_LEN = 26  # base32(16 bytes) unpadded
+PAIRING_SECRET_LEN_BYTES = 5  # 40 bits of entropy → 8 chars Crockford
+PAIRING_SECRET_TEXT_LEN = 8  # 8 Crockford-base32 chars
 
 _SEED_LEN = 32
 _FILE_MODE = 0o400
 _DIR_MODE = 0o700
 _ECIES_HKDF_INFO = b"agora-bootstrap-ecies-v1"
 
-# Base32 alphabet we expect the secret to use (RFC-4648 uppercase, no "=").
-_B32_ALPHA = set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+# Crockford base32 alphabet (no I, L, O, U).  Manually-typed pairing
+# codes are visually unambiguous; the CMS normalizer maps I/L→1 and
+# O→0 on input.  See cms/services/device_bootstrap.py:normalize_pairing_secret.
+_B32_ALPHA = set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+_CROCKFORD_ALPHA = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 
 # ---------------------------------------------------------------------
@@ -321,10 +326,15 @@ def load_or_create_device_identity(key_path: Path) -> DeviceIdentity:
 
 def _generate_pairing_secret() -> str:
     raw = os.urandom(PAIRING_SECRET_LEN_BYTES)
-    # b32encode pads to multiple of 8; strip "=" so QR content stays minimal.
-    text = base64.b32encode(raw).decode("ascii").rstrip("=")
+    # Manual Crockford base32 (stdlib has none).  5 bytes = 40 bits = 8 chars.
+    n = int.from_bytes(raw, "big")
+    chars = []
+    for _ in range(PAIRING_SECRET_TEXT_LEN):
+        chars.append(_CROCKFORD_ALPHA[n & 0x1F])
+        n >>= 5
+    text = "".join(reversed(chars))
     assert len(text) == PAIRING_SECRET_TEXT_LEN, (
-        f"base32 length drift: got {len(text)}"
+        f"crockford length drift: got {len(text)}"
     )
     return text
 
@@ -333,8 +343,8 @@ def load_or_create_pairing_secret(secret_path: Path) -> str:
     """Load the pairing secret from ``secret_path`` or create it.
 
     Shares the same file-system contract and create-once semantics as
-    :func:`load_or_create_device_identity`.  Returns the 26-char base32
-    text form.
+    :func:`load_or_create_device_identity`.  Returns the 8-char
+    Crockford-base32 text form.
     """
     _check_parent_dir(secret_path, BootstrapSecretFileError)
     new_text = _generate_pairing_secret()
@@ -352,7 +362,7 @@ def load_or_create_pairing_secret(secret_path: Path) -> str:
     if len(text) != PAIRING_SECRET_TEXT_LEN or not set(text).issubset(_B32_ALPHA):
         raise BootstrapSecretFileError(
             f"{secret_path} contents are not a {PAIRING_SECRET_TEXT_LEN}-char "
-            f"RFC-4648 base32 string; refusing to silently regenerate. "
+            f"Crockford-base32 string; refusing to silently regenerate. "
             f"Delete the file manually to generate a fresh secret."
         )
     return text

--- a/tests/test_bootstrap_identity.py
+++ b/tests/test_bootstrap_identity.py
@@ -277,8 +277,8 @@ def test_pairing_secret_roundtrip(tmp_path: Path) -> None:
     secret_path = tmp_path / "pairing_secret"
     text1 = load_or_create_pairing_secret(secret_path)
     assert len(text1) == PAIRING_SECRET_TEXT_LEN
-    assert text1 == text1.upper()  # uppercase base32
-    assert set(text1).issubset(set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"))
+    assert text1 == text1.upper()  # uppercase Crockford base32
+    assert set(text1).issubset(set("0123456789ABCDEFGHJKMNPQRSTVWXYZ"))
     assert stat.S_IMODE(os.stat(secret_path).st_mode) == 0o400
 
     text2 = load_or_create_pairing_secret(secret_path)
@@ -299,9 +299,9 @@ def test_pairing_secret_malformed_never_regenerates(tmp_path: Path) -> None:
 
 def test_pairing_secret_hash_hex_frozen() -> None:
     # Pin the hash contract with a frozen input → expected SHA-256 hex.
-    digest = pairing_secret_hash_hex("MFRGG2DFMZTWQ2LKNNWG23TV")
+    digest = pairing_secret_hash_hex("7K3Q4M2P")
     expected = hashlib.sha256(
-        "MFRGG2DFMZTWQ2LKNNWG23TV".encode("utf-8")
+        "7K3Q4M2P".encode("utf-8")
     ).hexdigest()
     assert digest == expected
 
@@ -492,7 +492,7 @@ def test_pairing_secret_concurrent_create_does_not_overwrite(
 ) -> None:
     os.chmod(tmp_path, 0o700)
     secret_path = tmp_path / "pairing_secret"
-    pre_existing = "AAAAAAAAAAAAAAAAAAAAAAAAAA"  # 26-char valid base32
+    pre_existing = "AAAAAAAA"  # 8-char valid Crockford base32
     assert _create_new_secret_file(
         secret_path, pre_existing.encode("ascii"), BootstrapSecretFileError,
     )

--- a/tests/test_provision_pairing.py
+++ b/tests/test_provision_pairing.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from provision.pairing import read_pairing_secret
 
-# 26-char RFC-4648 base32 — every char is in the alphabet ([A-Z2-7]).
-SAMPLE_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+# 8-char Crockford base32 — every char is in the alphabet ([0-9A-HJKMNP-TV-Z]).
+SAMPLE_SECRET = "7K3Q4M2P"
 
 
 def test_missing_file_returns_none(tmp_path):
@@ -31,14 +31,14 @@ def test_strips_trailing_newline(tmp_path):
 
 def test_wrong_length_returns_none(tmp_path):
     p = tmp_path / "pairing_secret"
-    p.write_text("ABCDEFGHIJ")
+    p.write_text("ABCD")
     assert read_pairing_secret(p) is None
 
 
 def test_invalid_chars_returns_none(tmp_path):
     p = tmp_path / "pairing_secret"
-    # "1" and "8" are NOT in the RFC-4648 base32 alphabet (A-Z + 2-7).
-    p.write_text("1BCDEFGHIJKLMNOPQRSTUVWXY8")
+    # "I", "L", "O", "U" are NOT in Crockford base32.
+    p.write_text("ILOUABCD")
     assert read_pairing_secret(p) is None
 
 
@@ -50,7 +50,7 @@ def test_lowercase_rejected(tmp_path):
 
 def test_internal_whitespace_rejected(tmp_path):
     p = tmp_path / "pairing_secret"
-    p.write_text("ABCDEFGHIJKL MNOPQRSTUVWXY")  # space in middle
+    p.write_text("7K3Q 4M2P")  # space in middle, len 9
     assert read_pairing_secret(p) is None
 
 

--- a/tests/test_provision_qr_display.py
+++ b/tests/test_provision_qr_display.py
@@ -25,7 +25,7 @@ from provision import service as provision_service  # noqa: E402
 from provision import display as display_mod  # noqa: E402
 
 
-SAMPLE_SECRET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+SAMPLE_SECRET = "7K3Q4M2P"
 
 
 def _make_display():
@@ -122,7 +122,7 @@ def test_pending_with_secret_renders_qr_only_once():
 
 def test_show_pairing_qr_encodes_canonical_payload(monkeypatch):
     """The QR payload must match what the CMS scanner accepts:
-    ``{"v":1,"secret":<26-char base32>}`` with no whitespace.
+    ``{"v":1,"secret":<8-char Crockford base32>}`` with no whitespace.
     See ``cms/static/app.js:_parsePairingQr``.
     """
     captured = {}


### PR DESCRIPTION
## Why

The OOBE adoption screen previously showed a 26-character RFC-4648
base32 pairing secret under "Or enter this code manually". That's
unreasonable to type by hand. This PR shortens the pairing code to
**8 characters of Crockford base32** (no I/L/O/U) formatted on screen
as `XXXX-XXXX`, and pairs with the matching CMS PR
(sslivins/agora-cms#465) that normalizes the input.

40 bits of entropy is more than enough for a single-tenant adopt
window — the secret is one-shot, sha256-hashed at the CMS, and the
CMS already rejects same-hash-different-pubkey.

## What

- `shared/bootstrap_identity.py`:
  - `PAIRING_SECRET_LEN_BYTES = 5`, `PAIRING_SECRET_TEXT_LEN = 8`
  - `_B32_ALPHA` switched to Crockford (`0-9` + `A-Z` minus I/L/O/U)
  - `_generate_pairing_secret()` now does a manual int→Crockford
    encode (stdlib has no Crockford encoder)
  - Loader's "refusing to silently regenerate" error now says
    Crockford instead of RFC-4648
- `provision/pairing.py`:
  - `_PAIRING_SECRET_RE` updated to `^[0-9A-HJKMNP-TV-Z]{8}$`
  - Module docstring updated
- `provision/display.py`:
  - Manual-entry badge text now formatted `f"{secret[:4]}-{secret[4:]}"`
    when the secret is 8 chars (legacy lengths fall through to raw)
  - QR payload itself stays the raw 8 chars (no hyphen) so
    `cms/static/app.js:_parsePairingQr` reads it cleanly
- Tests updated:
  - `test_bootstrap_identity.py` — new alphabet expectations, new
    8-char fixtures, new frozen-hash sample
  - `test_provision_pairing.py` — Crockford `SAMPLE_SECRET`,
    invalid-char test now uses the visually-confusable I/L/O/U set
  - `test_provision_qr_display.py` — Crockford `SAMPLE_SECRET`,
    docstring updated

## Compat

No production fleet, no backward compat needed. Existing devices
with a 26-char pairing_secret on disk will refuse to start until the
file is removed (the loader still refuses to silently regenerate);
test Pi will be cleaned manually before OTA install:

```sh
ssh agora@<pi> "echo agora | sudo -S rm -f /opt/agora/state/pairing_secret"
```

## Tests

- `tests/test_bootstrap_identity.py` (8 cases run, 30 skipped on
  Windows for posix-only) — green.
- `tests/test_provision_pairing.py` (10 cases) — green.
- `tests/test_provision_qr_display.py` (15 cases) — green.
- Full suite (509 cases, excluding known Windows-env-incompatible
  files) — green.
