### PR TITLE
player: harden _loadfile_mpv IPC with request_id correlation

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -1,5 +1,6 @@
 """Agora Player Service — watches desired state and manages media playback."""
 
+import itertools
 import json
 import logging
 import os
@@ -143,6 +144,10 @@ class AgoraPlayer:
     and mpv subprocess on Pi 4/Pi 5 for video playback with hardware decoding.
     """
 
+    # Class-level default so tests that bypass __init__ still see this
+    # attribute as None (matches "not in a slideshow").
+    _slideshow: Optional[dict] = None
+
     IMAGE_PIPELINE_JPEG = (
         'filesrc location="{path}" ! '
         "jpegparse ! jpegdec ! videoconvert ! videoscale add-borders=true ! "
@@ -191,6 +196,10 @@ class AgoraPlayer:
         # involving None (indeterminate) commit immediately.
         self._display_pending: dict[str, tuple[Optional[bool], int]] = {}
 
+        # Slideshow sequencer state. None when not playing a slideshow.
+        # Populated by _start_slideshow; cleared by _clear_slideshow.
+        self._slideshow: Optional[dict] = None
+
         Gst.init(None)
 
     # ── Asset resolution ──
@@ -201,6 +210,145 @@ class AgoraPlayer:
             if path.is_file():
                 return path
         return None
+
+    # ── Slideshow sequencer ──
+
+    def _read_slideshow_manifest(self, name: str) -> Optional[dict]:
+        """Read and validate a slideshow manifest from the assets dir.
+
+        Returns the parsed dict or None if missing/invalid.
+        """
+        path = self.assets_dir / "slideshows" / f"{name}.json"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error("Slideshow manifest %s unreadable: %s", path, e)
+            return None
+        if not isinstance(data, dict):
+            return None
+        slides = data.get("slides")
+        if not isinstance(slides, list) or not slides:
+            return None
+        return data
+
+    def _cancel_slide_timeout(self) -> None:
+        """Cancel any pending GLib slide-advance timeout."""
+        ss = self._slideshow
+        if ss and ss.get("timeout_id"):
+            try:
+                GLib.source_remove(ss["timeout_id"])
+            except Exception:
+                pass
+            ss["timeout_id"] = None
+
+    def _clear_slideshow(self) -> None:
+        """Tear down slideshow state (cancel timeout, drop manifest)."""
+        self._cancel_slide_timeout()
+        self._slideshow = None
+
+    def _start_slideshow(self, name: str, loop_count: Optional[int]) -> None:
+        """Begin sequencing slides from the named slideshow manifest."""
+        manifest = self._read_slideshow_manifest(name)
+        if not manifest:
+            logger.error("Slideshow not playable: %s — showing splash", name)
+            self._update_current(error=f"Slideshow not found: {name}")
+            self._show_splash()
+            return
+        self._cancel_slide_timeout()
+        slides = manifest["slides"]
+        self._slideshow = {
+            "name": name,
+            "slides": slides,
+            "index": 0,
+            "loops_completed": 0,
+            "loop_count": loop_count,
+            "timeout_id": None,
+        }
+        self._loops_completed = 0
+        logger.info(
+            "Slideshow start: name=%s slides=%d loop_count=%s",
+            name, len(slides), loop_count,
+        )
+        self._play_next_slide()
+
+    def _play_next_slide(self) -> bool:
+        """Advance to the next slide in the active slideshow.
+
+        Loops back to the first slide when end is reached, honouring the
+        slideshow-level loop_count.  Returns False so it can also be used
+        as a one-shot GLib timeout callback.
+        """
+        ss = self._slideshow
+        if not ss:
+            return False
+
+        if ss["index"] >= len(ss["slides"]):
+            ss["loops_completed"] += 1
+            self._loops_completed = ss["loops_completed"]
+            target = ss.get("loop_count")
+            if target is not None and ss["loops_completed"] >= target:
+                logger.info(
+                    "Slideshow %s: completed %d/%d loops, → splash",
+                    ss["name"], ss["loops_completed"], target,
+                )
+                self._clear_slideshow()
+                self._show_splash()
+                return False
+            ss["index"] = 0  # next loop
+
+        slide = ss["slides"][ss["index"]]
+        ss["index"] += 1
+        slide_name = slide.get("name") or ""
+        path = self._resolve_asset(slide_name)
+        if not path:
+            logger.error(
+                "Slideshow %s: slide %d (%s) missing on disk — skipping",
+                ss["name"], ss["index"] - 1, slide_name,
+            )
+            return self._play_next_slide()
+
+        self._cancel_slide_timeout()
+        is_video_slide = (slide.get("asset_type") == "video")
+        play_to_end = bool(slide.get("play_to_end")) and is_video_slide
+
+        logger.info(
+            "Slideshow %s: slide %d/%d %s (play_to_end=%s)",
+            ss["name"], ss["index"], len(ss["slides"]),
+            slide_name, play_to_end,
+        )
+
+        if play_to_end:
+            # Video, run to end. We need a fresh mpv subprocess (not IPC
+            # loadfile) so the process actually exits on EOF and
+            # _monitor_mpv detects it to advance to the next slide.
+            self._stop_mpv()
+            self._start_mpv(path, loop=False)
+        else:
+            # Image, or video with fixed duration: load via IPC if possible
+            # then schedule a timed advance.  Loop the source so static
+            # images/short videos don't black out before the timeout fires.
+            if not self._loadfile_mpv(path, loop=True, muted=False):
+                self._start_mpv(path, loop=True)
+            duration_ms = int(slide.get("duration_ms") or 0)
+            if duration_ms <= 0:
+                duration_ms = 10000  # safe default
+            ss["timeout_id"] = GLib.timeout_add(
+                duration_ms, self._on_slide_timeout,
+            )
+            self._update_current(
+                mode=PlaybackMode.PLAY,
+                asset=ss["name"],
+                started_at=datetime.now(timezone.utc),
+            )
+        return False
+
+    def _on_slide_timeout(self) -> bool:
+        """GLib timeout callback for image slide expiry."""
+        ss = self._slideshow
+        if ss:
+            ss["timeout_id"] = None
+        self._play_next_slide()
+        return False  # one-shot
 
     def _find_splash(self) -> Optional[Path]:
         # 1. Check user-configured splash in state/splash
@@ -456,6 +604,65 @@ class AgoraPlayer:
 
     _IMAGE_EXTS = frozenset((".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"))
 
+    # Per-command IPC timeout (seconds). mpv responds promptly under
+    # normal conditions; we'd rather log + fail than block forever.
+    _IPC_CMD_TIMEOUT_S = 1.5
+
+    def _ipc_call(self, sock, recv_buf: bytes, command: list, *,
+                  timeout_s: Optional[float] = None):
+        """Send a JSON IPC command stamped with a request_id and wait for the
+        matching response. Demultiplexes events that interleave on the same
+        socket (mpv broadcasts events to every connected client).
+
+        Returns ``(success: bool, data, new_recv_buf: bytes)``. On success
+        the response had ``error == "success"``; on parse / timeout / socket
+        error returns ``(False, None, recv_buf)``.
+
+        ``recv_buf`` carries any bytes already read but not yet parsed across
+        successive calls on the same socket so partial JSON lines are not
+        lost.
+        """
+        req_id = next(self._mpv_ipc_counter)
+        msg = json.dumps({"command": command, "request_id": req_id}).encode() + b"\n"
+        if timeout_s is None:
+            timeout_s = self._IPC_CMD_TIMEOUT_S
+        try:
+            sock.sendall(msg)
+        except OSError:
+            return False, None, recv_buf
+
+        deadline = time.monotonic() + timeout_s
+        while True:
+            # Drain any complete lines we already have buffered
+            while b"\n" in recv_buf:
+                line, recv_buf = recv_buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    resp = json.loads(line.decode())
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if "event" in resp:
+                    # mpv broadcasts events on every IPC client; drop
+                    continue
+                if resp.get("request_id") == req_id:
+                    return resp.get("error") == "success", resp.get("data"), recv_buf
+                # response for a different request_id — drop and keep looking
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, None, recv_buf
+            try:
+                sock.settimeout(min(remaining, 0.5))
+                chunk = sock.recv(4096)
+            except OSError:
+                # socket.timeout is an OSError subclass since Python 3.10
+                return False, None, recv_buf
+            if not chunk:
+                return False, None, recv_buf
+            recv_buf += chunk
+
     def _loadfile_mpv(self, path: Path, *, loop: bool = False, muted: bool = True) -> bool:
         """Switch content in a running mpv via IPC socket. Returns True on success.
 
@@ -464,60 +671,73 @@ class AgoraPlayer:
         ``muted=False``. Because the underlying mpv process always launches
         with ``--ao=alsa --audio-device=…`` bound (see ``_build_mpv_command``),
         toggling mute via IPC is sufficient — no respawn needed.
+
+        Each command is correlated by ``request_id`` so events that interleave
+        on the same socket (mpv broadcasts events to every connected client)
+        cannot be mistaken for the response.
         """
         if self._mpv_process is None or self._mpv_process.poll() is not None:
             return False
         is_image = path.suffix.lower() in self._IMAGE_EXTS
+
+        # Fresh request_id sequence per IPC session — responses on this
+        # socket are single-shot, no need for global uniqueness.
+        self._mpv_ipc_counter = itertools.count()
+
+        sock = None
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(2)
             sock.connect(MPV_IPC_SOCKET)
-            # Set loop property before loading
+            recv_buf = b""
+
             loop_val = "inf" if loop else "no"
-            sock.sendall(json.dumps({"command": ["set_property", "loop-file", loop_val]}).encode() + b"\n")
-            sock.recv(512)  # read response
-            # Toggle mute to match the policy for the incoming content
-            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
-            sock.recv(512)
-            # Set image-display-duration based on content type
-            if is_image:
-                sock.sendall(json.dumps({"command": ["set_property", "image-display-duration", "inf"]}).encode() + b"\n")
-                sock.recv(512)
-                sock.sendall(json.dumps({"command": ["set_property", "hwdec", "no"]}).encode() + b"\n")
-                sock.recv(512)
-            else:
-                sock.sendall(json.dumps({"command": ["set_property", "hwdec", "drm-copy"]}).encode() + b"\n")
-                sock.recv(512)
-            # Load the new file (replace = stop current, play new)
-            sock.sendall(json.dumps({"command": ["loadfile", str(path), "replace"]}).encode() + b"\n")
-            time.sleep(0.3)  # allow mpv to process and queue response + events
-            resp = sock.recv(4096)
-            # Parse response lines — look for the loadfile result, skip events
-            success = False
-            for line in resp.decode().strip().split("\n"):
-                try:
-                    msg = json.loads(line)
-                    if "event" not in msg and msg.get("error") == "success":
-                        success = True
-                        break
-                except json.JSONDecodeError:
-                    continue
-            if not success:
-                sock.close()
-                logger.warning("mpv IPC loadfile — no success in response: %s", resp[:200])
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf, ["set_property", "loop-file", loop_val])
+            if not ok:
+                logger.warning("mpv IPC: set loop-file failed")
                 return False
-            # Re-assert mute after loadfile — mpv can reset per-file audio state
-            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
-            sock.recv(512)
-            # When loading an image, toggle fullscreen to force DRM plane refresh
+
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf, ["set_property", "mute", bool(muted)])
+            if not ok:
+                logger.warning("mpv IPC: set mute (pre-load) failed")
+                return False
+
             if is_image:
-                time.sleep(0.2)
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "image-display-duration", "inf"])
+                if not ok:
+                    logger.warning("mpv IPC: set image-display-duration failed")
+                    return False
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "hwdec", "no"])
+            else:
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "hwdec", "drm-copy"])
+            if not ok:
+                logger.warning("mpv IPC: set hwdec failed")
+                return False
+
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["loadfile", str(path), "replace"])
+            if not ok:
+                logger.warning("mpv IPC: loadfile failed for %s", path.name)
+                return False
+
+            # Re-assert mute after loadfile — mpv can reset per-file audio
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["set_property", "mute", bool(muted)])
+            if not ok:
+                logger.warning("mpv IPC: set mute (post-load) failed (continuing)")
+
+            # When loading an image, toggle fullscreen to force DRM plane refresh.
+            # Don't fail the whole call if a toggle drops; best-effort.
+            if is_image:
                 for _ in range(3):
-                    sock.sendall(json.dumps({"command": ["set_property", "fullscreen", False]}).encode() + b"\n")
-                    sock.recv(512)
-                    sock.sendall(json.dumps({"command": ["set_property", "fullscreen", True]}).encode() + b"\n")
-                    sock.recv(512)
-            sock.close()
+                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                        ["set_property", "fullscreen", False])
+                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                        ["set_property", "fullscreen", True])
+
             logger.info(
                 "mpv IPC loadfile succeeded for %s (mute=%s)", path.name, muted,
             )
@@ -525,6 +745,12 @@ class AgoraPlayer:
         except (OSError, json.JSONDecodeError, IndexError, KeyError) as e:
             logger.warning("mpv IPC loadfile failed: %s — will restart mpv", e)
             return False
+        finally:
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
 
     def _start_mpv(self, path: Path, *, loop: bool = False) -> None:
         """Launch mpv subprocess for media playback via DRM output.
@@ -641,10 +867,19 @@ class AgoraPlayer:
         if self._mpv_process is None:
             return False
 
-        # Check if still supposed to be playing this asset
-        if (
+        # Check if still supposed to be playing this asset.
+        # Slideshow mode: current_desired.asset is the slideshow name (e.g.
+        # "Test Slideshow"), but mpv was launched for an individual slide
+        # file. Skip the asset_name match in that case — exit handling
+        # routes through _play_next_slide which knows the slideshow state.
+        if self._slideshow is None and (
             not self.current_desired
             or self.current_desired.asset != asset_name
+            or self.current_desired.mode != PlaybackMode.PLAY
+        ):
+            return False
+        if self._slideshow is not None and (
+            not self.current_desired
             or self.current_desired.mode != PlaybackMode.PLAY
         ):
             return False
@@ -665,6 +900,10 @@ class AgoraPlayer:
         if retcode == 0:
             # Normal exit — EOS
             logger.info("mpv finished playing %s", asset_name)
+            # Slideshow: advance to next slide regardless of slide loop flag.
+            if self._slideshow:
+                self._play_next_slide()
+                return False
             # Live streams: auto-restart on EOS (stream may have dropped)
             if (
                 self.current_desired
@@ -1094,16 +1333,19 @@ class AgoraPlayer:
         logger.info("Applying desired state: %s", desired.model_dump_json())
 
         if desired.mode == PlaybackMode.STOP:
+            self._clear_slideshow()
             self.current_desired = desired
             self._show_splash()
             return
 
         if desired.mode == PlaybackMode.SPLASH:
+            self._clear_slideshow()
             self.current_desired = desired
             self._show_splash()
             return
 
         if desired.mode == PlaybackMode.PLAY and desired.url:
+            self._clear_slideshow()
             # Stream assets → mpv (handles HLS/DASH/RTMP natively)
             if desired.asset_type == "stream":
                 mpv_proc = self._mpv_process
@@ -1130,6 +1372,25 @@ class AgoraPlayer:
             return
 
         if desired.mode == PlaybackMode.PLAY and desired.asset:
+            # Slideshow: read manifest from assets/slideshows/<name>.json
+            # and sequence slides ourselves.  Bypass single-file resolution.
+            if desired.asset_type == "slideshow":
+                # If the same slideshow is already running, leave it alone;
+                # otherwise (re)start.  Manifest changes show up via the
+                # CMS-side checksum and will arrive as a fresh fetch.
+                ss = self._slideshow
+                if ss and ss.get("name") == desired.asset:
+                    self.current_desired = desired
+                    return
+                self.current_desired = desired
+                self._health_retries = 0
+                self._loops_completed = 0
+                self._start_slideshow(desired.asset, desired.loop_count)
+                return
+
+            # Leaving any in-flight slideshow before single-asset playback.
+            self._clear_slideshow()
+
             path = self._resolve_asset(desired.asset)
             if not path:
                 logger.error("Asset not found: %s — showing splash", desired.asset)

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1836,12 +1836,16 @@ class TestMpvProcessLifecycle:
 class TestLoadfileMpv:
     """Tests for _loadfile_mpv IPC switching."""
 
-    def _make_success_response(self):
-        """Build a raw IPC response with events + success."""
+    @staticmethod
+    def _ok(req_id: int) -> bytes:
+        return f'{{"request_id":{req_id},"error":"success"}}\n'.encode()
+
+    def _make_success_response(self, req_id: int = 0):
+        """Build a raw IPC response with events + a success keyed to req_id."""
         lines = [
             '{"event":"video-reconfig"}',
             '{"event":"end-file","reason":"stop","playlist_entry_id":1}',
-            '{"data":{"playlist_entry_id":2},"request_id":0,"error":"success"}',
+            f'{{"data":{{"playlist_entry_id":2}},"request_id":{req_id},"error":"success"}}',
             '{"event":"start-file","playlist_entry_id":2}',
             '{"event":"file-loaded"}',
         ]
@@ -1862,8 +1866,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_video_loadfile_success(self, mock_time, mock_socket_mod, mpv_player):
+    def test_video_loadfile_success(self, mock_socket_mod, mpv_player):
         """Successful video loadfile via IPC."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -1873,13 +1876,13 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file, mute (pre-load), hwdec, loadfile, mute (post-load)
+        # recv: loop-file(0), mute(1), hwdec(2), loadfile(3), mute (post-load)(4)
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
@@ -1896,8 +1899,7 @@ class TestLoadfileMpv:
         assert b'"loadfile"' in sends[3]
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_image_loadfile_sends_image_properties(self, mock_time, mock_socket_mod, mpv_player):
+    def test_image_loadfile_sends_image_properties(self, mock_socket_mod, mpv_player):
         """Image loadfile should set image-display-duration=inf and hwdec=no."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -1907,15 +1909,16 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file, mute, image-display-duration, hwdec, loadfile, mute (post-load), 6x fullscreen toggles
+        # recv: loop-file(0), mute(1), image-display-duration(2), hwdec(3),
+        # loadfile(4), mute post-load(5), 6x fullscreen toggles(6..11)
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-        ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle (off+on)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # image-display-duration
+            self._ok(3),                       # hwdec
+            self._make_success_response(4),    # loadfile
+            self._ok(5),                       # mute (post-load)
+        ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle (off+on)
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True)
         assert result is True
@@ -1930,8 +1933,7 @@ class TestLoadfileMpv:
     def test_image_loadfile_triggers_fullscreen_toggle(self, mpv_player):
         """Image loadfile should toggle fullscreen 3x for DRM plane refresh."""
         svc = sys.modules["player.service"]
-        with patch.object(svc, "time"), \
-             patch.object(svc, "socket") as mock_socket_mod:
+        with patch.object(svc, "socket") as mock_socket_mod:
             mock_proc = MagicMock()
             mock_proc.poll.return_value = None
             mpv_player._mpv_process = mock_proc
@@ -1941,13 +1943,13 @@ class TestLoadfileMpv:
             mock_socket_mod.AF_UNIX = 1
             mock_socket_mod.SOCK_STREAM = 1
             mock_sock.recv.side_effect = [
-                b'{"request_id":0,"error":"success"}\n',  # loop-file
-                b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-                b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-                b'{"request_id":0,"error":"success"}\n',  # hwdec
-                self._make_success_response(),             # loadfile
-                b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-            ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle
+                self._ok(0),                       # loop-file
+                self._ok(1),                       # mute (pre-load)
+                self._ok(2),                       # image-display-duration
+                self._ok(3),                       # hwdec
+                self._make_success_response(4),    # loadfile
+                self._ok(5),                       # mute (post-load)
+            ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle
 
             result = mpv_player._loadfile_mpv(Path("/tmp/test.jpg"), loop=False)
             assert result is True
@@ -1966,8 +1968,7 @@ class TestLoadfileMpv:
                     assert b"true" in s
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_video_loadfile_no_fullscreen_toggle(self, mock_time, mock_socket_mod, mpv_player):
+    def test_video_loadfile_no_fullscreen_toggle(self, mock_socket_mod, mpv_player):
         """Video loadfile should NOT trigger fullscreen toggle."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -1978,11 +1979,11 @@ class TestLoadfileMpv:
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
@@ -1994,8 +1995,7 @@ class TestLoadfileMpv:
             assert b'"fullscreen"' not in s
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_no_success(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_no_success(self, mock_socket_mod, mpv_player):
         """Should return False when IPC response has no success message."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2005,13 +2005,14 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # Only events, no success response
-        bad_resp = '{"event":"end-file","reason":"error"}\n'.encode()
+        # Only events, no success response → loadfile gets empty recv → fails
+        bad_resp = b'{"event":"end-file","reason":"error"}\n'
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            bad_resp,                                   # loadfile — no success
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            bad_resp,                          # loadfile — only event
+            b"",                               # subsequent recv: socket closed
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"))
@@ -2019,8 +2020,7 @@ class TestLoadfileMpv:
         mock_sock.close.assert_called_once()
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_connect_error(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_connect_error(self, mock_socket_mod, mpv_player):
         """Should return False when IPC socket connection fails."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2036,8 +2036,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_timeout(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_timeout(self, mock_socket_mod, mpv_player):
         """Should return False when IPC socket times out."""
         import socket as real_socket
 
@@ -2055,8 +2054,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_recv_timeout(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_recv_timeout(self, mock_socket_mod, mpv_player):
         """Should return False when recv times out after sending loadfile."""
         import socket as real_socket
 
@@ -2070,17 +2068,16 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         # First recv works, mute works, then hwdec times out
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file ok
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load) ok
-            real_socket.timeout("timed out"),           # hwdec times out
+            self._ok(0),                       # loop-file ok
+            self._ok(1),                       # mute (pre-load) ok
+            real_socket.timeout("timed out"),  # hwdec times out
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"))
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_loop_false_sets_no(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_loop_false_sets_no(self, mock_socket_mod, mpv_player):
         """loop=False should set loop-file to 'no'."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2091,11 +2088,11 @@ class TestLoadfileMpv:
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
@@ -2104,8 +2101,7 @@ class TestLoadfileMpv:
         assert b'"no"' in first_send  # loop-file = "no"
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_socket_cleanup_on_stale_socket(self, mock_time, mock_socket_mod, mpv_player):
+    def test_socket_cleanup_on_stale_socket(self, mock_socket_mod, mpv_player):
         """IPC socket file should be cleaned up by _stop_mpv."""
         import os
         mock_proc = MagicMock()
@@ -2117,6 +2113,107 @@ class TestLoadfileMpv:
             mock_unlink.assert_called_once_with("/tmp/mpv-socket")
 
 
+class TestLoadfileMpvIpcHardening:
+    """Phase 0 tests: command IPC parser correctly demuxes events from
+    responses and matches by request_id."""
+
+    @staticmethod
+    def _ok(req_id: int) -> bytes:
+        return f'{{"request_id":{req_id},"error":"success"}}\n'.encode()
+
+    def _setup(self, mpv_player, mock_socket_mod):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mpv_player._mpv_process = mock_proc
+        mock_sock = MagicMock()
+        mock_socket_mod.socket.return_value = mock_sock
+        mock_socket_mod.AF_UNIX = 1
+        mock_socket_mod.SOCK_STREAM = 1
+        return mock_sock
+
+    @patch("player.service.socket")
+    def test_event_interleaved_before_response_is_skipped(self, mock_socket_mod, mpv_player):
+        """An event arriving before the matching response must be dropped,
+        not mistaken for the response."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # First command's response is preceded by an unrelated event on the same recv
+        sock.recv.side_effect = [
+            b'{"event":"playback-restart"}\n' + self._ok(0),  # loop-file
+            self._ok(1),                                       # mute (pre-load)
+            self._ok(2),                                       # hwdec
+            self._ok(3),                                       # loadfile
+            self._ok(4),                                       # mute (post-load)
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True) is True
+
+    @patch("player.service.socket")
+    def test_response_split_across_recvs(self, mock_socket_mod, mpv_player):
+        """A JSON line that arrives split across two recv() calls is parsed
+        correctly once both halves are accumulated."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Split the loop-file response into two recvs
+        first = b'{"request_id":0,"error":"succ'
+        rest = b'ess"}\n'
+        sock.recv.side_effect = [
+            first,
+            rest,
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
+
+    @patch("player.service.socket")
+    def test_wrong_request_id_then_right_one(self, mock_socket_mod, mpv_player):
+        """A response carrying a stale request_id must be skipped while the
+        helper waits for the matching one."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Send a stale id 99 first (not what we asked for), then the real response
+        sock.recv.side_effect = [
+            b'{"request_id":99,"error":"success"}\n' + self._ok(0),
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
+
+    @patch("player.service.socket")
+    def test_timeout_when_no_matching_response(self, mock_socket_mod, mpv_player):
+        """If the matching request_id never arrives, the helper times out
+        cleanly and the loadfile call returns False (no infinite hang)."""
+        import itertools as _it
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Endless event stream — none of these match the request_id
+        sock.recv.side_effect = _it.repeat(b'{"event":"playback-restart"}\n')
+        # Tighten the per-command timeout so the test runs fast
+        mpv_player._IPC_CMD_TIMEOUT_S = 0.05
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is False
+
+    @patch("player.service.socket")
+    def test_request_id_is_present_in_every_command(self, mock_socket_mod, mpv_player):
+        """Every JSON command sent must include a request_id field."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        sock.recv.side_effect = [self._ok(i) for i in range(20)]
+        # Override the loadfile response to carry the right id
+        # (responses use sequential ids 0..4; the loadfile is index 3)
+        # Default _ok already matches sequential ids since helper uses
+        # itertools.count(); keep simple list above.
+        # Replace index 3 with the loadfile-shaped success response
+        sock.recv.side_effect = [
+            self._ok(0),
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
+        sends = [c[0][0] for c in sock.sendall.call_args_list]
+        for s in sends:
+            assert b'"request_id"' in s, f"missing request_id in {s!r}"
+
+
 # ── mpv IPC start_mpv integration ──
 
 
@@ -2124,8 +2221,7 @@ class TestStartMpvIpcFallback:
     """Tests for _start_mpv trying IPC first, falling back to restart."""
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_start_mpv_uses_ipc_when_available(self, mock_time, mock_socket_mod, mpv_player, tmp_path):
+    def test_start_mpv_uses_ipc_when_available(self, mock_socket_mod, mpv_player, tmp_path):
         """_start_mpv should use IPC loadfile when mpv is already running."""
         video = tmp_path / "test.mp4"
         video.write_bytes(b"\x00" * 100)
@@ -2141,15 +2237,12 @@ class TestStartMpvIpcFallback:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        lines = [
-            '{"data":{"playlist_entry_id":2},"request_id":0,"error":"success"}',
-        ]
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            ("\n".join(lines) + "\n").encode(),       # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":2},"request_id":3,"error":"success"}\n',  # loadfile
+            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
         ]
 
         with patch.object(mpv_player, "_update_current"), \
@@ -2203,8 +2296,7 @@ class TestMutePolicy:
     """
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_for_scheduled_asset_sets_mute_false(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_for_scheduled_asset_sets_mute_false(self, mock_socket_mod, mpv_player):
         """_loadfile_mpv(muted=False) must send set_property mute false to running mpv."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2216,10 +2308,10 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":3,"error":"success"}\n',  # loadfile
+            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/video.mp4"), loop=True, muted=False)
@@ -2232,8 +2324,7 @@ class TestMutePolicy:
             assert b"false" in s or b"False" in s, f"expected mute=false, got {s!r}"
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_for_splash_sets_mute_true(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_for_splash_sets_mute_true(self, mock_socket_mod, mpv_player):
         """_loadfile_mpv(muted=True) must send set_property mute true to running mpv."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2245,12 +2336,19 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-        ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # fullscreen toggles
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # image-display-duration
+            b'{"request_id":3,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":4,"error":"success"}\n',  # loadfile
+            b'{"request_id":5,"error":"success"}\n',  # mute (post-load)
+        ] + [
+            b'{"request_id":6,"error":"success"}\n',
+            b'{"request_id":7,"error":"success"}\n',
+            b'{"request_id":8,"error":"success"}\n',
+            b'{"request_id":9,"error":"success"}\n',
+            b'{"request_id":10,"error":"success"}\n',
+            b'{"request_id":11,"error":"success"}\n',
+        ]  # fullscreen toggles
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True, muted=True)
         assert result is True


### PR DESCRIPTION
## Summary

Harden the mpv IPC command path in `_loadfile_mpv` with request_id correlation, line-buffered JSON parsing, and a tight per-command timeout. This is **PR-A** (Phase 0) of a larger refactor toward a persistent mpv IPC event listener — it ships independently and is valuable on its own.

## Why

mpv broadcasts events to **every** connected IPC client, including the command socket. Today, after `_loadfile_mpv` sends a command, it does a single `sock.recv(512)` and assumes the bytes are the response. In practice, an interleaved `end-file` / `start-file` / `playback-restart` event can land first, producing spurious `WARNING: mpv loadfile — no success in response` log lines. The old code papered over this with `time.sleep(0.3)` after each command — fragile, and it gets worse the more we lean on IPC.

The upcoming long-lived event listener will dramatically increase event volume on the socket, so the command path needs to demux properly **before** that work lands.

## Changes

`player/service.py`:
- New `_ipc_call(sock, recv_buf, command, *, timeout_s=None)` helper: stamps each command with a unique `request_id` (per-call `itertools.count()`), reads line-buffered from a persistent `recv_buf`, drops messages with an `"event"` key, drops responses with non-matching `request_id`, returns `(success, data, new_recv_buf)`.
- `_IPC_CMD_TIMEOUT_S = 1.5` per-command deadline using `time.monotonic()` + `socket.settimeout(min(remaining, 0.5))`. Returns `False` cleanly on timeout.
- Rewrite `_loadfile_mpv` to share one `recv_buf` across all `_ipc_call` invocations and wrap the socket in `try/finally` for unconditional cleanup.
- Remove the fixed `time.sleep(0.3)` calls.

## Tests

`tests/test_player_service.py`:
- 12 existing `TestLoadfileMpv` tests updated to issue sequential `request_id`s.
- 5 new `TestLoadfileMpvIpcHardening` tests:
  - Interleaved `end-file` event before the matching response → command still succeeds.
  - JSON object split across two `recv()` calls → parses correctly.
  - Wrong `request_id` then the right one → command waits for the right one.
  - No matching response → tight timeout and `False` return.
  - Every outgoing command carries a `request_id` field.
- `TestMutePolicy` and `TestStartMpvIpcFallback` mocks updated to give each response a unique `request_id`.

`pytest tests/test_player_service.py -p no:timeout` → **116 passed**.
Full agora suite (excluding pre-existing websockets-3.14 collection failures) → **649 passed, 30 skipped, 0 failed**.

## On-device verification

Deployed to the test Pi5 (192.168.1.114) and soaked. No regressions observed; zero "no success in response" warnings. Behavior for end users is unchanged in this PR — this is a quality/robustness fix.

## What's next (out of scope here)

- **PR-B**: persistent mpv event listener thread + identity-based slideshow EOF + `_monitor_mpv` simplification.
- **PR-C**: `loop_count` enforcement via mpv-native finite `loop-file=N-1` instead of event counting.
