### PR TITLE
hardware/display: switch Pi 4 to DRM sysfs probe

### DIFF
--- a/hardware/display/factory.py
+++ b/hardware/display/factory.py
@@ -19,13 +19,23 @@ _cached_probe: Optional[DisplayProbe] = None
 def build_probe(board: Board, ports: list[HdmiPort]) -> DisplayProbe:
     """Return the best :class:`DisplayProbe` for *board* and *ports*.
 
-    * Pi 5 / CM 5 → :class:`DrmSysfsDisplayProbe`
-    * Pi Zero 2 W / Pi 3 / Pi 4 → :class:`I2cEdidDisplayProbe`
+    * Pi 4 / Pi 5 / CM 5 → :class:`DrmSysfsDisplayProbe`
+    * Pi Zero 2 W / Pi 3 → :class:`I2cEdidDisplayProbe`
     * Unknown → :class:`NullDisplayProbe`
+
+    Pi 4 was historically routed through :class:`I2cEdidDisplayProbe` on the
+    assumption that VC4 sysfs lied under ``hdmi_force_hotplug=1``.  In
+    practice on modern Raspberry Pi OS (``vc4-kms-v3d``) the DDC i2c
+    buses moved to ``/dev/i2c-20`` and ``/dev/i2c-21`` while the per-port
+    ``i2c_bus`` config still pointed at ``/dev/i2c-1`` / ``/dev/i2c-10``,
+    so the i2c probe always returned ``None``.  The DRM sysfs probe
+    cross-checks ``status`` against an EDID read, which makes it
+    reliable on Pi 4 and immune to GPIO-header i2c bus contention from
+    HATs (e.g. the InnoMaker HiFi DAC).
     """
-    if board is Board.PI_5:
+    if board in (Board.PI_4, Board.PI_5):
         return DrmSysfsDisplayProbe(ports)
-    if board in (Board.PI_4, Board.ZERO_2W):
+    if board is Board.ZERO_2W:
         return I2cEdidDisplayProbe(ports)
     return NullDisplayProbe(ports)
 

--- a/tests/test_hardware_display.py
+++ b/tests/test_hardware_display.py
@@ -21,7 +21,7 @@ from shared.board import Board, HdmiPort
     "board,expected_cls",
     [
         (Board.PI_5, DrmSysfsDisplayProbe),
-        (Board.PI_4, I2cEdidDisplayProbe),
+        (Board.PI_4, DrmSysfsDisplayProbe),
         (Board.ZERO_2W, I2cEdidDisplayProbe),
         (Board.UNKNOWN, NullDisplayProbe),
     ],


### PR DESCRIPTION
## Summary

Pi 4 has been silently reporting "no display connected" on every
device in the fleet because the per-port I²C DDC bus paths in
`shared/board.py` (`/dev/i2c-1` and `/dev/i2c-10`) don't exist on
modern Raspberry Pi OS (`vc4-kms-v3d`), where DDC moved to
`/dev/i2c-20` / `/dev/i2c-21`. Result: `_probe_bus` always hits
`OSError` on `os.open` and every `PortStatus.connected` comes back
`None`.

Switch Pi 4 to use `DrmSysfsDisplayProbe` (the same probe Pi 5
already uses), which reads `/sys/class/drm/card*-HDMI-A-1/status`
and cross-checks it against a real EDID read.

## Verification

Verified on a live Pi 4 B Rev 1.5 running prod firmware:

```
/sys/class/drm/card1-HDMI-A-1/status → connected
EDID read returned 256 bytes (real monitor)
/dev/i2c-20 present, /dev/i2c-1 absent
```

Local: `pytest -p no:timeout tests/test_hardware_display.py` →
24 passed.

## Why DRM sysfs is safe on Pi 4

The historical reason for picking the i2c probe over sysfs on Pi 4
was the concern that VC4 sysfs lies under `hdmi_force_hotplug=1`.
Agora doesn't ship that quirk, and `DrmSysfsDisplayProbe` already
gates `connected=True` on a non-empty EDID read, so spurious
`status=connected` lines without a real sink are filtered out.

This change also makes Pi 4 display detection robust against
GPIO-header HATs (notably the InnoMaker HiFi DAC HAT being added
in a follow-up PR) which can take over `/dev/i2c-1`.

## Out of scope

- Zero 2 W stays on `I2cEdidDisplayProbe` (its `/dev/i2c-2`
  mapping is correct and it's known-working in the field).
- Missing `device_type` / `firmware_version` / `supported_codecs`
  in CMS for WPS-transport devices is a separate issue (the WPS
  bootstrap metadata payload doesn't include `supported_codecs`,
  unlike the WS register message). Will be addressed separately.
