### PR TITLE
feat(audio): autodetect InnoMaker HiFi DAC HAT

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -168,6 +168,19 @@ if [ -f "${BOOT_CFG}" ]; then
             echo "Agora: added ${setting} to ${BOOT_CFG}"
         fi
     done
+    # ── HiFi DAC HAT (InnoMaker PCM5122 / HiFiBerry-compatible) ──
+    # Loading the overlay on boards without the HAT is harmless: the I²C
+    # probe fails and no card is registered, leaving HDMI audio intact.
+    # We also disable the onboard analog jack (agora doesn't use the
+    # 3.5mm output) to avoid contention with the DAC for ALSA card 0.
+    # Use exact-line match (not key-only) because dtoverlay/dtparam can
+    # legitimately appear multiple times in config.txt.
+    for line in 'dtoverlay=hifiberry-dacplus' 'dtparam=audio=off'; do
+        if ! grep -qxF "${line}" "${BOOT_CFG}"; then
+            echo "${line}" >> "${BOOT_CFG}"
+            echo "Agora: added ${line} to ${BOOT_CFG}"
+        fi
+    done
 fi
 
 # ── Disable console login on HDMI (tty1) ──

--- a/player/service.py
+++ b/player/service.py
@@ -17,7 +17,7 @@ gi.require_version("Gst", "1.0")
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib, Gst  # noqa: E402
 
-from shared.board import Board, alsa_card, get_board, player_backend, supported_codecs  # noqa: E402
+from shared.board import Board, alsa_device_string, alsa_device_string_gst, get_board, player_backend, supported_codecs  # noqa: E402
 from hardware.display import PortStatus, get_display_probe  # noqa: E402
 from shared.models import CurrentState, DesiredState, PlaybackMode  # noqa: E402
 from shared.state import read_state, write_state  # noqa: E402
@@ -36,13 +36,13 @@ def _build_video_pipeline_str(board: Board) -> str:
     else:
         decode = "h264parse ! v4l2h264dec"
 
-    _card = alsa_card()
+    _gst_dev = alsa_device_string_gst()
     return (
         'filesrc location="{path}" ! '
         "qtdemux name=dmux "
         f"dmux.video_0 ! queue ! {decode} ! kmssink driver-name=vc4 sync=true "
         "dmux.audio_0 ! queue ! decodebin ! audioconvert ! audioresample ! "
-        f'alsasink device="hdmi:CARD={_card},DEV=0"'
+        f'alsasink device="{_gst_dev}"'
     )
 
 
@@ -92,7 +92,7 @@ def _build_mpv_command(path: Path, *, muted: bool = True, loop: bool = False) ->
         "--no-osc",
         f"--input-ipc-server={MPV_IPC_SOCKET}",
         "--ao=alsa",
-        f"--audio-device=alsa/hdmi:CARD={alsa_card()},DEV=0",
+        f"--audio-device={alsa_device_string()}",
     ]
     if is_image:
         cmd.append("--image-display-duration=inf")
@@ -130,7 +130,7 @@ def _build_stream_command(url: str) -> list[str]:
         # Loop for VOD streams (harmless for live — they don't end)
         "--loop=inf",
         "--ao=alsa",
-        f"--audio-device=alsa/hdmi:CARD={alsa_card()},DEV=0",
+        f"--audio-device={alsa_device_string()}",
         url,
     ]
     return cmd

--- a/shared/board.py
+++ b/shared/board.py
@@ -13,6 +13,18 @@ logger = logging.getLogger("agora.board")
 # Device tree model file (standard on all Raspberry Pi boards)
 _MODEL_PATH = Path("/proc/device-tree/model")
 
+# ALSA card-list file used to detect attached audio devices at runtime.
+# Format example:
+#     0 [vc4hdmi0       ]: vc4-hdmi - vc4-hdmi-0
+#                          vc4-hdmi-0
+#     1 [sndrpihifiberry]: simple-card - snd_rpi_hifiberry_dacplus
+#                          snd_rpi_hifiberry_dacplus
+_ASOUND_CARDS_PATH = Path("/proc/asound/cards")
+
+# ALSA card name used by the upstream snd_soc_hifiberry_dacplus driver
+# (which the InnoMaker PCM5122 HAT binds against via dtoverlay=hifiberry-dacplus).
+_HIFIBERRY_CARD = "sndrpihifiberry"
+
 
 class Board(str, enum.Enum):
     """Supported Raspberry Pi board variants."""
@@ -87,6 +99,10 @@ _UNKNOWN_CONFIG: dict = {
 
 # Cached board detection result
 _cached_board: Board | None = None
+
+# Cached audio-device detection result (card_name, device_prefix).
+# Audio cards do not change at runtime, so probe once per process.
+_cached_audio_device: tuple[str, str] | None = None
 
 
 def _read_model_string() -> str:
@@ -191,9 +207,77 @@ def player_backend() -> str:
     return _config()["player_backend"]
 
 
+def _read_asound_cards() -> str:
+    """Read /proc/asound/cards. Returns "" if the file is missing or unreadable.
+
+    Wrapped for easy mocking in tests; not part of the public API.
+    """
+    try:
+        return _ASOUND_CARDS_PATH.read_text()
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def detect_audio_device() -> tuple[str, str]:
+    """Return ``(card_name, device_prefix)`` for the active audio output.
+
+    If a HiFiBerry-compatible DAC HAT (e.g. the InnoMaker PCM5122 HAT) is
+    present, ``/proc/asound/cards`` will list a ``sndrpihifiberry`` card
+    once ``dtoverlay=hifiberry-dacplus`` has registered the driver. In
+    that case audio is routed via ALSA ``hw:`` (raw PCM, no HDMI quirks),
+    and we return ``("sndrpihifiberry", "hw")``.
+
+    Otherwise we fall back to the per-board HDMI card from
+    ``_BOARD_CONFIG`` and a ``hdmi`` device prefix — preserving the
+    pre-HAT behaviour on Pis without the DAC.
+
+    Cached after the first call: audio cards do not appear/disappear at
+    runtime on these boards.
+    """
+    global _cached_audio_device
+    if _cached_audio_device is not None:
+        return _cached_audio_device
+    cards = _read_asound_cards()
+    if _HIFIBERRY_CARD in cards:
+        _cached_audio_device = (_HIFIBERRY_CARD, "hw")
+        logger.info("Detected HiFiBerry-compatible DAC HAT (%s); routing audio via ALSA hw:", _HIFIBERRY_CARD)
+    else:
+        _cached_audio_device = (_config()["alsa_card"], "hdmi")
+        logger.info("No DAC HAT detected; routing audio via HDMI card %s", _cached_audio_device[0])
+    return _cached_audio_device
+
+
 def alsa_card() -> str:
-    """Return the ALSA card name for HDMI audio on the current board."""
-    return _config()["alsa_card"]
+    """Return the ALSA card name for the active audio output.
+
+    On boards with a HiFiBerry-compatible DAC HAT this returns
+    ``sndrpihifiberry``; otherwise it returns the per-board HDMI card
+    name from ``_BOARD_CONFIG``. Kept for backwards compatibility — new
+    callers should prefer :func:`alsa_device_string` /
+    :func:`alsa_device_string_gst` so the device prefix (``hw`` vs.
+    ``hdmi``) is consistent with the card.
+    """
+    return detect_audio_device()[0]
+
+
+def alsa_device_string() -> str:
+    """Return the mpv-form ALSA device string, e.g. ``alsa/hw:CARD=…,DEV=0``.
+
+    Used for ``mpv --audio-device=…``. Reflects DAC vs. HDMI routing
+    based on :func:`detect_audio_device`.
+    """
+    card, prefix = detect_audio_device()
+    return f"alsa/{prefix}:CARD={card},DEV=0"
+
+
+def alsa_device_string_gst() -> str:
+    """Return the GStreamer-form ALSA device string, e.g. ``hw:CARD=…,DEV=0``.
+
+    Used for ``alsasink device=…``. Reflects DAC vs. HDMI routing based
+    on :func:`detect_audio_device`.
+    """
+    card, prefix = detect_audio_device()
+    return f"{prefix}:CARD={card},DEV=0"
 
 
 def _detect_wifi_interface() -> bool:

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -8,6 +8,10 @@ from shared.board import (
     Board,
     HdmiPort,
     _detect_board,
+    alsa_card,
+    alsa_device_string,
+    alsa_device_string_gst,
+    detect_audio_device,
     get_board,
     get_cpu_temp,
     get_i2c_bus,
@@ -27,8 +31,10 @@ import shared.board as board_module
 def _reset_cache():
     """Reset the cached board detection before each test."""
     board_module._cached_board = None
+    board_module._cached_audio_device = None
     yield
     board_module._cached_board = None
+    board_module._cached_audio_device = None
 
 
 # ── Board detection from model string ──
@@ -269,3 +275,96 @@ class TestPlayerBackend:
     def test_unknown_board_uses_gstreamer(self):
         with patch.object(board_module, "_read_model_string", return_value="Something Else"):
             assert player_backend() == "gstreamer"
+
+
+# ── Audio device detection (HiFi DAC HAT vs HDMI) ──
+
+
+_HDMI_ONLY_CARDS = """\
+ 0 [vc4hdmi0       ]: vc4-hdmi - vc4-hdmi-0
+                      vc4-hdmi-0
+ 1 [vc4hdmi1       ]: vc4-hdmi - vc4-hdmi-1
+                      vc4-hdmi-1
+"""
+
+_HAT_PRESENT_CARDS = """\
+ 0 [vc4hdmi0       ]: vc4-hdmi - vc4-hdmi-0
+                      vc4-hdmi-0
+ 1 [sndrpihifiberry]: simple-card - snd_rpi_hifiberry_dacplus
+                      snd_rpi_hifiberry_dacplus
+"""
+
+
+class TestDetectAudioDevice:
+    def test_hat_present_overrides_hdmi(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HAT_PRESENT_CARDS):
+                assert detect_audio_device() == ("sndrpihifiberry", "hw")
+
+    def test_no_hat_falls_back_to_hdmi_pi4(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert detect_audio_device() == ("vc4hdmi", "hdmi")
+
+    def test_no_hat_falls_back_to_hdmi_pi5(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 5"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert detect_audio_device() == ("vc4hdmi0", "hdmi")
+
+    def test_no_hat_falls_back_to_hdmi_zero2w(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi Zero 2 W"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert detect_audio_device() == ("vc4hdmi", "hdmi")
+
+    def test_missing_proc_file_falls_back_to_hdmi(self):
+        """If /proc/asound/cards is missing entirely, treat as no HAT."""
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=""):
+                assert detect_audio_device() == ("vc4hdmi", "hdmi")
+
+    def test_malformed_proc_file_does_not_crash(self):
+        """Garbage content should fall back to HDMI rather than blow up."""
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value="not a real cards file\n\x00\x01"):
+                assert detect_audio_device() == ("vc4hdmi", "hdmi")
+
+    def test_result_is_cached(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HAT_PRESENT_CARDS) as mock:
+                detect_audio_device()
+                detect_audio_device()
+                detect_audio_device()
+                mock.assert_called_once()
+
+    def test_alsa_card_returns_hat_when_present(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HAT_PRESENT_CARDS):
+                assert alsa_card() == "sndrpihifiberry"
+
+    def test_alsa_card_returns_hdmi_when_no_hat(self):
+        """Backwards-compat: existing callers that only need the card name."""
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert alsa_card() == "vc4hdmi"
+
+    def test_alsa_device_string_hat(self):
+        """mpv-form string for the HAT path."""
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 4 Model B"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HAT_PRESENT_CARDS):
+                assert alsa_device_string() == "alsa/hw:CARD=sndrpihifiberry,DEV=0"
+
+    def test_alsa_device_string_hdmi(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi 5"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert alsa_device_string() == "alsa/hdmi:CARD=vc4hdmi0,DEV=0"
+
+    def test_alsa_device_string_gst_hat(self):
+        """GStreamer-form string (no ``alsa/`` prefix) for the HAT path."""
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi Zero 2 W"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HAT_PRESENT_CARDS):
+                assert alsa_device_string_gst() == "hw:CARD=sndrpihifiberry,DEV=0"
+
+    def test_alsa_device_string_gst_hdmi(self):
+        with patch.object(board_module, "_read_model_string", return_value="Raspberry Pi Zero 2 W"):
+            with patch.object(board_module, "_read_asound_cards", return_value=_HDMI_ONLY_CARDS):
+                assert alsa_device_string_gst() == "hdmi:CARD=vc4hdmi,DEV=0"

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1561,6 +1561,56 @@ class TestBuildMpvCommand:
             cmd = svc._build_mpv_command(Path("/test.mp4"), loop=True)
             assert "--loop=inf" in cmd
 
+    def test_audio_device_routes_to_dac_when_hat_present(self):
+        """When a HiFiBerry-compatible DAC HAT is detected, the mpv
+        --audio-device flag must use ``alsa/hw:CARD=sndrpihifiberry,DEV=0``
+        instead of the HDMI form."""
+        with patch.dict("sys.modules", {
+            "gi": MagicMock(),
+            "gi.repository": MagicMock(),
+        }):
+            import importlib
+            import shared.board as board_module
+            import player.service as svc
+            importlib.reload(svc)
+
+            board_module._cached_audio_device = None
+            try:
+                with patch.object(
+                    board_module,
+                    "_read_asound_cards",
+                    return_value=" 1 [sndrpihifiberry]: simple-card - snd_rpi_hifiberry_dacplus\n",
+                ):
+                    cmd = svc._build_mpv_command(Path("/test.mp4"))
+                    assert "--ao=alsa" in cmd
+                    assert "--audio-device=alsa/hw:CARD=sndrpihifiberry,DEV=0" in cmd
+                    assert not any(a.startswith("--audio-device=alsa/hdmi:") for a in cmd)
+            finally:
+                board_module._cached_audio_device = None
+
+    def test_stream_command_routes_to_dac_when_hat_present(self):
+        """The streaming mpv command must also route audio through the DAC."""
+        with patch.dict("sys.modules", {
+            "gi": MagicMock(),
+            "gi.repository": MagicMock(),
+        }):
+            import importlib
+            import shared.board as board_module
+            import player.service as svc
+            importlib.reload(svc)
+
+            board_module._cached_audio_device = None
+            try:
+                with patch.object(
+                    board_module,
+                    "_read_asound_cards",
+                    return_value=" 1 [sndrpihifiberry]: simple-card - snd_rpi_hifiberry_dacplus\n",
+                ):
+                    cmd = svc._build_stream_command("https://example.com/live.m3u8")
+                    assert "--audio-device=alsa/hw:CARD=sndrpihifiberry,DEV=0" in cmd
+            finally:
+                board_module._cached_audio_device = None
+
 
 # ── mpv player backend selection ──
 


### PR DESCRIPTION
## Summary

Adds support for the [InnoMaker HiFi DAC HAT](https://github.com/INNO-MAKER/HIFI-DAC-Hat-For-Raspberry-Pi)
(PCM5122-based) so the agora player can route audio to the DAC instead of HDMI
when the HAT is physically attached.

Single image — no separate build for HAT vs no-HAT. Auto-detected at runtime.

## Changes

### Boot config (`packaging/debian/postinst`)
- Idempotently adds two lines to `/boot/firmware/config.txt`:
  - `dtoverlay=hifiberry-dacplus` — registers the PCM5122 driver via the
    upstream HiFiBerry DAC+ overlay (same silicon).
  - `dtparam=audio=off` — disables onboard analog jack so it can't fight
    the DAC for ALSA card 0 ordering.
- Uses exact-line `grep -qxF` matching since `dtoverlay=`/`dtparam=` legitimately
  appear multiple times in `config.txt`.
- Safe on no-HAT Pis: when the I²C probe at boot fails, no card registers and
  HDMI audio is unaffected.

### Runtime detection (`shared/board.py`)
- New `detect_audio_device() -> tuple[str, str]` reads `/proc/asound/cards`:
  - HAT present (`sndrpihifiberry`) → `("sndrpihifiberry", "hw")`
  - Otherwise → `(per-board HDMI card, "hdmi")`
- Cached after first call (audio cards are static at runtime).
- Logs one INFO line at first call so it's obvious from journalctl which path
  was chosen.
- New helpers `alsa_device_string()` and `alsa_device_string_gst()` return the
  fully-formed ALSA device strings for mpv and GStreamer respectively.
- `alsa_card()` retained for backwards compatibility.

### Player wiring (`player/service.py`)
- mpv (`_build_mpv_command`, `_build_stream_command`) consumes
  `alsa_device_string()`.
- GStreamer pipeline (`_build_video_pipeline_str`, Zero 2 W) consumes
  `alsa_device_string_gst()`.

### Tests
- `tests/test_board.py`: 13 new tests covering HAT-present override, per-board
  HDMI fallback (Pi 4 / Pi 5 / Zero 2 W), missing/malformed
  `/proc/asound/cards`, caching, `alsa_card()` backwards-compat, and the
  device-string helpers.
- `tests/test_player_service.py`: 2 new tests asserting the mpv command flips
  to `alsa/hw:CARD=sndrpihifiberry,DEV=0` when the HAT is detected.

## Out of scope (follow-up)

- CMS-side per-device override toggle (force HDMI even with HAT, or vice
  versa) — separate PR in `sslivins/agora-cms`.
- Hardware volume / mixer control (mpv software volume still works).
