### PR TITLE
postinst: HiFi DAC HAT overlay -> hifiberry-dacplus-std (fix 2x speed)

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -175,7 +175,22 @@ if [ -f "${BOOT_CFG}" ]; then
     # 3.5mm output) to avoid contention with the DAC for ALSA card 0.
     # Use exact-line match (not key-only) because dtoverlay/dtparam can
     # legitimately appear multiple times in config.txt.
-    for line in 'dtoverlay=hifiberry-dacplus' 'dtparam=audio=off'; do
+    #
+    # Overlay choice: hifiberry-dacplus-std is correct for PCM5122 boards
+    # *without* a CS2000 master clock chip (which the InnoMaker HAT lacks).
+    # The plain hifiberry-dacplus overlay assumes a CS2000 is present and
+    # mis-programs sample-rate clocks — symptom is audio playing at ~2x
+    # speed. The hifiberry-dac overlay targets PCM5102A (no I²C control)
+    # and produces a card with no working clocks on the PCM5122 — symptom
+    # is silence. See agora-cms PR #149 for original wiring.
+    #
+    # Migrate any pre-existing buggy 'hifiberry-dacplus' line (without the
+    # -std suffix) installed by older agora packages.
+    if grep -qxF 'dtoverlay=hifiberry-dacplus' "${BOOT_CFG}"; then
+        sed -i 's|^dtoverlay=hifiberry-dacplus$|dtoverlay=hifiberry-dacplus-std|' "${BOOT_CFG}"
+        echo "Agora: migrated dtoverlay=hifiberry-dacplus -> hifiberry-dacplus-std in ${BOOT_CFG}"
+    fi
+    for line in 'dtoverlay=hifiberry-dacplus-std' 'dtparam=audio=off'; do
         if ! grep -qxF "${line}" "${BOOT_CFG}"; then
             echo "${line}" >> "${BOOT_CFG}"
             echo "Agora: added ${line} to ${BOOT_CFG}"

--- a/shared/board.py
+++ b/shared/board.py
@@ -22,7 +22,9 @@ _MODEL_PATH = Path("/proc/device-tree/model")
 _ASOUND_CARDS_PATH = Path("/proc/asound/cards")
 
 # ALSA card name used by the upstream snd_soc_hifiberry_dacplus driver
-# (which the InnoMaker PCM5122 HAT binds against via dtoverlay=hifiberry-dacplus).
+# (which the InnoMaker PCM5122 HAT binds against via
+# dtoverlay=hifiberry-dacplus-std). The card name is the same regardless
+# of which hifiberry-dacplus* overlay variant is loaded.
 _HIFIBERRY_CARD = "sndrpihifiberry"
 
 
@@ -223,7 +225,7 @@ def detect_audio_device() -> tuple[str, str]:
 
     If a HiFiBerry-compatible DAC HAT (e.g. the InnoMaker PCM5122 HAT) is
     present, ``/proc/asound/cards`` will list a ``sndrpihifiberry`` card
-    once ``dtoverlay=hifiberry-dacplus`` has registered the driver. In
+    once ``dtoverlay=hifiberry-dacplus-std`` has registered the driver. In
     that case audio is routed via ALSA ``hw:`` (raw PCM, no HDMI quirks),
     and we return ``("sndrpihifiberry", "hw")``.
 


### PR DESCRIPTION
## Why

PR #149 wired the InnoMaker HiFi DAC HAT via `dtoverlay=hifiberry-dacplus`. Live testing on Pi 220 (Pi 4 + InnoMaker HAT) showed audio plays at **~2× speed** with that overlay.

Root cause: the plain `hifiberry-dacplus` overlay is for the HiFiBerry DAC+ Pro, which has a CS2000 master-clock chip. The InnoMaker HAT is a bare PCM5122 with no external clock — without the CS2000, the kernel programs the wrong BCLK/LRCLK ratio.

## Overlay matrix (verified on hardware)

| Overlay                       | Result                                                                |
|-------------------------------|-----------------------------------------------------------------------|
| `hifiberry-dacplus`           | ~2× speed playback                                                    |
| `hifiberry-dac`               | Silence (PCM5102A driver, no I²C, leaves PCM5122 uninitialized)       |
| **`hifiberry-dacplus-std`**   | ✅ Correct pitch + full PCM5122 mixer set                              |

`hifiberry-dacplus-std` is the DAC+ Standard variant: PCM5122 over I²C, no external clock chip — exactly InnoMaker's topology.

## Changes

* `packaging/debian/postinst` — add `dtoverlay=hifiberry-dacplus-std` instead of `dtoverlay=hifiberry-dacplus`. Migrate any pre-existing buggy line installed by older agora packages via `sed -i`.
* `shared/board.py` — comment-only update; the ALSA card name (`sndrpihifiberry`) is unchanged across all three overlay variants, so detection logic needs no change.

## Tests

`pytest -p no:timeout tests/test_board.py tests/test_player_service.py` → 169 passed. No test changes needed (card name unchanged).

## Verification

End-to-end MP3 playback on Pi 220 with the `-std` overlay:
- Card: `snd_rpi_hifiberry_dacplus / pcm512x-hifi-0`
- Mixers: Digital (-103 to 0 dB), Analogue, DSP Program, Auto Mute, etc.
- 86s test MP3 played at correct duration / correct pitch — confirmed by ear.
