### PR TITLE
player: persistent mpv + IPC-driven slideshow / loop_count (slideshow refactor)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -78,6 +78,10 @@ class Settings(BaseSettings):
         return self.assets_dir / "splash"
 
     @property
+    def slideshows_dir(self) -> Path:
+        return self.assets_dir / "slideshows"
+
+    @property
     def state_dir(self) -> Path:
         return self.agora_base / "state"
 
@@ -141,6 +145,7 @@ class Settings(BaseSettings):
             self.videos_dir,
             self.images_dir,
             self.splash_dir,
+            self.slideshows_dir,
             self.state_dir,
             self.persist_dir,
             self.log_dir,

--- a/cms_client/asset_manager.py
+++ b/cms_client/asset_manager.py
@@ -73,6 +73,11 @@ class AssetManager:
             return False
         return True
 
+    def get(self, name: str) -> dict | None:
+        """Return a copy of the manifest entry for `name`, or None."""
+        entry = self._manifest.get(name)
+        return dict(entry) if entry else None
+
     def touch(self, name: str) -> None:
         """Update last_used timestamp for an asset."""
         if name in self._manifest:

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1416,7 +1416,18 @@ class CMSClient:
 
         for asset_name, expected_checksum in needed:
             if self.asset_manager.has_asset(asset_name, expected_checksum):
-                continue
+                # Slideshows can be "registered" (parent JSON cached) yet have
+                # one or more slide source files evicted independently. Treat
+                # those as incomplete and force a refetch from CMS.
+                if self._is_slideshow_asset(asset_name) and not self._has_complete_slideshow(
+                    asset_name, expected_checksum,
+                ):
+                    logger.info(
+                        "Slideshow %s registered but incomplete on disk; requesting refetch",
+                        asset_name,
+                    )
+                else:
+                    continue
 
             if expected_checksum:
                 logger.info("Requesting asset: %s (checksum mismatch or missing)", asset_name)
@@ -1524,9 +1535,16 @@ class CMSClient:
     async def _handle_fetch_asset(self, msg: dict, ws) -> None:
         """CMS tells us to download an asset — with budget-aware eviction."""
         asset_name = msg.get("asset_name", "")
+        asset_type = msg.get("asset_type", "")
         download_url = msg.get("download_url", "")
         expected_checksum = msg.get("checksum", "")
         expected_size = msg.get("size_bytes", 0)
+
+        # Slideshow assets carry their payload in msg["slides"]; the outer
+        # download_url is empty.  Dispatch BEFORE the empty-URL guard.
+        if asset_type == "slideshow":
+            await self._handle_fetch_slideshow(msg, ws)
+            return
 
         if not asset_name or not download_url:
             logger.warning("Invalid fetch_asset message: missing fields")
@@ -1571,14 +1589,46 @@ class CMSClient:
                 await ws.send(json.dumps(fail))
                 return
 
-        logger.info("Fetching asset: %s from %s", asset_name, download_url)
+        actual_checksum = await self._download_one_asset(
+            asset_name, asset_type, download_url, expected_checksum,
+        )
+        if actual_checksum is None:
+            return  # already logged
 
+        # Re-trigger desired state if player is waiting for this asset
+        desired = read_state(self.settings.desired_state_path, DesiredState)
+        if desired.asset == asset_name:
+            logger.info("Re-applying desired state for just-downloaded asset: %s", asset_name)
+            desired.timestamp = datetime.now(timezone.utc)
+            write_state(self.settings.desired_state_path, desired)
+
+        ack = {
+            "type": "asset_ack",
+            "protocol_version": PROTOCOL_VERSION,
+            "device_id": self.device_id,
+            "asset_name": asset_name,
+            "checksum": actual_checksum,
+        }
+        await ws.send(json.dumps(ack))
+
+    async def _download_one_asset(
+        self,
+        asset_name: str,
+        asset_type: str,
+        download_url: str,
+        expected_checksum: str,
+    ) -> str | None:
+        """Download one asset to its target dir + register in the manifest.
+
+        Caller is responsible for eviction and ACK. Returns the actual
+        SHA-256 checksum on success or ``None`` on any failure (errors
+        are logged here).
+        """
         try:
             import aiohttp
 
             # Determine target directory using asset_type from CMS (issue #110),
             # falling back to extension-based detection for older CMS versions.
-            asset_type = msg.get("asset_type", "")
             if asset_type in ("video", "saved_stream"):
                 target_dir = self.settings.videos_dir
             elif asset_type == "image":
@@ -1594,7 +1644,10 @@ class CMSClient:
                     # Default to videos/ — player searches there (never root assets/)
                     target_dir = self.settings.videos_dir
 
+            target_dir.mkdir(parents=True, exist_ok=True)
             target_path = target_dir / asset_name
+
+            logger.info("Fetching asset: %s from %s", asset_name, download_url)
 
             async with aiohttp.ClientSession() as session:
                 headers = {}
@@ -1604,7 +1657,7 @@ class CMSClient:
                 async with session.get(download_url, headers=headers) as resp:
                     if resp.status != 200:
                         logger.error("Failed to download %s: HTTP %d", asset_name, resp.status)
-                        return
+                        return None
 
                     sha256 = hashlib.sha256()
                     tmp_path = target_path.with_suffix(".tmp")
@@ -1620,7 +1673,7 @@ class CMSClient:
                         logger.error("Checksum mismatch for %s: expected %s, got %s",
                                      asset_name, expected_checksum, actual_checksum)
                         tmp_path.unlink(missing_ok=True)
-                        return
+                        return None
 
                     os.replace(tmp_path, target_path)
                     file_size = target_path.stat().st_size
@@ -1629,25 +1682,239 @@ class CMSClient:
             # Register in manifest
             rel_path = str(target_path.relative_to(self.settings.assets_dir))
             self.asset_manager.register(asset_name, rel_path, file_size, actual_checksum)
+            return actual_checksum
 
-            # Re-trigger desired state if player is waiting for this asset
-            desired = read_state(self.settings.desired_state_path, DesiredState)
-            if desired.asset == asset_name:
-                logger.info("Re-applying desired state for just-downloaded asset: %s", asset_name)
-                desired.timestamp = datetime.now(timezone.utc)
-                write_state(self.settings.desired_state_path, desired)
+        except Exception:
+            logger.exception("Error fetching asset %s", asset_name)
+            return None
 
-            ack = {
+    # ── Slideshow fetch ──
+
+    async def _handle_fetch_slideshow(self, msg: dict, ws) -> None:
+        """Fetch a slideshow: download each slide, write a local manifest.
+
+        The slideshow's asset_manager entry is registered only after every
+        slide is on disk with a verified checksum. Partial downloads are
+        kept in cache (slides are independently useful) so a retry only
+        re-fetches the missing ones.
+        """
+        asset_name = msg.get("asset_name", "")
+        expected_checksum = msg.get("checksum", "")
+        slides = msg.get("slides") or []
+
+        if not asset_name:
+            logger.warning("Invalid slideshow fetch_asset: missing asset_name")
+            return
+        if not slides or not isinstance(slides, list):
+            logger.warning("Invalid slideshow fetch_asset for %s: empty or non-list slides", asset_name)
+            await ws.send(json.dumps({
+                "type": "fetch_failed",
+                "protocol_version": PROTOCOL_VERSION,
+                "device_id": self.device_id,
+                "asset": asset_name,
+                "reason": "invalid_slideshow_payload",
+            }))
+            return
+
+        # Validate slide descriptors up front
+        for i, slide in enumerate(slides):
+            if not isinstance(slide, dict) or not slide.get("asset_name") or not slide.get("download_url"):
+                logger.warning(
+                    "Invalid slideshow fetch_asset for %s: slide %d malformed", asset_name, i,
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "invalid_slide_descriptor",
+                    "slide_position": i,
+                }))
+                return
+
+        # Fast path: slideshow + every slide already cached with matching checksums.
+        if self._has_complete_slideshow(asset_name, expected_checksum, slides):
+            logger.info("Slideshow already cached and complete: %s", asset_name)
+            await self._touch_slideshow_slides(asset_name, slides)
+            await ws.send(json.dumps({
                 "type": "asset_ack",
                 "protocol_version": PROTOCOL_VERSION,
                 "device_id": self.device_id,
                 "asset_name": asset_name,
-                "checksum": actual_checksum,
-            }
-            await ws.send(json.dumps(ack))
+                "checksum": expected_checksum,
+            }))
+            return
 
-        except Exception:
-            logger.exception("Error fetching asset %s", asset_name)
+        # Deduplicate slides by (asset_name, checksum) for budgeting and
+        # downloading. The playlist itself preserves duplicates and order.
+        unique_missing: dict[tuple[str, str], dict] = {}
+        for slide in slides:
+            key = (slide["asset_name"], slide.get("checksum", ""))
+            if key in unique_missing:
+                continue
+            if self.asset_manager.has_asset(slide["asset_name"], slide.get("checksum") or None):
+                continue
+            unique_missing[key] = slide
+
+        # Bulk eviction once for the sum of missing-slide bytes (the slideshow
+        # manifest itself is sub-1 KB JSON, ignored in budgeting).
+        if unique_missing:
+            total_bytes = sum(s.get("size_bytes", 0) for s in unique_missing.values())
+            scheduled_assets = self._get_scheduled_asset_names()
+            sync_data = self._read_schedule_cache()
+            default_asset = sync_data.get("default_asset") if sync_data else None
+            # Slides we are about to download must also be protected during eviction
+            # so the loop doesn't evict siblings out from under us.
+            protected = scheduled_assets | {key[0] for key in unique_missing.keys()}
+
+            ok = self.asset_manager.evict_for(total_bytes, protected, default_asset)
+            if not ok:
+                logger.error(
+                    "Cannot fit slideshow %s (%d bytes total): budget=%dMB",
+                    asset_name, total_bytes, self.asset_manager.budget_mb,
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "insufficient_storage",
+                    "budget_mb": self.asset_manager.budget_mb,
+                    "available_mb": self.asset_manager.available_bytes // (1024 * 1024),
+                    "required_mb": total_bytes // (1024 * 1024),
+                }))
+                return
+
+        # Download each unique missing slide.
+        for slide in unique_missing.values():
+            actual = await self._download_one_asset(
+                slide["asset_name"],
+                slide.get("asset_type", ""),
+                slide["download_url"],
+                slide.get("checksum", ""),
+            )
+            if actual is None:
+                logger.error(
+                    "Slideshow %s: slide %s download failed",
+                    asset_name, slide["asset_name"],
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "slide_download_failed",
+                    "slide_asset": slide["asset_name"],
+                }))
+                return
+
+        # All slides verified. Write the slideshow manifest with per-slide
+        # checksums so the completeness check has all the data it needs.
+        manifest_payload = {
+            "name": asset_name,
+            "checksum": expected_checksum,
+            "slides": [
+                {
+                    "name": s["asset_name"],
+                    "asset_type": s.get("asset_type", ""),
+                    "checksum": s.get("checksum", ""),
+                    "size_bytes": s.get("size_bytes", 0),
+                    "duration_ms": s.get("duration_ms", 0),
+                    "play_to_end": bool(s.get("play_to_end", False)),
+                }
+                for s in slides
+            ],
+        }
+        self.settings.slideshows_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = self.settings.slideshows_dir / f"{asset_name}.json"
+        atomic_write(manifest_path, json.dumps(manifest_payload, indent=2))
+        manifest_size = manifest_path.stat().st_size
+
+        rel_path = str(manifest_path.relative_to(self.settings.assets_dir))
+        self.asset_manager.register(asset_name, rel_path, manifest_size, expected_checksum)
+        await self._touch_slideshow_slides(asset_name, slides)
+
+        # Re-trigger desired state if player is waiting for this slideshow
+        desired = read_state(self.settings.desired_state_path, DesiredState)
+        if desired.asset == asset_name:
+            logger.info("Re-applying desired state for just-downloaded slideshow: %s", asset_name)
+            desired.timestamp = datetime.now(timezone.utc)
+            write_state(self.settings.desired_state_path, desired)
+
+        logger.info(
+            "Slideshow fetched: %s (%d slides, %d unique downloads)",
+            asset_name, len(slides), len(unique_missing),
+        )
+        await ws.send(json.dumps({
+            "type": "asset_ack",
+            "protocol_version": PROTOCOL_VERSION,
+            "device_id": self.device_id,
+            "asset_name": asset_name,
+            "checksum": expected_checksum,
+        }))
+
+    async def _touch_slideshow_slides(self, _asset_name: str, slides: list[dict]) -> None:
+        """Bump LRU timestamps for every slide source in a slideshow."""
+        seen: set[str] = set()
+        for slide in slides:
+            name = slide.get("asset_name") or slide.get("name")
+            if name and name not in seen:
+                self.asset_manager.touch(name)
+                seen.add(name)
+
+    def _is_slideshow_asset(self, asset_name: str) -> bool:
+        """True iff `asset_name` is registered as a slideshow on this device."""
+        entry = self.asset_manager.get(asset_name)
+        if not isinstance(entry, dict):
+            return False
+        path = entry.get("path", "")
+        return isinstance(path, str) and path.startswith("slideshows/")
+
+    def _read_slideshow_manifest(self, asset_name: str) -> dict | None:
+        """Read and parse a local slideshow manifest. Returns None if missing/corrupt."""
+        path = self.settings.slideshows_dir / f"{asset_name}.json"
+        try:
+            data = json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        if not isinstance(data.get("slides"), list):
+            return None
+        return data
+
+    def _has_complete_slideshow(
+        self,
+        asset_name: str,
+        expected_checksum: str,
+        slides: list[dict] | None = None,
+    ) -> bool:
+        """A slideshow is complete only when:
+
+        - the parent manifest entry is registered with a matching checksum,
+        - the local slideshow JSON parses and matches that checksum,
+        - every referenced slide is in the asset_manager with a matching checksum.
+
+        If `slides` is provided (e.g. fresh from a FETCH_ASSET message), it is
+        used as the authoritative slide list; otherwise the local manifest's
+        slide list is used.
+        """
+        if not self.asset_manager.has_asset(asset_name, expected_checksum):
+            return False
+        manifest = self._read_slideshow_manifest(asset_name)
+        if manifest is None:
+            return False
+        if expected_checksum and manifest.get("checksum") != expected_checksum:
+            return False
+        slide_list = slides if slides is not None else manifest.get("slides", [])
+        for slide in slide_list:
+            slide_name = slide.get("asset_name") or slide.get("name")
+            slide_checksum = slide.get("checksum") or None
+            if not slide_name:
+                return False
+            if not self.asset_manager.has_asset(slide_name, slide_checksum):
+                return False
+        return True
 
     async def _handle_delete_asset(self, msg: dict, ws) -> None:
         asset_name = msg.get("asset_name", "")
@@ -1657,11 +1924,17 @@ class CMSClient:
         self.asset_manager.remove(asset_name)
 
         # Also check disk directly in case it wasn't in manifest
-        for d in [self.settings.videos_dir, self.settings.images_dir, self.settings.splash_dir]:
+        for d in [self.settings.videos_dir, self.settings.images_dir, self.settings.splash_dir, self.settings.slideshows_dir]:
             target = d / asset_name
             if target.exists():
                 target.unlink()
                 break
+            # Slideshows live under <slideshows_dir>/<name>.json, not <name>.
+            if d == self.settings.slideshows_dir:
+                slideshow_target = d / f"{asset_name}.json"
+                if slideshow_target.exists():
+                    slideshow_target.unlink()
+                    break
 
         ack = {
             "type": "asset_deleted",
@@ -1783,7 +2056,7 @@ class CMSClient:
         _safe_unlink(state_dir / "assets.json")
 
         # Wipe assets on disk
-        for subdir in [self.settings.videos_dir, self.settings.images_dir]:
+        for subdir in [self.settings.videos_dir, self.settings.images_dir, self.settings.slideshows_dir]:
             if subdir.exists():
                 for f in subdir.iterdir():
                     if f.is_file():
@@ -1834,7 +2107,7 @@ class CMSClient:
         _safe_unlink(state_dir / "assets.json")
 
         # Wipe asset files on disk
-        for subdir in [self.settings.videos_dir, self.settings.images_dir]:
+        for subdir in [self.settings.videos_dir, self.settings.images_dir, self.settings.slideshows_dir]:
             if subdir.exists():
                 for f in subdir.iterdir():
                     if f.is_file():
@@ -2090,13 +2363,33 @@ class CMSClient:
             return None
 
     def _get_scheduled_asset_names(self) -> set[str]:
-        """Get all asset names from the cached schedule."""
+        """Get all asset names from the cached schedule, expanding any
+        slideshow whose local manifest is on disk to include its slide
+        sources so they are protected from LRU eviction while scheduled."""
         data = self._read_schedule_cache()
         if not data:
             return set()
-        names = set()
+        names: set[str] = set()
         for entry in data.get("schedules", []):
             asset = entry.get("asset")
             if asset:
                 names.add(asset)
+        default_asset = data.get("default_asset")
+        if default_asset:
+            names.add(default_asset)
+        # Expand slideshows → slide sources
+        for asset in list(names):
+            if not self._is_slideshow_asset(asset):
+                continue
+            manifest = self._read_slideshow_manifest(asset)
+            if manifest is None:
+                continue
+            for slide in manifest.get("slides", []):
+                slide_name = slide.get("name") or slide.get("asset_name")
+                if slide_name:
+                    names.add(slide_name)
+        if default_asset:
+            # Caller may use default_asset as a separate protection axis;
+            # leave it in `names` as well for safety but don't double-add.
+            pass
         return names

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -35,6 +35,16 @@ logger = logging.getLogger("agora.cms_client")
 
 PROTOCOL_VERSION = 2
 
+# Firmware-advertised capability flags consumed by the CMS to gate
+# features that require specific firmware behaviour. The CMS persists
+# these on the device row and rejects schedule create/updates that
+# would push assets the device can't render.
+#
+# - "slideshow_v1": this firmware understands ``asset_type=slideshow``
+#   on FETCH_ASSET messages, fetches the manifest+slides, and stores
+#   them under ``assets/slideshows/<name>/``.
+DEVICE_CAPABILITIES = ["slideshow_v1"]
+
 # Bootstrap v2 renewal policy (issue #420 stage B.3).
 # Minimum delay between JWT refreshes on the renewal task, so a clock
 # skew or an early-expired JWT doesn't spin at full speed.
@@ -657,6 +667,7 @@ class CMSClient:
                 "device_name_custom": name_is_custom,
                 "device_type": _get_device_type(),
                 "supported_codecs": supported_codecs(),
+                "capabilities": list(DEVICE_CAPABILITIES),
                 "ip_address": _get_local_ip(),
                 "storage_capacity_mb": cap_mb,
                 "storage_used_mb": used_mb,
@@ -1045,6 +1056,7 @@ class CMSClient:
             asset = winner.get("asset", "")
             checksum = winner.get("asset_checksum")
             loop_count = winner.get("loop_count")
+            asset_type = winner.get("asset_type")
             new_schedule_id = winner.get("id")
             new_schedule_name = winner.get("name", "")
 
@@ -1202,14 +1214,21 @@ class CMSClient:
                     self._last_eval_state = ("waiting", asset, checksum)
                 return
 
-            state_key = ("play", asset, checksum, loop_count)
+            state_key = ("play", asset, checksum, loop_count, asset_type)
             if self._last_eval_state == state_key:
                 return
 
             # Schedule changed — send ENDED for previous, STARTED for new
             self._end_current_playback()
 
-            desired = DesiredState(mode=PlaybackMode.PLAY, asset=asset, loop=True, loop_count=loop_count, expected_checksum=checksum)
+            desired = DesiredState(
+                mode=PlaybackMode.PLAY,
+                asset=asset,
+                asset_type=asset_type,
+                loop=True,
+                loop_count=loop_count,
+                expected_checksum=checksum,
+            )
             write_state(self.settings.desired_state_path, desired)
             self.asset_manager.touch(asset)
             self._last_eval_state = state_key

--- a/player/service.py
+++ b/player/service.py
@@ -540,7 +540,16 @@ class AgoraPlayer:
             return True
 
     def _teardown(self) -> None:
-        self._stop_mpv_event_listener()
+        # NOTE: do *not* stop the persistent mpv IPC event listener here.
+        # _teardown() runs from many normal-operation paths (mode
+        # switches, splash fallback, pipeline error/health-retry, stream
+        # start). Stopping the listener inside _teardown would leave us
+        # without an event source for the rest of the service lifetime —
+        # the thread is only started once at run() startup. Slideshow
+        # play_to_end and scheduled loop_count would then silently fall
+        # back to the legacy duration/respawn paths after the first
+        # teardown. The listener is shutdown explicitly from the run()
+        # signal handler and finally clause instead.
         self._stop_mpv()
         self._stop_cage()
         if self.pipeline:
@@ -864,11 +873,16 @@ class AgoraPlayer:
             # Always unpause before loadfile. If the previous file was
             # an image, mpv may be paused at frame 0; without this the
             # newly-loaded video would never advance and the listener
-            # would never observe end-file{reason=eof}.
+            # would never observe end-file{reason=eof}. Treat this as
+            # fatal: returning False lets _start_mpv() fall back to a
+            # fresh respawn rather than press on with an mpv that may
+            # be stuck paused — which would defeat the very fix this
+            # call exists for.
             ok, _, recv_buf = self._ipc_call(sock, recv_buf,
                 ["set_property", "pause", False])
             if not ok:
                 logger.warning("mpv IPC: set pause=False (pre-load) failed")
+                return False
 
             if is_image:
                 ok, _, recv_buf = self._ipc_call(sock, recv_buf,
@@ -1013,39 +1027,59 @@ class AgoraPlayer:
         ENOENT (mpv not up) and on connection close (mpv respawned).
         Each event dict is stamped with ``_generation`` matching the mpv
         instance that emitted it.
+
+        The outer loop is wrapped in a try/except so an unexpected
+        exception (e.g., from a malformed event or downstream consumer)
+        cannot kill the listener thread permanently — that would silently
+        strand any armed slideshow ``play_to_end`` or scheduled
+        ``loop_count`` since both rely on the listener for completion.
         """
         while not self._mpv_event_stop.is_set():
-            sock = self._mpv_event_connect()
-            if sock is None:
-                # No mpv yet — wait briefly, then retry. wait() returns
-                # True if stop was set during the sleep so we exit cleanly.
+            try:
+                sock = self._mpv_event_connect()
+                if sock is None:
+                    # No mpv yet — wait briefly, then retry. wait() returns
+                    # True if stop was set during the sleep so we exit cleanly.
+                    if self._mpv_event_stop.wait(self._MPV_EVENT_RECONNECT_DELAY_S):
+                        return
+                    continue
+
+                gen = self._mpv_generation
+                self._mpv_event_connected.set()
+                logger.debug("mpv event listener connected (gen %d)", gen)
+                # Subscribe to eof-reached. With keep-open=yes (which we use to
+                # avoid black flashes between assets), mpv suppresses the
+                # end-file{reason=eof} event and instead pauses on the last
+                # frame. The eof-reached property still flips to True at the
+                # natural end of file, so we observe that as our EOF signal.
+                try:
+                    sock.send((json.dumps(
+                        {"command": ["observe_property", 1, "eof-reached"]}
+                    ) + "\n").encode())
+                except OSError:
+                    logger.warning("mpv event listener: observe_property send failed")
+                try:
+                    self._mpv_event_read_loop(sock, gen)
+                finally:
+                    self._mpv_event_connected.clear()
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+                    logger.debug("mpv event listener disconnected; will retry")
+            except Exception:  # pragma: no cover — defensive self-heal
+                logger.exception(
+                    "mpv event listener: unexpected exception; "
+                    "reconnecting after backoff"
+                )
+                # Make sure consumers see us as not-ready so they fall
+                # back to legacy paths until we're reconnected.
+                try:
+                    self._mpv_event_connected.clear()
+                except Exception:
+                    pass
                 if self._mpv_event_stop.wait(self._MPV_EVENT_RECONNECT_DELAY_S):
                     return
-                continue
-
-            gen = self._mpv_generation
-            self._mpv_event_connected.set()
-            logger.debug("mpv event listener connected (gen %d)", gen)
-            # Subscribe to eof-reached. With keep-open=yes (which we use to
-            # avoid black flashes between assets), mpv suppresses the
-            # end-file{reason=eof} event and instead pauses on the last
-            # frame. The eof-reached property still flips to True at the
-            # natural end of file, so we observe that as our EOF signal.
-            try:
-                sock.send((json.dumps(
-                    {"command": ["observe_property", 1, "eof-reached"]}
-                ) + "\n").encode())
-            except OSError:
-                logger.warning("mpv event listener: observe_property send failed")
-            try:
-                self._mpv_event_read_loop(sock, gen)
-            finally:
-                self._mpv_event_connected.clear()
-                try:
-                    sock.close()
-                except OSError:
-                    pass
-                logger.debug("mpv event listener disconnected; will retry")
 
     def _mpv_event_connect(self) -> Optional[socket.socket]:
         """Open a non-blocking-ish AF_UNIX connection to MPV_IPC_SOCKET.
@@ -2271,6 +2305,7 @@ class AgoraPlayer:
         def on_shutdown(signum, frame):
             logger.info("Received signal %d, shutting down", signum)
             self._running = False
+            self._stop_mpv_event_listener()
             self._teardown()
             self.loop.quit()
 
@@ -2282,5 +2317,6 @@ class AgoraPlayer:
         except KeyboardInterrupt:
             pass
         finally:
+            self._stop_mpv_event_listener()
             self._teardown()
             logger.info("Agora Player stopped")

--- a/player/service.py
+++ b/player/service.py
@@ -171,6 +171,8 @@ class AgoraPlayer:
     # __init__ for clarity, but the int is immutable so the class default
     # poses no shared-state hazard.
     _mpv_generation: int = 0
+    _mpv_active_entry_id: Optional[int] = None
+    _mpv_keep_open_active: bool = False
 
     def __init__(self, base_path: str = "/opt/agora"):
         self.base = Path(base_path)
@@ -225,6 +227,8 @@ class AgoraPlayer:
         self._mpv_event_queue: "queue.Queue[dict]" = queue.Queue()
         self._mpv_event_connected = threading.Event()
         self._mpv_generation: int = 0
+        self._mpv_active_entry_id: Optional[int] = None
+        self._mpv_keep_open_active: bool = False
         self._mpv_drain_lock = threading.Lock()
         self._mpv_drain_pending: bool = False
 
@@ -272,6 +276,7 @@ class AgoraPlayer:
     def _clear_slideshow(self) -> None:
         """Tear down slideshow state (cancel timeout, drop manifest)."""
         self._cancel_slide_timeout()
+        self._cancel_play_to_end_watchdog()
         self._slideshow = None
 
     def _start_slideshow(self, name: str, loop_count: Optional[int]) -> None:
@@ -284,6 +289,10 @@ class AgoraPlayer:
             return
         self._cancel_slide_timeout()
         slides = manifest["slides"]
+        # ``epoch`` is bumped each time a slideshow starts so a stale
+        # play_to_end watchdog or late mpv event from a prior slideshow
+        # cannot drive the new one.
+        prev_epoch = (self._slideshow or {}).get("epoch", 0)
         self._slideshow = {
             "name": name,
             "slides": slides,
@@ -291,11 +300,13 @@ class AgoraPlayer:
             "loops_completed": 0,
             "loop_count": loop_count,
             "timeout_id": None,
+            "epoch": prev_epoch + 1,
+            "pending_play_to_end": None,
         }
         self._loops_completed = 0
         logger.info(
-            "Slideshow start: name=%s slides=%d loop_count=%s",
-            name, len(slides), loop_count,
+            "Slideshow start: name=%s slides=%d loop_count=%s epoch=%d",
+            name, len(slides), loop_count, self._slideshow["epoch"],
         )
         self._play_next_slide()
 
@@ -346,11 +357,7 @@ class AgoraPlayer:
         )
 
         if play_to_end:
-            # Video, run to end. We need a fresh mpv subprocess (not IPC
-            # loadfile) so the process actually exits on EOF and
-            # _monitor_mpv detects it to advance to the next slide.
-            self._stop_mpv()
-            self._start_mpv(path, loop=False)
+            self._play_slide_to_end(slide, slide_name, path, ss)
         else:
             # Image, or video with fixed duration: load via IPC if possible
             # then schedule a timed advance.  Loop the source so static
@@ -369,6 +376,86 @@ class AgoraPlayer:
                 started_at=datetime.now(timezone.utc),
             )
         return False
+
+    # Hard cap (ms) on how long we'll wait for an mpv ``end-file`` event
+    # for a play_to_end slide before giving up and advancing. Keeps a
+    # broken video from stalling the slideshow forever.
+    _PLAY_TO_END_WATCHDOG_HARD_CAP_MS = 10 * 60 * 1000
+
+    def _play_slide_to_end(self, slide: dict, slide_name: str,
+                           path: Path, ss: dict) -> None:
+        """Play a slide that runs to its natural end.
+
+        Preferred path: if the mpv IPC event listener is ready, IPC-load
+        the file with ``keep_open=True`` so mpv stays alive past EOF and
+        emits an ``end-file`` event. We arm a ``pending_play_to_end``
+        record on the slideshow so ``_on_mpv_event`` advances when the
+        matching event arrives, plus a watchdog timer in case mpv
+        silently misbehaves.
+
+        Fallback: if the listener isn't ready or the IPC load fails or
+        no entry_id was returned, respawn mpv (legacy path) so EOF causes
+        the process to exit and ``_monitor_mpv`` advances on retcode==0.
+        """
+        if self.is_mpv_event_listener_ready():
+            if self._loadfile_mpv(path, loop=False, muted=False, keep_open=True):
+                entry_id = self._mpv_active_entry_id
+                if entry_id is not None:
+                    duration_ms = int(slide.get("duration_ms") or 0)
+                    # Watchdog: 2× hinted duration with 60s floor, capped
+                    # at the hard cap so a misreported duration can't
+                    # stall the show indefinitely.
+                    if duration_ms > 0:
+                        watchdog_ms = max(duration_ms * 2, 60_000)
+                    else:
+                        watchdog_ms = self._PLAY_TO_END_WATCHDOG_HARD_CAP_MS
+                    watchdog_ms = min(watchdog_ms, self._PLAY_TO_END_WATCHDOG_HARD_CAP_MS)
+                    epoch = ss["epoch"]
+                    watchdog_id = GLib.timeout_add(
+                        watchdog_ms, self._on_play_to_end_watchdog, epoch,
+                    )
+                    ss["pending_play_to_end"] = {
+                        "slide_index": ss["index"] - 1,
+                        "slide_name": slide_name,
+                        "entry_id": entry_id,
+                        "generation": self._mpv_generation,
+                        "armed_at": datetime.now(timezone.utc),
+                        "watchdog_id": watchdog_id,
+                    }
+                    self._update_current(
+                        mode=PlaybackMode.PLAY,
+                        asset=ss["name"],
+                        started_at=datetime.now(timezone.utc),
+                    )
+                    logger.info(
+                        "Slideshow %s: armed play_to_end via IPC "
+                        "(slide=%s entry_id=%s gen=%d watchdog=%dms)",
+                        ss["name"], slide_name, entry_id,
+                        self._mpv_generation, watchdog_ms,
+                    )
+                    return
+                logger.warning(
+                    "Slideshow %s: IPC loadfile succeeded but no "
+                    "playlist_entry_id — falling back to respawn",
+                    ss["name"],
+                )
+            else:
+                logger.info(
+                    "Slideshow %s: IPC loadfile failed for play_to_end "
+                    "slide — falling back to respawn",
+                    ss["name"],
+                )
+        else:
+            logger.info(
+                "Slideshow %s: event listener not ready — using respawn "
+                "path for play_to_end slide",
+                ss["name"],
+            )
+        # Legacy fallback: fresh mpv subprocess so EOF causes the
+        # process to exit; _monitor_mpv detects retcode==0 and calls
+        # _play_next_slide.
+        self._stop_mpv()
+        self._start_mpv(path, loop=False)
 
     def _on_slide_timeout(self) -> bool:
         """GLib timeout callback for image slide expiry."""
@@ -692,7 +779,8 @@ class AgoraPlayer:
                 return False, None, recv_buf
             recv_buf += chunk
 
-    def _loadfile_mpv(self, path: Path, *, loop: bool = False, muted: bool = True) -> bool:
+    def _loadfile_mpv(self, path: Path, *, loop: bool = False,
+                      muted: bool = True, keep_open: bool = False) -> bool:
         """Switch content in a running mpv via IPC socket. Returns True on success.
 
         ``muted`` controls the runtime ``mute`` property after the file is
@@ -701,9 +789,23 @@ class AgoraPlayer:
         with ``--ao=alsa --audio-device=…`` bound (see ``_build_mpv_command``),
         toggling mute via IPC is sufficient — no respawn needed.
 
+        ``keep_open`` controls mpv's ``keep-open`` property. When True, mpv
+        stays loaded after EOF (paused on last frame) and emits an
+        ``end-file`` event that consumers can watch for via the IPC event
+        listener. The slideshow ``play_to_end`` path sets this so it can
+        advance to the next slide via the event listener instead of having
+        to respawn mpv. Always set explicitly (yes/no) so consecutive
+        loadfile calls don't inherit the previous setting.
+
         Each command is correlated by ``request_id`` so events that interleave
         on the same socket (mpv broadcasts events to every connected client)
         cannot be mistaken for the response.
+
+        On success, ``self._mpv_active_entry_id`` is updated with the
+        ``playlist_entry_id`` returned by mpv's loadfile response (None if
+        mpv didn't include one — older mpv versions). Slideshow consumers
+        use this for identity matching against subsequent ``end-file``
+        events.
         """
         if self._mpv_process is None or self._mpv_process.poll() is not None:
             return False
@@ -726,6 +828,21 @@ class AgoraPlayer:
                 logger.warning("mpv IPC: set loop-file failed")
                 return False
 
+            # Set keep-open lazily: only when transitioning. Default is
+            # "no" (mpv's own default), so we only send a command when
+            # arming play_to_end (keep_open=True) or when un-arming after
+            # a previous keep_open=True load. This keeps the IPC chatter
+            # — and the test surface — unchanged for the common case.
+            prev_keep_open = getattr(self, "_mpv_keep_open_active", False)
+            if keep_open or prev_keep_open:
+                keep_open_val = "yes" if keep_open else "no"
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "keep-open", keep_open_val])
+                if not ok:
+                    logger.warning("mpv IPC: set keep-open failed")
+                    return False
+                self._mpv_keep_open_active = bool(keep_open)
+
             ok, _, recv_buf = self._ipc_call(sock, recv_buf, ["set_property", "mute", bool(muted)])
             if not ok:
                 logger.warning("mpv IPC: set mute (pre-load) failed")
@@ -746,11 +863,20 @@ class AgoraPlayer:
                 logger.warning("mpv IPC: set hwdec failed")
                 return False
 
-            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+            ok, data, recv_buf = self._ipc_call(sock, recv_buf,
                 ["loadfile", str(path), "replace"])
             if not ok:
                 logger.warning("mpv IPC: loadfile failed for %s", path.name)
                 return False
+
+            # Capture the playlist entry id from the loadfile response.
+            # mpv 0.36+ returns ``{"playlist_entry_id": N}`` in data; older
+            # versions may not, in which case we leave it None and consumers
+            # fall back to a non-identity-based path.
+            entry_id = None
+            if isinstance(data, dict):
+                entry_id = data.get("playlist_entry_id")
+            self._mpv_active_entry_id = entry_id
 
             # Re-assert mute after loadfile — mpv can reset per-file audio
             ok, _, recv_buf = self._ipc_call(sock, recv_buf,
@@ -768,7 +894,8 @@ class AgoraPlayer:
                         ["set_property", "fullscreen", True])
 
             logger.info(
-                "mpv IPC loadfile succeeded for %s (mute=%s)", path.name, muted,
+                "mpv IPC loadfile succeeded for %s (mute=%s keep_open=%s entry_id=%s)",
+                path.name, muted, keep_open, entry_id,
             )
             return True
         except (OSError, json.JSONDecodeError, IndexError, KeyError) as e:
@@ -854,7 +981,8 @@ class AgoraPlayer:
         relying on event-driven transitions; if False, they fall back to
         the legacy duration/respawn paths so we never get stuck.
         """
-        return self._mpv_event_connected.is_set()
+        evt = getattr(self, "_mpv_event_connected", None)
+        return evt is not None and evt.is_set()
 
     def _mpv_event_loop(self) -> None:
         """Background thread body: connect, read events, dispatch via GLib.
@@ -973,14 +1101,100 @@ class AgoraPlayer:
     def _on_mpv_event(self, event: dict) -> None:
         """Dispatch a single mpv IPC event on the main loop thread.
 
-        Phase 1 leaves this as a no-op pass-through (the listener still
-        runs and is observable for tests / readiness gating). Phase 2
-        wires slideshow ``play_to_end`` advancement here, and Phase 3
-        wires ``loop_count`` accounting.
+        Phase 2 wires slideshow ``play_to_end`` advancement here. We watch
+        for ``end-file`` events whose ``playlist_entry_id`` matches the
+        slide we armed via ``_loadfile_mpv(keep_open=True)`` and whose
+        ``_generation`` matches the mpv instance that was active at arm
+        time. Stale events from a previous mpv (post-respawn) or for a
+        different entry (e.g. user clicking through assets fast) are
+        ignored.
+
+        Reasons handled:
+          * ``eof``    – natural end of the video → advance.
+          * ``error``  – mpv hit a decode error mid-playback → advance
+                         (logs at warning so we don't get stuck on a
+                         broken slide).
+          * ``stop``/``quit``/``redirect`` – ignored. These come from
+            explicit caller action (loadfile of next slide, _stop_mpv,
+            mpv playlist redirects) and must not double-advance.
         """
-        # Phase 2/3 will populate this. Keep the no-op explicit so unit
-        # tests can patch / observe dispatches without subclassing.
-        return None
+        evt_name = event.get("event")
+        if evt_name != "end-file":
+            return
+        ss = self._slideshow
+        if not ss:
+            return
+        pending = ss.get("pending_play_to_end")
+        if not pending:
+            return
+        if event.get("_generation") != pending["generation"]:
+            logger.debug(
+                "mpv end-file ignored: generation mismatch (event=%s armed=%s)",
+                event.get("_generation"), pending["generation"],
+            )
+            return
+        if event.get("playlist_entry_id") != pending["entry_id"]:
+            logger.debug(
+                "mpv end-file ignored: entry_id mismatch (event=%s armed=%s)",
+                event.get("playlist_entry_id"), pending["entry_id"],
+            )
+            return
+        reason = event.get("reason")
+        if reason in ("stop", "quit", "redirect"):
+            logger.debug("mpv end-file reason=%s — ignoring (caller-initiated)", reason)
+            return
+        if reason == "error":
+            logger.warning(
+                "mpv end-file reason=error for slide %d (%s) — advancing anyway",
+                pending["slide_index"], pending["slide_name"],
+            )
+        else:
+            logger.info(
+                "mpv end-file reason=%s for slide %d (%s) — advancing",
+                reason, pending["slide_index"], pending["slide_name"],
+            )
+        # Cancel watchdog and clear pending before advancing so a re-entrant
+        # _play_next_slide can install a fresh pending dict.
+        self._cancel_play_to_end_watchdog()
+        ss["pending_play_to_end"] = None
+        self._play_next_slide()
+
+    def _cancel_play_to_end_watchdog(self) -> None:
+        """Cancel any pending play_to_end watchdog timeout."""
+        ss = self._slideshow
+        if not ss:
+            return
+        pending = ss.get("pending_play_to_end")
+        if not pending:
+            return
+        wid = pending.get("watchdog_id")
+        if wid:
+            try:
+                GLib.source_remove(wid)
+            except Exception:
+                pass
+            pending["watchdog_id"] = None
+
+    def _on_play_to_end_watchdog(self, slideshow_epoch: int) -> bool:
+        """GLib timeout fired when an armed play_to_end slide hasn't ended
+        within its watchdog window. Advances anyway so we never get stuck.
+
+        Returns False (one-shot).
+        """
+        ss = self._slideshow
+        if not ss or ss.get("epoch") != slideshow_epoch:
+            return False
+        pending = ss.get("pending_play_to_end")
+        if not pending:
+            return False
+        logger.warning(
+            "play_to_end watchdog fired for slide %d (%s) — advancing",
+            pending["slide_index"], pending["slide_name"],
+        )
+        pending["watchdog_id"] = None
+        ss["pending_play_to_end"] = None
+        self._play_next_slide()
+        return False
 
     def _start_mpv(self, path: Path, *, loop: bool = False) -> None:
         """Launch mpv subprocess for media playback via DRM output.
@@ -1010,6 +1224,8 @@ class AgoraPlayer:
         logger.info("Starting mpv: %s", " ".join(cmd))
         try:
             self._mpv_generation += 1
+            self._mpv_keep_open_active = False
+            self._mpv_active_entry_id = None
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1050,6 +1266,8 @@ class AgoraPlayer:
         logger.info("Starting stream: %s", " ".join(cmd))
         try:
             self._mpv_generation += 1
+            self._mpv_keep_open_active = False
+            self._mpv_active_entry_id = None
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1357,6 +1575,8 @@ class AgoraPlayer:
                     logger.info("Showing splash via mpv: %s", splash.name)
                     try:
                         self._mpv_generation += 1
+                        self._mpv_keep_open_active = False
+                        self._mpv_active_entry_id = None
                         self._mpv_process = subprocess.Popen(
                             cmd,
                             stdout=subprocess.DEVNULL,

--- a/player/service.py
+++ b/player/service.py
@@ -1401,7 +1401,33 @@ class AgoraPlayer:
         self._mpv_process = None
 
         if retcode == 0:
-            # Normal exit — EOS
+            # Normal exit — EOS.
+            # If the IPC event listener was armed for this generation, it
+            # means it missed the corresponding end-file event (or mpv exited
+            # before delivering it). Log loudly and clear the stale arm so
+            # we don't fire splash twice.
+            if self._scheduled_pending is not None:
+                logger.warning(
+                    "mpv exited (rc=0) while _scheduled_pending was armed "
+                    "for %s (%d/%d loops) — listener missed events; "
+                    "monitor will handle splash transition",
+                    self._scheduled_pending.get("asset_name"),
+                    self._scheduled_pending.get("completed_count"),
+                    self._scheduled_pending.get("target_count"),
+                )
+                self._scheduled_pending = None
+            if self._slideshow is not None:
+                pending_pte = self._slideshow.get("pending_play_to_end")
+                if pending_pte is not None:
+                    logger.warning(
+                        "mpv exited (rc=0) while slideshow pending_play_to_end "
+                        "was armed for slide %d (%s) — listener missed events; "
+                        "monitor will advance",
+                        pending_pte.get("slide_index"),
+                        pending_pte.get("slide_name"),
+                    )
+                    self._cancel_play_to_end_watchdog()
+                    self._slideshow["pending_play_to_end"] = None
             logger.info("mpv finished playing %s", asset_name)
             # Slideshow: advance to next slide regardless of slide loop flag.
             if self._slideshow:
@@ -1438,6 +1464,13 @@ class AgoraPlayer:
                 logger.info("Playback complete (no loop), switching to splash")
                 self._show_splash()
         else:
+            # Error exit — also clear any stale listener-armed pendings so
+            # they can't drive a re-entrant transition.
+            if self._scheduled_pending is not None:
+                self._scheduled_pending = None
+            if self._slideshow is not None and self._slideshow.get("pending_play_to_end"):
+                self._cancel_play_to_end_watchdog()
+                self._slideshow["pending_play_to_end"] = None
             # Error exit
             error_msg = f"mpv exited with code {retcode}"
             if stderr_output:

--- a/player/service.py
+++ b/player/service.py
@@ -1,5 +1,6 @@
 """Agora Player Service — watches desired state and manages media playback."""
 
+import itertools
 import json
 import logging
 import os
@@ -143,6 +144,10 @@ class AgoraPlayer:
     and mpv subprocess on Pi 4/Pi 5 for video playback with hardware decoding.
     """
 
+    # Class-level default so tests that bypass __init__ still see this
+    # attribute as None (matches "not in a slideshow").
+    _slideshow: Optional[dict] = None
+
     IMAGE_PIPELINE_JPEG = (
         'filesrc location="{path}" ! '
         "jpegparse ! jpegdec ! videoconvert ! videoscale add-borders=true ! "
@@ -191,6 +196,10 @@ class AgoraPlayer:
         # involving None (indeterminate) commit immediately.
         self._display_pending: dict[str, tuple[Optional[bool], int]] = {}
 
+        # Slideshow sequencer state. None when not playing a slideshow.
+        # Populated by _start_slideshow; cleared by _clear_slideshow.
+        self._slideshow: Optional[dict] = None
+
         Gst.init(None)
 
     # ── Asset resolution ──
@@ -201,6 +210,145 @@ class AgoraPlayer:
             if path.is_file():
                 return path
         return None
+
+    # ── Slideshow sequencer ──
+
+    def _read_slideshow_manifest(self, name: str) -> Optional[dict]:
+        """Read and validate a slideshow manifest from the assets dir.
+
+        Returns the parsed dict or None if missing/invalid.
+        """
+        path = self.assets_dir / "slideshows" / f"{name}.json"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error("Slideshow manifest %s unreadable: %s", path, e)
+            return None
+        if not isinstance(data, dict):
+            return None
+        slides = data.get("slides")
+        if not isinstance(slides, list) or not slides:
+            return None
+        return data
+
+    def _cancel_slide_timeout(self) -> None:
+        """Cancel any pending GLib slide-advance timeout."""
+        ss = self._slideshow
+        if ss and ss.get("timeout_id"):
+            try:
+                GLib.source_remove(ss["timeout_id"])
+            except Exception:
+                pass
+            ss["timeout_id"] = None
+
+    def _clear_slideshow(self) -> None:
+        """Tear down slideshow state (cancel timeout, drop manifest)."""
+        self._cancel_slide_timeout()
+        self._slideshow = None
+
+    def _start_slideshow(self, name: str, loop_count: Optional[int]) -> None:
+        """Begin sequencing slides from the named slideshow manifest."""
+        manifest = self._read_slideshow_manifest(name)
+        if not manifest:
+            logger.error("Slideshow not playable: %s — showing splash", name)
+            self._update_current(error=f"Slideshow not found: {name}")
+            self._show_splash()
+            return
+        self._cancel_slide_timeout()
+        slides = manifest["slides"]
+        self._slideshow = {
+            "name": name,
+            "slides": slides,
+            "index": 0,
+            "loops_completed": 0,
+            "loop_count": loop_count,
+            "timeout_id": None,
+        }
+        self._loops_completed = 0
+        logger.info(
+            "Slideshow start: name=%s slides=%d loop_count=%s",
+            name, len(slides), loop_count,
+        )
+        self._play_next_slide()
+
+    def _play_next_slide(self) -> bool:
+        """Advance to the next slide in the active slideshow.
+
+        Loops back to the first slide when end is reached, honouring the
+        slideshow-level loop_count.  Returns False so it can also be used
+        as a one-shot GLib timeout callback.
+        """
+        ss = self._slideshow
+        if not ss:
+            return False
+
+        if ss["index"] >= len(ss["slides"]):
+            ss["loops_completed"] += 1
+            self._loops_completed = ss["loops_completed"]
+            target = ss.get("loop_count")
+            if target is not None and ss["loops_completed"] >= target:
+                logger.info(
+                    "Slideshow %s: completed %d/%d loops, → splash",
+                    ss["name"], ss["loops_completed"], target,
+                )
+                self._clear_slideshow()
+                self._show_splash()
+                return False
+            ss["index"] = 0  # next loop
+
+        slide = ss["slides"][ss["index"]]
+        ss["index"] += 1
+        slide_name = slide.get("name") or ""
+        path = self._resolve_asset(slide_name)
+        if not path:
+            logger.error(
+                "Slideshow %s: slide %d (%s) missing on disk — skipping",
+                ss["name"], ss["index"] - 1, slide_name,
+            )
+            return self._play_next_slide()
+
+        self._cancel_slide_timeout()
+        is_video_slide = (slide.get("asset_type") == "video")
+        play_to_end = bool(slide.get("play_to_end")) and is_video_slide
+
+        logger.info(
+            "Slideshow %s: slide %d/%d %s (play_to_end=%s)",
+            ss["name"], ss["index"], len(ss["slides"]),
+            slide_name, play_to_end,
+        )
+
+        if play_to_end:
+            # Video, run to end. We need a fresh mpv subprocess (not IPC
+            # loadfile) so the process actually exits on EOF and
+            # _monitor_mpv detects it to advance to the next slide.
+            self._stop_mpv()
+            self._start_mpv(path, loop=False)
+        else:
+            # Image, or video with fixed duration: load via IPC if possible
+            # then schedule a timed advance.  Loop the source so static
+            # images/short videos don't black out before the timeout fires.
+            if not self._loadfile_mpv(path, loop=True, muted=False):
+                self._start_mpv(path, loop=True)
+            duration_ms = int(slide.get("duration_ms") or 0)
+            if duration_ms <= 0:
+                duration_ms = 10000  # safe default
+            ss["timeout_id"] = GLib.timeout_add(
+                duration_ms, self._on_slide_timeout,
+            )
+            self._update_current(
+                mode=PlaybackMode.PLAY,
+                asset=ss["name"],
+                started_at=datetime.now(timezone.utc),
+            )
+        return False
+
+    def _on_slide_timeout(self) -> bool:
+        """GLib timeout callback for image slide expiry."""
+        ss = self._slideshow
+        if ss:
+            ss["timeout_id"] = None
+        self._play_next_slide()
+        return False  # one-shot
 
     def _find_splash(self) -> Optional[Path]:
         # 1. Check user-configured splash in state/splash
@@ -456,6 +604,65 @@ class AgoraPlayer:
 
     _IMAGE_EXTS = frozenset((".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"))
 
+    # Per-command IPC timeout (seconds). mpv responds promptly under
+    # normal conditions; we'd rather log + fail than block forever.
+    _IPC_CMD_TIMEOUT_S = 1.5
+
+    def _ipc_call(self, sock, recv_buf: bytes, command: list, *,
+                  timeout_s: Optional[float] = None):
+        """Send a JSON IPC command stamped with a request_id and wait for the
+        matching response. Demultiplexes events that interleave on the same
+        socket (mpv broadcasts events to every connected client).
+
+        Returns ``(success: bool, data, new_recv_buf: bytes)``. On success
+        the response had ``error == "success"``; on parse / timeout / socket
+        error returns ``(False, None, recv_buf)``.
+
+        ``recv_buf`` carries any bytes already read but not yet parsed across
+        successive calls on the same socket so partial JSON lines are not
+        lost.
+        """
+        req_id = next(self._mpv_ipc_counter)
+        msg = json.dumps({"command": command, "request_id": req_id}).encode() + b"\n"
+        if timeout_s is None:
+            timeout_s = self._IPC_CMD_TIMEOUT_S
+        try:
+            sock.sendall(msg)
+        except OSError:
+            return False, None, recv_buf
+
+        deadline = time.monotonic() + timeout_s
+        while True:
+            # Drain any complete lines we already have buffered
+            while b"\n" in recv_buf:
+                line, recv_buf = recv_buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    resp = json.loads(line.decode())
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if "event" in resp:
+                    # mpv broadcasts events on every IPC client; drop
+                    continue
+                if resp.get("request_id") == req_id:
+                    return resp.get("error") == "success", resp.get("data"), recv_buf
+                # response for a different request_id — drop and keep looking
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, None, recv_buf
+            try:
+                sock.settimeout(min(remaining, 0.5))
+                chunk = sock.recv(4096)
+            except OSError:
+                # socket.timeout is an OSError subclass since Python 3.10
+                return False, None, recv_buf
+            if not chunk:
+                return False, None, recv_buf
+            recv_buf += chunk
+
     def _loadfile_mpv(self, path: Path, *, loop: bool = False, muted: bool = True) -> bool:
         """Switch content in a running mpv via IPC socket. Returns True on success.
 
@@ -464,60 +671,73 @@ class AgoraPlayer:
         ``muted=False``. Because the underlying mpv process always launches
         with ``--ao=alsa --audio-device=…`` bound (see ``_build_mpv_command``),
         toggling mute via IPC is sufficient — no respawn needed.
+
+        Each command is correlated by ``request_id`` so events that interleave
+        on the same socket (mpv broadcasts events to every connected client)
+        cannot be mistaken for the response.
         """
         if self._mpv_process is None or self._mpv_process.poll() is not None:
             return False
         is_image = path.suffix.lower() in self._IMAGE_EXTS
+
+        # Fresh request_id sequence per IPC session — responses on this
+        # socket are single-shot, no need for global uniqueness.
+        self._mpv_ipc_counter = itertools.count()
+
+        sock = None
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(2)
             sock.connect(MPV_IPC_SOCKET)
-            # Set loop property before loading
+            recv_buf = b""
+
             loop_val = "inf" if loop else "no"
-            sock.sendall(json.dumps({"command": ["set_property", "loop-file", loop_val]}).encode() + b"\n")
-            sock.recv(512)  # read response
-            # Toggle mute to match the policy for the incoming content
-            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
-            sock.recv(512)
-            # Set image-display-duration based on content type
-            if is_image:
-                sock.sendall(json.dumps({"command": ["set_property", "image-display-duration", "inf"]}).encode() + b"\n")
-                sock.recv(512)
-                sock.sendall(json.dumps({"command": ["set_property", "hwdec", "no"]}).encode() + b"\n")
-                sock.recv(512)
-            else:
-                sock.sendall(json.dumps({"command": ["set_property", "hwdec", "drm-copy"]}).encode() + b"\n")
-                sock.recv(512)
-            # Load the new file (replace = stop current, play new)
-            sock.sendall(json.dumps({"command": ["loadfile", str(path), "replace"]}).encode() + b"\n")
-            time.sleep(0.3)  # allow mpv to process and queue response + events
-            resp = sock.recv(4096)
-            # Parse response lines — look for the loadfile result, skip events
-            success = False
-            for line in resp.decode().strip().split("\n"):
-                try:
-                    msg = json.loads(line)
-                    if "event" not in msg and msg.get("error") == "success":
-                        success = True
-                        break
-                except json.JSONDecodeError:
-                    continue
-            if not success:
-                sock.close()
-                logger.warning("mpv IPC loadfile — no success in response: %s", resp[:200])
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf, ["set_property", "loop-file", loop_val])
+            if not ok:
+                logger.warning("mpv IPC: set loop-file failed")
                 return False
-            # Re-assert mute after loadfile — mpv can reset per-file audio state
-            sock.sendall(json.dumps({"command": ["set_property", "mute", bool(muted)]}).encode() + b"\n")
-            sock.recv(512)
-            # When loading an image, toggle fullscreen to force DRM plane refresh
+
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf, ["set_property", "mute", bool(muted)])
+            if not ok:
+                logger.warning("mpv IPC: set mute (pre-load) failed")
+                return False
+
             if is_image:
-                time.sleep(0.2)
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "image-display-duration", "inf"])
+                if not ok:
+                    logger.warning("mpv IPC: set image-display-duration failed")
+                    return False
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "hwdec", "no"])
+            else:
+                ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "hwdec", "drm-copy"])
+            if not ok:
+                logger.warning("mpv IPC: set hwdec failed")
+                return False
+
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["loadfile", str(path), "replace"])
+            if not ok:
+                logger.warning("mpv IPC: loadfile failed for %s", path.name)
+                return False
+
+            # Re-assert mute after loadfile — mpv can reset per-file audio
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["set_property", "mute", bool(muted)])
+            if not ok:
+                logger.warning("mpv IPC: set mute (post-load) failed (continuing)")
+
+            # When loading an image, toggle fullscreen to force DRM plane refresh.
+            # Don't fail the whole call if a toggle drops; best-effort.
+            if is_image:
                 for _ in range(3):
-                    sock.sendall(json.dumps({"command": ["set_property", "fullscreen", False]}).encode() + b"\n")
-                    sock.recv(512)
-                    sock.sendall(json.dumps({"command": ["set_property", "fullscreen", True]}).encode() + b"\n")
-                    sock.recv(512)
-            sock.close()
+                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                        ["set_property", "fullscreen", False])
+                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                        ["set_property", "fullscreen", True])
+
             logger.info(
                 "mpv IPC loadfile succeeded for %s (mute=%s)", path.name, muted,
             )
@@ -525,6 +745,12 @@ class AgoraPlayer:
         except (OSError, json.JSONDecodeError, IndexError, KeyError) as e:
             logger.warning("mpv IPC loadfile failed: %s — will restart mpv", e)
             return False
+        finally:
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
 
     def _start_mpv(self, path: Path, *, loop: bool = False) -> None:
         """Launch mpv subprocess for media playback via DRM output.
@@ -641,10 +867,19 @@ class AgoraPlayer:
         if self._mpv_process is None:
             return False
 
-        # Check if still supposed to be playing this asset
-        if (
+        # Check if still supposed to be playing this asset.
+        # Slideshow mode: current_desired.asset is the slideshow name (e.g.
+        # "Test Slideshow"), but mpv was launched for an individual slide
+        # file. Skip the asset_name match in that case — exit handling
+        # routes through _play_next_slide which knows the slideshow state.
+        if self._slideshow is None and (
             not self.current_desired
             or self.current_desired.asset != asset_name
+            or self.current_desired.mode != PlaybackMode.PLAY
+        ):
+            return False
+        if self._slideshow is not None and (
+            not self.current_desired
             or self.current_desired.mode != PlaybackMode.PLAY
         ):
             return False
@@ -665,6 +900,10 @@ class AgoraPlayer:
         if retcode == 0:
             # Normal exit — EOS
             logger.info("mpv finished playing %s", asset_name)
+            # Slideshow: advance to next slide regardless of slide loop flag.
+            if self._slideshow:
+                self._play_next_slide()
+                return False
             # Live streams: auto-restart on EOS (stream may have dropped)
             if (
                 self.current_desired
@@ -1094,16 +1333,19 @@ class AgoraPlayer:
         logger.info("Applying desired state: %s", desired.model_dump_json())
 
         if desired.mode == PlaybackMode.STOP:
+            self._clear_slideshow()
             self.current_desired = desired
             self._show_splash()
             return
 
         if desired.mode == PlaybackMode.SPLASH:
+            self._clear_slideshow()
             self.current_desired = desired
             self._show_splash()
             return
 
         if desired.mode == PlaybackMode.PLAY and desired.url:
+            self._clear_slideshow()
             # Stream assets → mpv (handles HLS/DASH/RTMP natively)
             if desired.asset_type == "stream":
                 mpv_proc = self._mpv_process
@@ -1130,6 +1372,25 @@ class AgoraPlayer:
             return
 
         if desired.mode == PlaybackMode.PLAY and desired.asset:
+            # Slideshow: read manifest from assets/slideshows/<name>.json
+            # and sequence slides ourselves.  Bypass single-file resolution.
+            if desired.asset_type == "slideshow":
+                # If the same slideshow is already running, leave it alone;
+                # otherwise (re)start.  Manifest changes show up via the
+                # CMS-side checksum and will arrive as a fresh fetch.
+                ss = self._slideshow
+                if ss and ss.get("name") == desired.asset:
+                    self.current_desired = desired
+                    return
+                self.current_desired = desired
+                self._health_retries = 0
+                self._loops_completed = 0
+                self._start_slideshow(desired.asset, desired.loop_count)
+                return
+
+            # Leaving any in-flight slideshow before single-asset playback.
+            self._clear_slideshow()
+
             path = self._resolve_asset(desired.asset)
             if not path:
                 logger.error("Asset not found: %s — showing splash", desired.asset)

--- a/player/service.py
+++ b/player/service.py
@@ -4,9 +4,11 @@ import itertools
 import json
 import logging
 import os
+import queue
 import signal
 import socket
 import subprocess
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -164,6 +166,12 @@ class AgoraPlayer:
 
     DEFAULT_SPLASH_CONFIG = "splash/default.png"
 
+    # Class-level default so bypass-init test fixtures see a sane value
+    # before _start_mpv increments it. Real instances overwrite via
+    # __init__ for clarity, but the int is immutable so the class default
+    # poses no shared-state hazard.
+    _mpv_generation: int = 0
+
     def __init__(self, base_path: str = "/opt/agora"):
         self.base = Path(base_path)
         self.state_dir = self.base / "state"
@@ -199,6 +207,26 @@ class AgoraPlayer:
         # Slideshow sequencer state. None when not playing a slideshow.
         # Populated by _start_slideshow; cleared by _clear_slideshow.
         self._slideshow: Optional[dict] = None
+
+        # ── mpv IPC event listener (Phase 1) ──
+        #
+        # A persistent background thread connects to ``MPV_IPC_SOCKET`` and
+        # reads events broadcast by mpv (start-file, end-file, etc.) onto
+        # ``_mpv_event_queue``. Events are drained on the GLib main loop
+        # via ``GLib.idle_add(self._drain_mpv_events)`` so all dispatch
+        # happens single-threaded.
+        #
+        # ``_mpv_generation`` is bumped every time a fresh mpv subprocess is
+        # spawned. Each event is stamped with the generation that was
+        # current when the listener was connected, so consumers (slideshow,
+        # loop_count) can ignore stale events from a previous mpv instance.
+        self._mpv_event_thread: Optional[threading.Thread] = None
+        self._mpv_event_stop = threading.Event()
+        self._mpv_event_queue: "queue.Queue[dict]" = queue.Queue()
+        self._mpv_event_connected = threading.Event()
+        self._mpv_generation: int = 0
+        self._mpv_drain_lock = threading.Lock()
+        self._mpv_drain_pending: bool = False
 
         Gst.init(None)
 
@@ -423,6 +451,7 @@ class AgoraPlayer:
             return True
 
     def _teardown(self) -> None:
+        self._stop_mpv_event_listener()
         self._stop_mpv()
         self._stop_cage()
         if self.pipeline:
@@ -752,6 +781,207 @@ class AgoraPlayer:
                 except OSError:
                     pass
 
+    # ── mpv IPC event listener (Phase 1) ──
+    #
+    # Long-lived thread that subscribes to mpv's IPC event stream so the
+    # main loop can react to ``end-file`` / ``start-file`` / etc. without
+    # having to poll ``_mpv_process.poll()`` or run a watchdog timer per
+    # asset. This is the foundation for identity-based slideshow EOF
+    # tracking (Phase 2) and mpv-native finite-loop accounting (Phase 3).
+
+    # Reconnect cadence when the IPC socket is unavailable (e.g. mpv not
+    # yet up, or restarting between schedules). Kept short so a freshly
+    # spawned mpv is picked up promptly.
+    _MPV_EVENT_RECONNECT_DELAY_S = 0.3
+
+    # Read timeout so the listener checks ``_mpv_event_stop`` regularly
+    # and exits promptly during shutdown without abandoning a recv() call.
+    _MPV_EVENT_READ_TIMEOUT_S = 0.5
+
+    def _start_mpv_event_listener(self) -> None:
+        """Start the persistent mpv IPC event listener thread. Idempotent.
+
+        The thread reconnects to ``MPV_IPC_SOCKET`` whenever it becomes
+        available, so it is safe to call before mpv has been spawned.
+        """
+        # Lazy-init threading primitives so bypass-init test fixtures
+        # that go through run() don't have to set them up by hand.
+        if getattr(self, "_mpv_event_stop", None) is None:
+            self._mpv_event_stop = threading.Event()
+        if getattr(self, "_mpv_event_connected", None) is None:
+            self._mpv_event_connected = threading.Event()
+        if getattr(self, "_mpv_event_queue", None) is None:
+            self._mpv_event_queue = queue.Queue()
+        if getattr(self, "_mpv_drain_lock", None) is None:
+            self._mpv_drain_lock = threading.Lock()
+        if not hasattr(self, "_mpv_drain_pending"):
+            self._mpv_drain_pending = False
+        existing = getattr(self, "_mpv_event_thread", None)
+        if existing is not None and existing.is_alive():
+            return
+        self._mpv_event_stop.clear()
+        self._mpv_event_thread = threading.Thread(
+            target=self._mpv_event_loop,
+            name="mpv-event-listener",
+            daemon=True,
+        )
+        self._mpv_event_thread.start()
+        logger.info("mpv event listener thread started")
+
+    def _stop_mpv_event_listener(self) -> None:
+        """Signal the listener to stop and wait briefly for it to exit."""
+        # Defensive: this is called from _teardown, which can run in test
+        # contexts where the listener fields were never initialised
+        # (bypass-init fixtures). Treat missing fields as "no listener".
+        stop_evt = getattr(self, "_mpv_event_stop", None)
+        if stop_evt is None:
+            return
+        stop_evt.set()
+        connected_evt = getattr(self, "_mpv_event_connected", None)
+        if connected_evt is not None:
+            connected_evt.clear()
+        t = getattr(self, "_mpv_event_thread", None)
+        if t is not None and t.is_alive():
+            t.join(timeout=2.0)
+            if t.is_alive():
+                logger.warning("mpv event listener did not exit within 2s")
+        self._mpv_event_thread = None
+
+    def is_mpv_event_listener_ready(self) -> bool:
+        """Return True if the listener is currently connected to a running mpv.
+
+        Consumers (slideshow ``play_to_end``, loop_count) check this before
+        relying on event-driven transitions; if False, they fall back to
+        the legacy duration/respawn paths so we never get stuck.
+        """
+        return self._mpv_event_connected.is_set()
+
+    def _mpv_event_loop(self) -> None:
+        """Background thread body: connect, read events, dispatch via GLib.
+
+        Runs until ``self._mpv_event_stop`` is set. Auto-reconnects on
+        ENOENT (mpv not up) and on connection close (mpv respawned).
+        Each event dict is stamped with ``_generation`` matching the mpv
+        instance that emitted it.
+        """
+        while not self._mpv_event_stop.is_set():
+            sock = self._mpv_event_connect()
+            if sock is None:
+                # No mpv yet — wait briefly, then retry. wait() returns
+                # True if stop was set during the sleep so we exit cleanly.
+                if self._mpv_event_stop.wait(self._MPV_EVENT_RECONNECT_DELAY_S):
+                    return
+                continue
+
+            gen = self._mpv_generation
+            self._mpv_event_connected.set()
+            logger.debug("mpv event listener connected (gen %d)", gen)
+            try:
+                self._mpv_event_read_loop(sock, gen)
+            finally:
+                self._mpv_event_connected.clear()
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+                logger.debug("mpv event listener disconnected; will retry")
+
+    def _mpv_event_connect(self) -> Optional[socket.socket]:
+        """Open a non-blocking-ish AF_UNIX connection to MPV_IPC_SOCKET.
+
+        Returns the connected socket on success, or None if mpv isn't up.
+        """
+        sock = None
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(self._MPV_EVENT_READ_TIMEOUT_S)
+            sock.connect(MPV_IPC_SOCKET)
+            return sock
+        except OSError:
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            return None
+
+    def _mpv_event_read_loop(self, sock: socket.socket, generation: int) -> None:
+        """Inner loop: read newline-delimited JSON events until disconnect."""
+        recv_buf = b""
+        while not self._mpv_event_stop.is_set():
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                # Expected — gives us a chance to check the stop flag.
+                continue
+            except OSError:
+                return
+            if not chunk:
+                # mpv closed its end of the socket
+                return
+            recv_buf += chunk
+            while b"\n" in recv_buf:
+                line, recv_buf = recv_buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line.decode())
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                if "event" not in msg:
+                    # Command responses go to the requesting client only
+                    # in practice, but be defensive in case mpv changes.
+                    continue
+                msg["_generation"] = generation
+                self._mpv_event_queue.put(msg)
+                self._schedule_drain()
+
+    def _schedule_drain(self) -> None:
+        """Schedule a single GLib.idle_add of the drain callback.
+
+        If a drain is already pending, do nothing — the existing callback
+        will dequeue everything currently buffered when it runs. This
+        prevents flooding the main loop with idle callbacks on bursty
+        event streams.
+        """
+        with self._mpv_drain_lock:
+            if self._mpv_drain_pending:
+                return
+            self._mpv_drain_pending = True
+        GLib.idle_add(self._drain_mpv_events)
+
+    def _drain_mpv_events(self) -> bool:
+        """GLib idle callback: drain the queue and dispatch each event.
+
+        Always runs on the main loop thread, so consumers don't need
+        their own locks. Returns False (one-shot).
+        """
+        with self._mpv_drain_lock:
+            self._mpv_drain_pending = False
+        while True:
+            try:
+                event = self._mpv_event_queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                self._on_mpv_event(event)
+            except Exception:  # pragma: no cover — defensive
+                logger.exception("Error handling mpv event")
+        return False
+
+    def _on_mpv_event(self, event: dict) -> None:
+        """Dispatch a single mpv IPC event on the main loop thread.
+
+        Phase 1 leaves this as a no-op pass-through (the listener still
+        runs and is observable for tests / readiness gating). Phase 2
+        wires slideshow ``play_to_end`` advancement here, and Phase 3
+        wires ``loop_count`` accounting.
+        """
+        # Phase 2/3 will populate this. Keep the no-op explicit so unit
+        # tests can patch / observe dispatches without subclassing.
+        return None
+
     def _start_mpv(self, path: Path, *, loop: bool = False) -> None:
         """Launch mpv subprocess for media playback via DRM output.
 
@@ -779,6 +1009,7 @@ class AgoraPlayer:
         cmd = _build_mpv_command(path, muted=False, loop=loop)
         logger.info("Starting mpv: %s", " ".join(cmd))
         try:
+            self._mpv_generation += 1
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -818,6 +1049,7 @@ class AgoraPlayer:
         cmd = _build_stream_command(url)
         logger.info("Starting stream: %s", " ".join(cmd))
         try:
+            self._mpv_generation += 1
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1124,6 +1356,7 @@ class AgoraPlayer:
                     cmd = _build_mpv_command(splash, muted=True, loop=True)
                     logger.info("Showing splash via mpv: %s", splash.name)
                     try:
+                        self._mpv_generation += 1
                         self._mpv_process = subprocess.Popen(
                             cmd,
                             stdout=subprocess.DEVNULL,
@@ -1615,6 +1848,10 @@ class AgoraPlayer:
 
         # Suppress VT console text (preserves Plymouth retained splash on framebuffer)
         self._suppress_console()
+
+        # Start the persistent mpv IPC event listener early. It auto-
+        # reconnects, so it's safe to run before the first mpv is spawned.
+        self._start_mpv_event_listener()
 
         # Apply initial state (may show splash, which can take seconds)
         self.apply_desired()

--- a/player/service.py
+++ b/player/service.py
@@ -173,6 +173,7 @@ class AgoraPlayer:
     _mpv_generation: int = 0
     _mpv_active_entry_id: Optional[int] = None
     _mpv_keep_open_active: bool = False
+    _scheduled_pending: Optional[dict] = None
 
     def __init__(self, base_path: str = "/opt/agora"):
         self.base = Path(base_path)
@@ -229,6 +230,7 @@ class AgoraPlayer:
         self._mpv_generation: int = 0
         self._mpv_active_entry_id: Optional[int] = None
         self._mpv_keep_open_active: bool = False
+        self._scheduled_pending: Optional[dict] = None
         self._mpv_drain_lock = threading.Lock()
         self._mpv_drain_pending: bool = False
 
@@ -1121,6 +1123,15 @@ class AgoraPlayer:
         evt_name = event.get("event")
         if evt_name != "end-file":
             return
+        # Slideshow play_to_end has its own pending dict per slide.
+        if self._slideshow:
+            self._dispatch_end_file_to_slideshow(event)
+        # Scheduled finite-loop playback has its own pending dict.
+        if self._scheduled_pending:
+            self._dispatch_end_file_to_scheduled(event)
+
+    def _dispatch_end_file_to_slideshow(self, event: dict) -> None:
+        """Dispatch an end-file event to slideshow play_to_end logic."""
         ss = self._slideshow
         if not ss:
             return
@@ -1153,11 +1164,51 @@ class AgoraPlayer:
                 "mpv end-file reason=%s for slide %d (%s) — advancing",
                 reason, pending["slide_index"], pending["slide_name"],
             )
-        # Cancel watchdog and clear pending before advancing so a re-entrant
-        # _play_next_slide can install a fresh pending dict.
         self._cancel_play_to_end_watchdog()
         ss["pending_play_to_end"] = None
         self._play_next_slide()
+
+    def _dispatch_end_file_to_scheduled(self, event: dict) -> None:
+        """Dispatch an end-file event to scheduled finite-loop logic.
+
+        We let mpv loop natively (--loop-file=inf) and count ``end-file``
+        events here. When the count hits the requested ``loop_count``,
+        we IPC-load the splash so the transition happens without an mpv
+        respawn (no black flash).
+        """
+        sp = self._scheduled_pending
+        if not sp:
+            return
+        if event.get("_generation") != sp["generation"]:
+            return
+        if event.get("playlist_entry_id") != sp["entry_id"]:
+            return
+        reason = event.get("reason")
+        if reason in ("stop", "quit", "redirect"):
+            # Caller initiated (loadfile of next asset, _show_splash,
+            # _stop_mpv): don't double-advance.
+            return
+        if reason == "error":
+            logger.warning(
+                "Scheduled play hit error mid-loop (%s %d/%d) — splashing",
+                sp["asset_name"], sp["completed_count"], sp["target_count"],
+            )
+            self._scheduled_pending = None
+            self._show_splash()
+            return
+        # reason == "eof" (or any non-caller-initiated end): one loop completed.
+        sp["completed_count"] += 1
+        logger.info(
+            "Scheduled play loop %d/%d for %s",
+            sp["completed_count"], sp["target_count"], sp["asset_name"],
+        )
+        if sp["completed_count"] >= sp["target_count"]:
+            logger.info(
+                "Completed %d/%d loops, switching to splash (IPC)",
+                sp["completed_count"], sp["target_count"],
+            )
+            self._scheduled_pending = None
+            self._show_splash()
 
     def _cancel_play_to_end_watchdog(self) -> None:
         """Cancel any pending play_to_end watchdog timeout."""
@@ -1226,6 +1277,7 @@ class AgoraPlayer:
             self._mpv_generation += 1
             self._mpv_keep_open_active = False
             self._mpv_active_entry_id = None
+            self._scheduled_pending = None
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1268,6 +1320,7 @@ class AgoraPlayer:
             self._mpv_generation += 1
             self._mpv_keep_open_active = False
             self._mpv_active_entry_id = None
+            self._scheduled_pending = None
             self._mpv_process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -1553,6 +1606,9 @@ class AgoraPlayer:
 
     def _show_splash(self) -> bool:
         """Show splash screen. Returns False to cancel GLib timeout repeat."""
+        # Clear any armed scheduled-pending so a stale event arriving from
+        # the file we're about to replace can't re-trigger _show_splash.
+        self._scheduled_pending = None
         self._stop_cage()
         error = self._pending_error
         self._pending_error = None
@@ -1577,6 +1633,7 @@ class AgoraPlayer:
                         self._mpv_generation += 1
                         self._mpv_keep_open_active = False
                         self._mpv_active_entry_id = None
+                        self._scheduled_pending = None
                         self._mpv_process = subprocess.Popen(
                             cmd,
                             stdout=subprocess.DEVNULL,
@@ -1879,9 +1936,46 @@ class AgoraPlayer:
             if self._player_backend == "mpv":
                 loop = bool(desired.loop)
                 # For finite loop count, let mpv handle it naturally
-                if is_video and desired.loop_count is not None and desired.loop_count > 0:
-                    loop = False  # Don't use --loop=inf; monitor exits instead
-                self._start_mpv(path, loop=loop)
+                finite_loop = bool(
+                    is_video
+                    and desired.loop_count is not None
+                    and desired.loop_count > 0
+                )
+                if finite_loop:
+                    loop = False  # legacy fallback path: monitor exits per loop
+                # Phase 3 IPC-driven path: if listener is ready and finite
+                # loop_count is requested, IPC-load with --loop-file=inf and
+                # count end-file events. mpv loops natively (no respawn,
+                # no black flash); we IPC-load splash on the Nth EOF.
+                used_ipc_loop_count = False
+                if (
+                    finite_loop
+                    and self.is_mpv_event_listener_ready()
+                    and self._loadfile_mpv(path, loop=True, muted=False)
+                ):
+                    entry_id = self._mpv_active_entry_id
+                    if entry_id is not None:
+                        self._scheduled_pending = {
+                            "entry_id": entry_id,
+                            "generation": self._mpv_generation,
+                            "asset_name": desired.asset,
+                            "target_count": int(desired.loop_count),
+                            "completed_count": 0,
+                        }
+                        used_ipc_loop_count = True
+                        self._update_current(
+                            mode=PlaybackMode.PLAY,
+                            asset=desired.asset,
+                            started_at=datetime.now(timezone.utc),
+                        )
+                        logger.info(
+                            "Scheduled finite-loop armed via IPC: %s "
+                            "loop_count=%d entry_id=%s gen=%d",
+                            desired.asset, desired.loop_count,
+                            entry_id, self._mpv_generation,
+                        )
+                if not used_ipc_loop_count:
+                    self._start_mpv(path, loop=loop)
                 GLib.timeout_add_seconds(10, self._update_position)
             else:
                 self._teardown()

--- a/player/service.py
+++ b/player/service.py
@@ -830,6 +830,17 @@ class AgoraPlayer:
                 logger.warning("mpv IPC: set loop-file failed")
                 return False
 
+            # Always force loop-playlist=no for IPC loads. The first mpv
+            # may have been spawned with --loop=inf for the splash image,
+            # which mpv treats as loop-playlist=inf — that would silently
+            # loop a video instead of emitting end-file{reason=eof}, so
+            # the play_to_end path would never advance.
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["set_property", "loop-playlist", "no"])
+            if not ok:
+                logger.warning("mpv IPC: set loop-playlist failed")
+                return False
+
             # Set keep-open lazily: only when transitioning. Default is
             # "no" (mpv's own default), so we only send a command when
             # arming play_to_end (keep_open=True) or when un-arming after
@@ -849,6 +860,15 @@ class AgoraPlayer:
             if not ok:
                 logger.warning("mpv IPC: set mute (pre-load) failed")
                 return False
+
+            # Always unpause before loadfile. If the previous file was
+            # an image, mpv may be paused at frame 0; without this the
+            # newly-loaded video would never advance and the listener
+            # would never observe end-file{reason=eof}.
+            ok, _, recv_buf = self._ipc_call(sock, recv_buf,
+                ["set_property", "pause", False])
+            if not ok:
+                logger.warning("mpv IPC: set pause=False (pre-load) failed")
 
             if is_image:
                 ok, _, recv_buf = self._ipc_call(sock, recv_buf,
@@ -1006,6 +1026,17 @@ class AgoraPlayer:
             gen = self._mpv_generation
             self._mpv_event_connected.set()
             logger.debug("mpv event listener connected (gen %d)", gen)
+            # Subscribe to eof-reached. With keep-open=yes (which we use to
+            # avoid black flashes between assets), mpv suppresses the
+            # end-file{reason=eof} event and instead pauses on the last
+            # frame. The eof-reached property still flips to True at the
+            # natural end of file, so we observe that as our EOF signal.
+            try:
+                sock.send((json.dumps(
+                    {"command": ["observe_property", 1, "eof-reached"]}
+                ) + "\n").encode())
+            except OSError:
+                logger.warning("mpv event listener: observe_property send failed")
             try:
                 self._mpv_event_read_loop(sock, gen)
             finally:
@@ -1121,6 +1152,26 @@ class AgoraPlayer:
             mpv playlist redirects) and must not double-advance.
         """
         evt_name = event.get("event")
+        # Translate property-change(eof-reached=True) into a synthetic
+        # end-file{reason=eof} for the currently-armed entry. mpv with
+        # keep-open=yes pauses on last frame instead of emitting end-file,
+        # so this is our only natural-EOF signal.
+        if evt_name == "property-change" and event.get("name") == "eof-reached" \
+                and event.get("data") is True:
+            gen = event.get("_generation")
+            armed_entry = None
+            if self._slideshow:
+                pending = self._slideshow.get("pending_play_to_end") or {}
+                armed_entry = pending.get("entry_id")
+            if armed_entry is None and self._scheduled_pending:
+                armed_entry = self._scheduled_pending.get("entry_id")
+            event = {
+                "event": "end-file",
+                "reason": "eof",
+                "playlist_entry_id": armed_entry,
+                "_generation": gen,
+            }
+            evt_name = "end-file"
         if evt_name != "end-file":
             return
         # Slideshow play_to_end has its own pending dict per slide.

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1926,27 +1926,33 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file(0), mute(1), hwdec(2), loadfile(3), mute (post-load)(4)
+        # recv: loop-file(0), loop-playlist(1), mute(2), pause(3), hwdec(4),
+        # loadfile(5), mute (post-load)(6)
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
-            self._ok(1),                       # mute (pre-load)
-            self._ok(2),                       # hwdec
-            self._make_success_response(3),    # loadfile
-            self._ok(4),                       # mute (post-load)
+            self._ok(1),                       # loop-playlist
+            self._ok(2),                       # mute (pre-load)
+            self._ok(3),                       # pause=False (pre-load)
+            self._ok(4),                       # hwdec
+            self._make_success_response(5),    # loadfile
+            self._ok(6),                       # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
         assert result is True
         mock_sock.close.assert_called_once()
 
-        # Should have sent: set loop-file, set hwdec drm-copy, loadfile
+        # Should have sent: set loop-file, loop-playlist, mute, pause,
+        # hwdec drm-copy, loadfile (post-load mute too)
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
         assert b'"loop-file"' in sends[0]
         assert b'"inf"' in sends[0]  # loop=True → inf
-        assert b'"mute"' in sends[1]
-        assert b'"hwdec"' in sends[2]
-        assert b'"drm-copy"' in sends[2]
-        assert b'"loadfile"' in sends[3]
+        assert b'"loop-playlist"' in sends[1]
+        assert b'"mute"' in sends[2]
+        assert b'"pause"' in sends[3]
+        assert b'"hwdec"' in sends[4]
+        assert b'"drm-copy"' in sends[4]
+        assert b'"loadfile"' in sends[5]
 
     @patch("player.service.socket")
     def test_image_loadfile_sends_image_properties(self, mock_socket_mod, mpv_player):
@@ -1959,26 +1965,30 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file(0), mute(1), image-display-duration(2), hwdec(3),
-        # loadfile(4), mute post-load(5), 6x fullscreen toggles(6..11)
+        # recv: loop-file(0), loop-playlist(1), mute(2), pause(3),
+        # image-display-duration(4), hwdec(5), loadfile(6), mute post-load(7),
+        # 6x fullscreen toggles(8..13)
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
-            self._ok(1),                       # mute (pre-load)
-            self._ok(2),                       # image-display-duration
-            self._ok(3),                       # hwdec
-            self._make_success_response(4),    # loadfile
-            self._ok(5),                       # mute (post-load)
-        ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle (off+on)
+            self._ok(1),                       # loop-playlist
+            self._ok(2),                       # mute (pre-load)
+            self._ok(3),                       # pause=False
+            self._ok(4),                       # image-display-duration
+            self._ok(5),                       # hwdec
+            self._make_success_response(6),    # loadfile
+            self._ok(7),                       # mute (post-load)
+        ] + [self._ok(8 + i) for i in range(6)]  # 3x toggle (off+on)
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True)
         assert result is True
 
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-        # loop-file, mute, image-display-duration, hwdec, loadfile, mute (post-load), 6x fullscreen
-        assert b'"image-display-duration"' in sends[2]
-        assert b'"inf"' in sends[2]
-        assert b'"hwdec"' in sends[3]
-        assert b'"no"' in sends[3]
+        # loop-file, loop-playlist, mute, pause, image-display-duration, hwdec,
+        # loadfile, mute (post-load), 6x fullscreen
+        assert b'"image-display-duration"' in sends[4]
+        assert b'"inf"' in sends[4]
+        assert b'"hwdec"' in sends[5]
+        assert b'"no"' in sends[5]
 
     def test_image_loadfile_triggers_fullscreen_toggle(self, mpv_player):
         """Image loadfile should toggle fullscreen 3x for DRM plane refresh."""
@@ -1994,19 +2004,22 @@ class TestLoadfileMpv:
             mock_socket_mod.SOCK_STREAM = 1
             mock_sock.recv.side_effect = [
                 self._ok(0),                       # loop-file
-                self._ok(1),                       # mute (pre-load)
-                self._ok(2),                       # image-display-duration
-                self._ok(3),                       # hwdec
-                self._make_success_response(4),    # loadfile
-                self._ok(5),                       # mute (post-load)
-            ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle
+                self._ok(1),                       # loop-playlist
+                self._ok(2),                       # mute (pre-load)
+                self._ok(3),                       # pause=False
+                self._ok(4),                       # image-display-duration
+                self._ok(5),                       # hwdec
+                self._make_success_response(6),    # loadfile
+                self._ok(7),                       # mute (post-load)
+            ] + [self._ok(8 + i) for i in range(6)]  # 3x toggle
 
             result = mpv_player._loadfile_mpv(Path("/tmp/test.jpg"), loop=False)
             assert result is True
 
             sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-            # loop-file, mute, img-dur, hwdec, loadfile, mute (post-load), 6x fullscreen
-            assert len(sends) == 12
+            # loop-file, loop-playlist, mute, pause, img-dur, hwdec, loadfile,
+            # mute (post-load), 6x fullscreen
+            assert len(sends) == 14
             # Filter to only fullscreen commands
             fullscreen_sends = [s for s in sends if b'"fullscreen"' in s]
             assert len(fullscreen_sends) == 6
@@ -2030,17 +2043,20 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
-            self._ok(1),                       # mute (pre-load)
-            self._ok(2),                       # hwdec
-            self._make_success_response(3),    # loadfile
-            self._ok(4),                       # mute (post-load)
+            self._ok(1),                       # loop-playlist
+            self._ok(2),                       # mute (pre-load)
+            self._ok(3),                       # pause=False
+            self._ok(4),                       # hwdec
+            self._make_success_response(5),    # loadfile
+            self._ok(6),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
 
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-        # 5 commands: loop-file, mute, hwdec, loadfile, mute (post-load) — no fullscreen
-        assert len(sends) == 5
+        # 7 commands: loop-file, loop-playlist, mute, pause, hwdec, loadfile,
+        # mute (post-load) — no fullscreen
+        assert len(sends) == 7
         for s in sends:
             assert b'"fullscreen"' not in s
 
@@ -2059,8 +2075,10 @@ class TestLoadfileMpv:
         bad_resp = b'{"event":"end-file","reason":"error"}\n'
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
-            self._ok(1),                       # mute (pre-load)
-            self._ok(2),                       # hwdec
+            self._ok(1),                       # loop-playlist
+            self._ok(2),                       # mute (pre-load)
+            self._ok(3),                       # pause=False
+            self._ok(4),                       # hwdec
             bad_resp,                          # loadfile — only event
             b"",                               # subsequent recv: socket closed
         ]
@@ -2116,10 +2134,12 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # First recv works, mute works, then hwdec times out
+        # First recv works, then through to hwdec which times out
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file ok
-            self._ok(1),                       # mute (pre-load) ok
+            self._ok(1),                       # loop-playlist ok
+            self._ok(2),                       # mute (pre-load) ok
+            self._ok(3),                       # pause=False ok
             real_socket.timeout("timed out"),  # hwdec times out
         ]
 
@@ -2139,10 +2159,12 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
-            self._ok(1),                       # mute (pre-load)
-            self._ok(2),                       # hwdec
-            self._make_success_response(3),    # loadfile
-            self._ok(4),                       # mute (post-load)
+            self._ok(1),                       # loop-playlist
+            self._ok(2),                       # mute (pre-load)
+            self._ok(3),                       # pause=False
+            self._ok(4),                       # hwdec
+            self._make_success_response(5),    # loadfile
+            self._ok(6),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
@@ -2189,10 +2211,12 @@ class TestLoadfileMpvIpcHardening:
         # First command's response is preceded by an unrelated event on the same recv
         sock.recv.side_effect = [
             b'{"event":"playback-restart"}\n' + self._ok(0),  # loop-file
-            self._ok(1),                                       # mute (pre-load)
-            self._ok(2),                                       # hwdec
-            self._ok(3),                                       # loadfile
-            self._ok(4),                                       # mute (post-load)
+            self._ok(1),                                       # loop-playlist
+            self._ok(2),                                       # mute (pre-load)
+            self._ok(3),                                       # pause=False
+            self._ok(4),                                       # hwdec
+            self._ok(5),                                       # loadfile
+            self._ok(6),                                       # mute (post-load)
         ]
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True) is True
 
@@ -2211,6 +2235,8 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),
             self._ok(3),
             self._ok(4),
+            self._ok(5),
+            self._ok(6),
         ]
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
 
@@ -2226,6 +2252,8 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),
             self._ok(3),
             self._ok(4),
+            self._ok(5),
+            self._ok(6),
         ]
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
 
@@ -2247,16 +2275,17 @@ class TestLoadfileMpvIpcHardening:
         sock = self._setup(mpv_player, mock_socket_mod)
         sock.recv.side_effect = [self._ok(i) for i in range(20)]
         # Override the loadfile response to carry the right id
-        # (responses use sequential ids 0..4; the loadfile is index 3)
+        # (responses use sequential ids 0..6; the loadfile is index 5)
         # Default _ok already matches sequential ids since helper uses
         # itertools.count(); keep simple list above.
-        # Replace index 3 with the loadfile-shaped success response
         sock.recv.side_effect = [
             self._ok(0),
             self._ok(1),
             self._ok(2),
             self._ok(3),
             self._ok(4),
+            self._ok(5),
+            self._ok(6),
         ]
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
         sends = [c[0][0] for c in sock.sendall.call_args_list]
@@ -2520,10 +2549,12 @@ class TestStartMpvIpcFallback:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":2,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":2},"request_id":3,"error":"success"}\n',  # loadfile
-            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # loop-playlist
+            b'{"request_id":2,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":3,"error":"success"}\n',  # pause=False
+            b'{"request_id":4,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":2},"request_id":5,"error":"success"}\n',  # loadfile
+            b'{"request_id":6,"error":"success"}\n',  # mute (post-load)
         ]
 
         with patch.object(mpv_player, "_update_current"), \
@@ -2589,10 +2620,12 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":2,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":3,"error":"success"}\n',  # loadfile
-            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # loop-playlist
+            b'{"request_id":2,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":3,"error":"success"}\n',  # pause=False
+            b'{"request_id":4,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n',  # loadfile
+            b'{"request_id":6,"error":"success"}\n',  # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/video.mp4"), loop=True, muted=False)
@@ -2617,18 +2650,20 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":2,"error":"success"}\n',  # image-display-duration
-            b'{"request_id":3,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":4,"error":"success"}\n',  # loadfile
-            b'{"request_id":5,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # loop-playlist
+            b'{"request_id":2,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":3,"error":"success"}\n',  # pause=False
+            b'{"request_id":4,"error":"success"}\n',  # image-display-duration
+            b'{"request_id":5,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":6,"error":"success"}\n',  # loadfile
+            b'{"request_id":7,"error":"success"}\n',  # mute (post-load)
         ] + [
-            b'{"request_id":6,"error":"success"}\n',
-            b'{"request_id":7,"error":"success"}\n',
             b'{"request_id":8,"error":"success"}\n',
             b'{"request_id":9,"error":"success"}\n',
             b'{"request_id":10,"error":"success"}\n',
             b'{"request_id":11,"error":"success"}\n',
+            b'{"request_id":12,"error":"success"}\n',
+            b'{"request_id":13,"error":"success"}\n',
         ]  # fullscreen toggles
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True, muted=True)

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1886,12 +1886,16 @@ class TestMpvProcessLifecycle:
 class TestLoadfileMpv:
     """Tests for _loadfile_mpv IPC switching."""
 
-    def _make_success_response(self):
-        """Build a raw IPC response with events + success."""
+    @staticmethod
+    def _ok(req_id: int) -> bytes:
+        return f'{{"request_id":{req_id},"error":"success"}}\n'.encode()
+
+    def _make_success_response(self, req_id: int = 0):
+        """Build a raw IPC response with events + a success keyed to req_id."""
         lines = [
             '{"event":"video-reconfig"}',
             '{"event":"end-file","reason":"stop","playlist_entry_id":1}',
-            '{"data":{"playlist_entry_id":2},"request_id":0,"error":"success"}',
+            f'{{"data":{{"playlist_entry_id":2}},"request_id":{req_id},"error":"success"}}',
             '{"event":"start-file","playlist_entry_id":2}',
             '{"event":"file-loaded"}',
         ]
@@ -1912,8 +1916,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_video_loadfile_success(self, mock_time, mock_socket_mod, mpv_player):
+    def test_video_loadfile_success(self, mock_socket_mod, mpv_player):
         """Successful video loadfile via IPC."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -1923,13 +1926,13 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file, mute (pre-load), hwdec, loadfile, mute (post-load)
+        # recv: loop-file(0), mute(1), hwdec(2), loadfile(3), mute (post-load)(4)
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
@@ -1946,8 +1949,7 @@ class TestLoadfileMpv:
         assert b'"loadfile"' in sends[3]
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_image_loadfile_sends_image_properties(self, mock_time, mock_socket_mod, mpv_player):
+    def test_image_loadfile_sends_image_properties(self, mock_socket_mod, mpv_player):
         """Image loadfile should set image-display-duration=inf and hwdec=no."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -1957,15 +1959,16 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # recv: loop-file, mute, image-display-duration, hwdec, loadfile, mute (post-load), 6x fullscreen toggles
+        # recv: loop-file(0), mute(1), image-display-duration(2), hwdec(3),
+        # loadfile(4), mute post-load(5), 6x fullscreen toggles(6..11)
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-        ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle (off+on)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # image-display-duration
+            self._ok(3),                       # hwdec
+            self._make_success_response(4),    # loadfile
+            self._ok(5),                       # mute (post-load)
+        ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle (off+on)
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True)
         assert result is True
@@ -1980,8 +1983,7 @@ class TestLoadfileMpv:
     def test_image_loadfile_triggers_fullscreen_toggle(self, mpv_player):
         """Image loadfile should toggle fullscreen 3x for DRM plane refresh."""
         svc = sys.modules["player.service"]
-        with patch.object(svc, "time"), \
-             patch.object(svc, "socket") as mock_socket_mod:
+        with patch.object(svc, "socket") as mock_socket_mod:
             mock_proc = MagicMock()
             mock_proc.poll.return_value = None
             mpv_player._mpv_process = mock_proc
@@ -1991,13 +1993,13 @@ class TestLoadfileMpv:
             mock_socket_mod.AF_UNIX = 1
             mock_socket_mod.SOCK_STREAM = 1
             mock_sock.recv.side_effect = [
-                b'{"request_id":0,"error":"success"}\n',  # loop-file
-                b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-                b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-                b'{"request_id":0,"error":"success"}\n',  # hwdec
-                self._make_success_response(),             # loadfile
-                b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-            ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # 3x toggle
+                self._ok(0),                       # loop-file
+                self._ok(1),                       # mute (pre-load)
+                self._ok(2),                       # image-display-duration
+                self._ok(3),                       # hwdec
+                self._make_success_response(4),    # loadfile
+                self._ok(5),                       # mute (post-load)
+            ] + [self._ok(6 + i) for i in range(6)]  # 3x toggle
 
             result = mpv_player._loadfile_mpv(Path("/tmp/test.jpg"), loop=False)
             assert result is True
@@ -2016,8 +2018,7 @@ class TestLoadfileMpv:
                     assert b"true" in s
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_video_loadfile_no_fullscreen_toggle(self, mock_time, mock_socket_mod, mpv_player):
+    def test_video_loadfile_no_fullscreen_toggle(self, mock_socket_mod, mpv_player):
         """Video loadfile should NOT trigger fullscreen toggle."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2028,11 +2029,11 @@ class TestLoadfileMpv:
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
@@ -2044,8 +2045,7 @@ class TestLoadfileMpv:
             assert b'"fullscreen"' not in s
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_no_success(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_no_success(self, mock_socket_mod, mpv_player):
         """Should return False when IPC response has no success message."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2055,13 +2055,14 @@ class TestLoadfileMpv:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        # Only events, no success response
-        bad_resp = '{"event":"end-file","reason":"error"}\n'.encode()
+        # Only events, no success response → loadfile gets empty recv → fails
+        bad_resp = b'{"event":"end-file","reason":"error"}\n'
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            bad_resp,                                   # loadfile — no success
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            bad_resp,                          # loadfile — only event
+            b"",                               # subsequent recv: socket closed
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"))
@@ -2069,8 +2070,7 @@ class TestLoadfileMpv:
         mock_sock.close.assert_called_once()
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_connect_error(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_connect_error(self, mock_socket_mod, mpv_player):
         """Should return False when IPC socket connection fails."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2086,8 +2086,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_timeout(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_timeout(self, mock_socket_mod, mpv_player):
         """Should return False when IPC socket times out."""
         import socket as real_socket
 
@@ -2105,8 +2104,7 @@ class TestLoadfileMpv:
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_returns_false_on_recv_timeout(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_returns_false_on_recv_timeout(self, mock_socket_mod, mpv_player):
         """Should return False when recv times out after sending loadfile."""
         import socket as real_socket
 
@@ -2120,17 +2118,16 @@ class TestLoadfileMpv:
         mock_socket_mod.SOCK_STREAM = 1
         # First recv works, mute works, then hwdec times out
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file ok
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load) ok
-            real_socket.timeout("timed out"),           # hwdec times out
+            self._ok(0),                       # loop-file ok
+            self._ok(1),                       # mute (pre-load) ok
+            real_socket.timeout("timed out"),  # hwdec times out
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"))
         assert result is False
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_loop_false_sets_no(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_loop_false_sets_no(self, mock_socket_mod, mpv_player):
         """loop=False should set loop-file to 'no'."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2141,11 +2138,11 @@ class TestLoadfileMpv:
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
-            b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            self._make_success_response(),             # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            self._ok(0),                       # loop-file
+            self._ok(1),                       # mute (pre-load)
+            self._ok(2),                       # hwdec
+            self._make_success_response(3),    # loadfile
+            self._ok(4),                       # mute (post-load)
         ]
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
@@ -2154,8 +2151,7 @@ class TestLoadfileMpv:
         assert b'"no"' in first_send  # loop-file = "no"
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_socket_cleanup_on_stale_socket(self, mock_time, mock_socket_mod, mpv_player):
+    def test_socket_cleanup_on_stale_socket(self, mock_socket_mod, mpv_player):
         """IPC socket file should be cleaned up by _stop_mpv."""
         import os
         mock_proc = MagicMock()
@@ -2167,6 +2163,107 @@ class TestLoadfileMpv:
             mock_unlink.assert_called_once_with("/tmp/mpv-socket")
 
 
+class TestLoadfileMpvIpcHardening:
+    """Phase 0 tests: command IPC parser correctly demuxes events from
+    responses and matches by request_id."""
+
+    @staticmethod
+    def _ok(req_id: int) -> bytes:
+        return f'{{"request_id":{req_id},"error":"success"}}\n'.encode()
+
+    def _setup(self, mpv_player, mock_socket_mod):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mpv_player._mpv_process = mock_proc
+        mock_sock = MagicMock()
+        mock_socket_mod.socket.return_value = mock_sock
+        mock_socket_mod.AF_UNIX = 1
+        mock_socket_mod.SOCK_STREAM = 1
+        return mock_sock
+
+    @patch("player.service.socket")
+    def test_event_interleaved_before_response_is_skipped(self, mock_socket_mod, mpv_player):
+        """An event arriving before the matching response must be dropped,
+        not mistaken for the response."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # First command's response is preceded by an unrelated event on the same recv
+        sock.recv.side_effect = [
+            b'{"event":"playback-restart"}\n' + self._ok(0),  # loop-file
+            self._ok(1),                                       # mute (pre-load)
+            self._ok(2),                                       # hwdec
+            self._ok(3),                                       # loadfile
+            self._ok(4),                                       # mute (post-load)
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True) is True
+
+    @patch("player.service.socket")
+    def test_response_split_across_recvs(self, mock_socket_mod, mpv_player):
+        """A JSON line that arrives split across two recv() calls is parsed
+        correctly once both halves are accumulated."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Split the loop-file response into two recvs
+        first = b'{"request_id":0,"error":"succ'
+        rest = b'ess"}\n'
+        sock.recv.side_effect = [
+            first,
+            rest,
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
+
+    @patch("player.service.socket")
+    def test_wrong_request_id_then_right_one(self, mock_socket_mod, mpv_player):
+        """A response carrying a stale request_id must be skipped while the
+        helper waits for the matching one."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Send a stale id 99 first (not what we asked for), then the real response
+        sock.recv.side_effect = [
+            b'{"request_id":99,"error":"success"}\n' + self._ok(0),
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
+
+    @patch("player.service.socket")
+    def test_timeout_when_no_matching_response(self, mock_socket_mod, mpv_player):
+        """If the matching request_id never arrives, the helper times out
+        cleanly and the loadfile call returns False (no infinite hang)."""
+        import itertools as _it
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # Endless event stream — none of these match the request_id
+        sock.recv.side_effect = _it.repeat(b'{"event":"playback-restart"}\n')
+        # Tighten the per-command timeout so the test runs fast
+        mpv_player._IPC_CMD_TIMEOUT_S = 0.05
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is False
+
+    @patch("player.service.socket")
+    def test_request_id_is_present_in_every_command(self, mock_socket_mod, mpv_player):
+        """Every JSON command sent must include a request_id field."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        sock.recv.side_effect = [self._ok(i) for i in range(20)]
+        # Override the loadfile response to carry the right id
+        # (responses use sequential ids 0..4; the loadfile is index 3)
+        # Default _ok already matches sequential ids since helper uses
+        # itertools.count(); keep simple list above.
+        # Replace index 3 with the loadfile-shaped success response
+        sock.recv.side_effect = [
+            self._ok(0),
+            self._ok(1),
+            self._ok(2),
+            self._ok(3),
+            self._ok(4),
+        ]
+        mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
+        sends = [c[0][0] for c in sock.sendall.call_args_list]
+        for s in sends:
+            assert b'"request_id"' in s, f"missing request_id in {s!r}"
+
+
 # ── mpv IPC start_mpv integration ──
 
 
@@ -2174,8 +2271,7 @@ class TestStartMpvIpcFallback:
     """Tests for _start_mpv trying IPC first, falling back to restart."""
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_start_mpv_uses_ipc_when_available(self, mock_time, mock_socket_mod, mpv_player, tmp_path):
+    def test_start_mpv_uses_ipc_when_available(self, mock_socket_mod, mpv_player, tmp_path):
         """_start_mpv should use IPC loadfile when mpv is already running."""
         video = tmp_path / "test.mp4"
         video.write_bytes(b"\x00" * 100)
@@ -2191,15 +2287,12 @@ class TestStartMpvIpcFallback:
         mock_socket_mod.socket.return_value = mock_sock
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
-        lines = [
-            '{"data":{"playlist_entry_id":2},"request_id":0,"error":"success"}',
-        ]
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            ("\n".join(lines) + "\n").encode(),       # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":2},"request_id":3,"error":"success"}\n',  # loadfile
+            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
         ]
 
         with patch.object(mpv_player, "_update_current"), \
@@ -2253,8 +2346,7 @@ class TestMutePolicy:
     """
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_for_scheduled_asset_sets_mute_false(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_for_scheduled_asset_sets_mute_false(self, mock_socket_mod, mpv_player):
         """_loadfile_mpv(muted=False) must send set_property mute false to running mpv."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2266,10 +2358,10 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":3,"error":"success"}\n',  # loadfile
+            b'{"request_id":4,"error":"success"}\n',  # mute (post-load)
         ]
 
         result = mpv_player._loadfile_mpv(Path("/tmp/video.mp4"), loop=True, muted=False)
@@ -2282,8 +2374,7 @@ class TestMutePolicy:
             assert b"false" in s or b"False" in s, f"expected mute=false, got {s!r}"
 
     @patch("player.service.socket")
-    @patch("player.service.time")
-    def test_loadfile_for_splash_sets_mute_true(self, mock_time, mock_socket_mod, mpv_player):
+    def test_loadfile_for_splash_sets_mute_true(self, mock_socket_mod, mpv_player):
         """_loadfile_mpv(muted=True) must send set_property mute true to running mpv."""
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -2295,12 +2386,19 @@ class TestMutePolicy:
         mock_socket_mod.SOCK_STREAM = 1
         mock_sock.recv.side_effect = [
             b'{"request_id":0,"error":"success"}\n',  # loop-file
-            b'{"request_id":0,"error":"success"}\n',  # mute (pre-load)
-            b'{"request_id":0,"error":"success"}\n',  # image-display-duration
-            b'{"request_id":0,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":0,"error":"success"}\n',  # loadfile
-            b'{"request_id":0,"error":"success"}\n',  # mute (post-load)
-        ] + [b'{"request_id":0,"error":"success"}\n'] * 6  # fullscreen toggles
+            b'{"request_id":1,"error":"success"}\n',  # mute (pre-load)
+            b'{"request_id":2,"error":"success"}\n',  # image-display-duration
+            b'{"request_id":3,"error":"success"}\n',  # hwdec
+            b'{"data":{"playlist_entry_id":1},"request_id":4,"error":"success"}\n',  # loadfile
+            b'{"request_id":5,"error":"success"}\n',  # mute (post-load)
+        ] + [
+            b'{"request_id":6,"error":"success"}\n',
+            b'{"request_id":7,"error":"success"}\n',
+            b'{"request_id":8,"error":"success"}\n',
+            b'{"request_id":9,"error":"success"}\n',
+            b'{"request_id":10,"error":"success"}\n',
+            b'{"request_id":11,"error":"success"}\n',
+        ]  # fullscreen toggles
 
         result = mpv_player._loadfile_mpv(Path("/tmp/splash.png"), loop=True, muted=True)
         assert result is True

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -2293,6 +2293,27 @@ class TestLoadfileMpvIpcHardening:
             assert b'"request_id"' in s, f"missing request_id in {s!r}"
 
 
+    @patch("player.service.socket")
+    def test_pause_false_failure_is_fatal(self, mock_socket_mod, mpv_player):
+        """Phase 6 regression: if mpv refuses the pre-load pause=False
+        IPC command, _loadfile_mpv must return False so callers fall
+        back to a fresh respawn. Pressing on with a possibly-paused mpv
+        defeats the very fix this command exists for (image→video
+        transitions where mpv is paused at frame 0 of the previous
+        image — the next loadfile would never advance, and the listener
+        would never observe end-file{reason=eof})."""
+        sock = self._setup(mpv_player, mock_socket_mod)
+        # loop-file ok, loop-playlist ok, mute ok, pause=False ERROR.
+        sock.recv.side_effect = [
+            self._ok(0),
+            self._ok(1),
+            self._ok(2),
+            b'{"request_id":3,"error":"property unavailable"}\n',
+            # No further responses should be requested.
+        ]
+        assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is False
+
+
 # ── mpv IPC event listener (Phase 1) ──
 
 
@@ -2395,6 +2416,59 @@ class TestMpvEventListener:
         self._prep(mpv_player)
         mpv_player._stop_mpv_event_listener()
         assert mpv_player._mpv_event_stop.is_set()
+
+    def test_teardown_does_not_stop_listener(self, mpv_player):
+        """Phase 6 regression: _teardown() must NOT kill the persistent
+        listener. _teardown runs from many normal-operation paths
+        (mode switches, fallback, health-retry); stopping the listener
+        there would silently strand all subsequent slideshow play_to_end
+        and scheduled loop_count arms for the rest of the service
+        lifetime — they would fall back to the legacy duration/respawn
+        paths and we would lose the seamless behavior of the refactor."""
+        self._prep(mpv_player)
+        fake_thread = MagicMock()
+        fake_thread.is_alive.return_value = True
+        mpv_player._mpv_event_thread = fake_thread
+        mpv_player._mpv_event_connected.set()
+        mpv_player._mpv_process = None
+        mpv_player.pipeline = None
+
+        with patch("player.service.Gst") as mock_gst:
+            mock_gst.State.NULL = "NULL"
+            mock_gst.CLOCK_TIME_NONE = 0
+            mpv_player._teardown()
+
+        # Listener must still be alive and unstopped.
+        assert mpv_player._mpv_event_thread is fake_thread
+        assert mpv_player._mpv_event_connected.is_set()
+        assert not mpv_player._mpv_event_stop.is_set()
+        fake_thread.join.assert_not_called()
+
+    def test_event_loop_self_heals_on_unexpected_exception(self, mpv_player):
+        """The outer listener loop must catch and recover from unexpected
+        exceptions — a single bad event must never permanently strand
+        finite loop_count or slideshow play_to_end consumers."""
+        self._prep(mpv_player)
+        mpv_player._MPV_EVENT_RECONNECT_DELAY_S = 0.001
+        mpv_player._mpv_event_connected.set()  # pretend prior connect
+        attempts = {"n": 0}
+
+        def fake_connect():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RuntimeError("simulated transient failure")
+            # Stop the loop on the second pass so the test terminates.
+            mpv_player._mpv_event_stop.set()
+            return None
+
+        with patch.object(mpv_player, "_mpv_event_connect", side_effect=fake_connect):
+            mpv_player._mpv_event_loop()
+
+        # Made it past the exception and reached a clean stop.
+        assert attempts["n"] >= 2
+        # Connected flag must be cleared after the exception so consumers
+        # see the listener as not-ready and fall back to legacy paths.
+        assert not mpv_player._mpv_event_connected.is_set()
 
     def test_is_listener_ready_reflects_connected_flag(self, mpv_player):
         self._prep(mpv_player)

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -2264,6 +2264,237 @@ class TestLoadfileMpvIpcHardening:
             assert b'"request_id"' in s, f"missing request_id in {s!r}"
 
 
+# ── mpv IPC event listener (Phase 1) ──
+
+
+class TestMpvEventListener:
+    """Tests for the persistent mpv IPC event listener thread."""
+
+    @staticmethod
+    def _prep(mpv_player):
+        """Initialise listener-related attributes on a bypass-init fixture."""
+        import queue as _queue
+        import threading as _threading
+
+        mpv_player._mpv_event_thread = None
+        mpv_player._mpv_event_stop = _threading.Event()
+        mpv_player._mpv_event_queue = _queue.Queue()
+        mpv_player._mpv_event_connected = _threading.Event()
+        mpv_player._mpv_generation = 0
+        mpv_player._mpv_drain_lock = _threading.Lock()
+        mpv_player._mpv_drain_pending = False
+
+    def test_schedule_drain_is_idempotent_while_pending(self, mpv_player):
+        """_schedule_drain should call GLib.idle_add at most once until the
+        drain callback runs."""
+        self._prep(mpv_player)
+        with patch("player.service.GLib") as glib:
+            mpv_player._schedule_drain()
+            mpv_player._schedule_drain()
+            mpv_player._schedule_drain()
+        assert glib.idle_add.call_count == 1
+        assert mpv_player._mpv_drain_pending is True
+
+    def test_drain_dispatches_all_queued_events_in_order(self, mpv_player):
+        """_drain_mpv_events should pop every queued event and call
+        _on_mpv_event in FIFO order, then return False (one-shot)."""
+        self._prep(mpv_player)
+        seen = []
+        mpv_player._on_mpv_event = lambda evt: seen.append(evt["event"])
+        mpv_player._mpv_drain_pending = True
+        for name in ("start-file", "playback-restart", "end-file"):
+            mpv_player._mpv_event_queue.put({"event": name})
+        result = mpv_player._drain_mpv_events()
+        assert result is False
+        assert seen == ["start-file", "playback-restart", "end-file"]
+        assert mpv_player._mpv_drain_pending is False
+
+    def test_drain_re_enables_scheduling_after_running(self, mpv_player):
+        """After drain runs, the next _schedule_drain should call idle_add
+        again."""
+        self._prep(mpv_player)
+        mpv_player._mpv_drain_pending = True
+        mpv_player._drain_mpv_events()
+        with patch("player.service.GLib") as glib:
+            mpv_player._schedule_drain()
+        assert glib.idle_add.call_count == 1
+
+    def test_drain_swallows_handler_exceptions(self, mpv_player):
+        """A buggy handler must not break the drain loop or leave
+        _mpv_drain_pending stuck."""
+        self._prep(mpv_player)
+        calls = []
+
+        def boom(evt):
+            calls.append(evt["event"])
+            if evt["event"] == "start-file":
+                raise RuntimeError("boom")
+
+        mpv_player._on_mpv_event = boom
+        mpv_player._mpv_drain_pending = True
+        mpv_player._mpv_event_queue.put({"event": "start-file"})
+        mpv_player._mpv_event_queue.put({"event": "end-file"})
+        mpv_player._drain_mpv_events()
+        assert calls == ["start-file", "end-file"]
+        assert mpv_player._mpv_drain_pending is False
+
+    def test_start_listener_is_idempotent(self, mpv_player):
+        """Calling _start_mpv_event_listener twice creates only one thread."""
+        self._prep(mpv_player)
+        with patch("player.service.threading.Thread") as ThreadCls:
+            ThreadCls.return_value.is_alive.return_value = True
+            mpv_player._start_mpv_event_listener()
+            mpv_player._start_mpv_event_listener()
+        assert ThreadCls.call_count == 1
+
+    def test_stop_listener_sets_stop_and_joins(self, mpv_player):
+        """_stop_mpv_event_listener must set stop, clear connected, and
+        join the thread."""
+        self._prep(mpv_player)
+        fake_thread = MagicMock()
+        fake_thread.is_alive.return_value = True
+        mpv_player._mpv_event_thread = fake_thread
+        mpv_player._mpv_event_connected.set()
+        mpv_player._stop_mpv_event_listener()
+        assert mpv_player._mpv_event_stop.is_set()
+        assert not mpv_player._mpv_event_connected.is_set()
+        fake_thread.join.assert_called_once_with(timeout=2.0)
+        assert mpv_player._mpv_event_thread is None
+
+    def test_stop_listener_no_thread_is_safe(self, mpv_player):
+        """Stopping with no thread set is a no-op."""
+        self._prep(mpv_player)
+        mpv_player._stop_mpv_event_listener()
+        assert mpv_player._mpv_event_stop.is_set()
+
+    def test_is_listener_ready_reflects_connected_flag(self, mpv_player):
+        self._prep(mpv_player)
+        assert mpv_player.is_mpv_event_listener_ready() is False
+        mpv_player._mpv_event_connected.set()
+        assert mpv_player.is_mpv_event_listener_ready() is True
+
+    @patch("player.service.GLib")
+    def test_read_loop_parses_lines_and_stamps_generation(self, _glib, mpv_player):
+        """The reader should split incoming bytes on newline, JSON-decode,
+        push events (and only events) onto the queue, and stamp each with
+        the generation it was given."""
+        self._prep(mpv_player)
+        events = [
+            b'{"event":"start-file","playlist_entry_id":7}\n',
+            b'{"event":"end-file","reason":"eof","playlist_entry_id":7}\n',
+            b'{"request_id":1,"error":"success"}\n',  # response — must be skipped
+            b'{"event":"shutdown"}\n',
+            b'',  # connection close
+        ]
+        sock = MagicMock()
+        sock.recv.side_effect = events
+        mpv_player._mpv_event_read_loop(sock, generation=42)
+        drained = []
+        while True:
+            try:
+                drained.append(mpv_player._mpv_event_queue.get_nowait())
+            except Exception:
+                break
+        assert [e["event"] for e in drained] == ["start-file", "end-file", "shutdown"]
+        assert all(e["_generation"] == 42 for e in drained)
+        assert all("request_id" not in e for e in drained)
+
+    @patch("player.service.GLib")
+    def test_read_loop_handles_split_lines(self, _glib, mpv_player):
+        """A JSON object split across two recv() calls should still parse."""
+        self._prep(mpv_player)
+        sock = MagicMock()
+        sock.recv.side_effect = [
+            b'{"event":"start-',
+            b'file","playlist_entry_id":3}\n',
+            b'',
+        ]
+        mpv_player._mpv_event_read_loop(sock, generation=1)
+        evt = mpv_player._mpv_event_queue.get_nowait()
+        assert evt["event"] == "start-file"
+        assert evt["playlist_entry_id"] == 3
+
+    @patch("player.service.GLib")
+    def test_read_loop_skips_garbage_lines(self, _glib, mpv_player):
+        """Lines that aren't valid JSON must not crash the loop."""
+        self._prep(mpv_player)
+        sock = MagicMock()
+        sock.recv.side_effect = [
+            b'not json\n',
+            b'{"event":"end-file","reason":"eof"}\n',
+            b'',
+        ]
+        mpv_player._mpv_event_read_loop(sock, generation=1)
+        evt = mpv_player._mpv_event_queue.get_nowait()
+        assert evt["event"] == "end-file"
+
+    @patch("player.service.GLib")
+    def test_read_loop_continues_after_socket_timeout(self, _glib, mpv_player):
+        """A socket.timeout (used to keep checking the stop flag) must not
+        terminate the reader."""
+        self._prep(mpv_player)
+        import socket as _socket
+        sock = MagicMock()
+        sock.recv.side_effect = [
+            _socket.timeout("read timeout"),
+            b'{"event":"end-file","reason":"eof"}\n',
+            b'',
+        ]
+        mpv_player._mpv_event_read_loop(sock, generation=1)
+        evt = mpv_player._mpv_event_queue.get_nowait()
+        assert evt["event"] == "end-file"
+
+    @patch("player.service.GLib")
+    def test_read_loop_exits_when_stop_set(self, _glib, mpv_player):
+        """Setting _mpv_event_stop should make the reader return on the
+        next timeout."""
+        self._prep(mpv_player)
+        import socket as _socket
+        mpv_player._mpv_event_stop.set()
+        sock = MagicMock()
+        # First call would time out, but stop is already set so the loop
+        # should exit before recv is called.
+        sock.recv.side_effect = _socket.timeout("read timeout")
+        mpv_player._mpv_event_read_loop(sock, generation=1)
+        # Either zero recvs (loop saw stop first) or one followed by exit.
+        assert mpv_player._mpv_event_queue.empty()
+
+    def test_event_loop_retries_when_socket_unavailable(self, mpv_player):
+        """If MPV_IPC_SOCKET doesn't exist yet, the listener should sleep
+        and retry rather than spin or crash."""
+        self._prep(mpv_player)
+        attempts = {"n": 0}
+
+        def fake_connect():
+            attempts["n"] += 1
+            if attempts["n"] >= 3:
+                # Trip the stop event so the loop exits cleanly
+                mpv_player._mpv_event_stop.set()
+            return None  # simulate "not available yet"
+
+        with patch.object(mpv_player, "_mpv_event_connect", side_effect=fake_connect):
+            mpv_player._mpv_event_loop()
+        assert attempts["n"] >= 2
+
+    def test_event_loop_sets_connected_flag_then_clears_on_disconnect(self, mpv_player):
+        """While a connection is live, _mpv_event_connected should be set;
+        after the read loop returns, it should be cleared."""
+        self._prep(mpv_player)
+        states = []
+
+        def fake_read(sock, generation):
+            states.append(("during", mpv_player._mpv_event_connected.is_set()))
+            mpv_player._mpv_event_stop.set()
+
+        fake_sock = MagicMock()
+        with patch.object(mpv_player, "_mpv_event_connect", return_value=fake_sock), \
+             patch.object(mpv_player, "_mpv_event_read_loop", side_effect=fake_read):
+            mpv_player._mpv_event_loop()
+        states.append(("after", mpv_player._mpv_event_connected.is_set()))
+        assert states == [("during", True), ("after", False)]
+        fake_sock.close.assert_called()
+
+
 # ── mpv IPC start_mpv integration ──
 
 

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -1,0 +1,503 @@
+"""Tests for slideshow asset fetching on the Pi (cms_client).
+
+The CMS sends a ``fetch_asset`` message with ``asset_type="slideshow"``
+and a ``slides`` list. The device must download every slide, write a
+local slideshow manifest, register the slideshow in its asset manager,
+and ACK with the resolved manifest checksum.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio  # noqa: F401  (registers asyncio fixtures)
+
+from cms_client.asset_manager import AssetManager  # noqa: E402
+from cms_client.service import CMSClient  # noqa: E402
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture
+def cms_client(tmp_path):
+    """CMSClient wired to a real AssetManager + tmp dirs.
+
+    Using a real AssetManager (not a MagicMock) so the manifest, eviction,
+    and has_asset semantics line up with production behaviour.
+    """
+    settings = MagicMock()
+    settings.agora_base = tmp_path
+    settings.assets_dir = tmp_path / "assets"
+    settings.videos_dir = tmp_path / "assets" / "videos"
+    settings.images_dir = tmp_path / "assets" / "images"
+    settings.splash_dir = tmp_path / "assets" / "splash"
+    settings.slideshows_dir = tmp_path / "assets" / "slideshows"
+    for d in (settings.assets_dir, settings.videos_dir, settings.images_dir,
+              settings.splash_dir, settings.slideshows_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    settings.manifest_path = tmp_path / "state" / "assets.json"
+    settings.manifest_path.parent.mkdir(parents=True)
+    settings.schedule_path = tmp_path / "state" / "schedule.json"
+    settings.desired_state_path = tmp_path / "state" / "desired.json"
+    settings.persist_dir = tmp_path / "persist"
+    settings.persist_dir.mkdir()
+    settings.asset_budget_mb = 100
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        client = CMSClient(settings)
+    client.settings = settings
+    client.device_id = "test-device"
+    client.asset_manager = AssetManager(
+        settings.manifest_path, settings.assets_dir, budget_mb=100,
+    )
+    client._ws = AsyncMock()
+    client._fetch_lock = asyncio.Lock()
+    client._fetch_tasks = {}
+    client._current_schedule_id = None
+    client._current_schedule_name = None
+    client._current_asset = None
+    client._eval_wake = asyncio.Event()
+    client._last_player_mode = None
+    return client
+
+
+def _make_slide(name: str, body: bytes, *, asset_type: str = "video",
+                duration_ms: int = 5000, play_to_end: bool = False) -> dict:
+    return {
+        "asset_name": name,
+        "asset_type": asset_type,
+        "download_url": f"http://cms.test/{name}",
+        "checksum": _sha256(body),
+        "size_bytes": len(body),
+        "duration_ms": duration_ms,
+        "play_to_end": play_to_end,
+    }
+
+
+class _FakeAioHttpResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+        self.content = self  # iter_chunked is on .content
+
+    async def iter_chunked(self, _size):
+        yield self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeAioHttpSession:
+    """aiohttp.ClientSession() stand-in that maps URL → fixed body."""
+
+    def __init__(self, mapping: dict[str, bytes]):
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        body = self._mapping.get(url, b"")
+        status = 200 if url in self._mapping else 404
+        return _FakeAioHttpResponse(body, status)
+
+
+def _patch_aiohttp(mapping):
+    fake_session = _FakeAioHttpSession(mapping)
+    fake_module = MagicMock()
+    fake_module.ClientSession = lambda: fake_session
+    return fake_module, fake_session
+
+
+class TestSlideshowFetch:
+    @pytest.mark.asyncio
+    async def test_happy_path_three_slides(self, cms_client):
+        b1, b2, b3 = b"slide-one-bytes", b"slide-two-bytes", b"slide-three-bytes!"
+        slides = [
+            _make_slide("clip1.mp4", b1, asset_type="video", duration_ms=4000),
+            _make_slide("pic1.jpg",  b2, asset_type="image", duration_ms=3000),
+            _make_slide("clip2.mp4", b3, asset_type="video", duration_ms=5000, play_to_end=True),
+        ]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Lobby Slideshow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "manifest-hash-abc",
+            "size_bytes": 0,
+            "slides": slides,
+        }
+        mapping = {s["download_url"]: body for s, body in zip(slides, [b1, b2, b3])}
+        fake_aiohttp, fake_session = _patch_aiohttp(mapping)
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Each slide downloaded once
+        assert len(fake_session.calls) == 3
+
+        # Slide files on disk
+        assert (cms_client.settings.videos_dir / "clip1.mp4").read_bytes() == b1
+        assert (cms_client.settings.images_dir / "pic1.jpg").read_bytes() == b2
+        assert (cms_client.settings.videos_dir / "clip2.mp4").read_bytes() == b3
+
+        # Slideshow manifest on disk with per-slide metadata
+        manifest_path = cms_client.settings.slideshows_dir / "Lobby Slideshow.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["checksum"] == "manifest-hash-abc"
+        assert [s["name"] for s in manifest["slides"]] == ["clip1.mp4", "pic1.jpg", "clip2.mp4"]
+        assert manifest["slides"][0]["asset_type"] == "video"
+        assert manifest["slides"][2]["play_to_end"] is True
+        assert manifest["slides"][1]["duration_ms"] == 3000
+
+        # AssetManager registered every slide + the slideshow itself
+        am = cms_client.asset_manager
+        assert am.has_asset("clip1.mp4", _sha256(b1))
+        assert am.has_asset("pic1.jpg",  _sha256(b2))
+        assert am.has_asset("clip2.mp4", _sha256(b3))
+        assert am.has_asset("Lobby Slideshow.slideshow", "manifest-hash-abc")
+        slideshow_entry = am.get("Lobby Slideshow.slideshow")
+        assert "slideshows" in Path(slideshow_entry["path"]).parts
+
+        # Single ACK with the resolved manifest checksum
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        acks = [m for m in sent if m["type"] == "asset_ack"]
+        assert len(acks) == 1
+        assert acks[0]["asset_name"] == "Lobby Slideshow.slideshow"
+        assert acks[0]["checksum"] == "manifest-hash-abc"
+        assert not [m for m in sent if m["type"] == "fetch_failed"]
+
+    @pytest.mark.asyncio
+    async def test_already_cached_short_circuits(self, cms_client):
+        """Slideshow + every slide already cached → ACK without re-downloading."""
+        b1, b2 = b"already-have-1", b"already-have-2"
+        slide1 = _make_slide("a.mp4", b1, asset_type="video")
+        slide2 = _make_slide("b.jpg", b2, asset_type="image")
+        # Pre-seed the cache
+        (cms_client.settings.videos_dir / "a.mp4").write_bytes(b1)
+        (cms_client.settings.images_dir / "b.jpg").write_bytes(b2)
+        cms_client.asset_manager.register("a.mp4", "videos/a.mp4", len(b1), _sha256(b1))
+        cms_client.asset_manager.register("b.jpg", "images/b.jpg", len(b2), _sha256(b2))
+        # Pre-seed the slideshow manifest + asset_manager entry
+        manifest_path = cms_client.settings.slideshows_dir / "MyShow.slideshow.json"
+        manifest_path.write_text(json.dumps({
+            "name": "MyShow.slideshow",
+            "checksum": "stable-hash",
+            "slides": [
+                {"name": "a.mp4", "asset_type": "video", "checksum": _sha256(b1),
+                 "size_bytes": len(b1), "duration_ms": 1000, "play_to_end": False},
+                {"name": "b.jpg", "asset_type": "image", "checksum": _sha256(b2),
+                 "size_bytes": len(b2), "duration_ms": 2000, "play_to_end": False},
+            ],
+        }))
+        cms_client.asset_manager.register(
+            "MyShow.slideshow", f"slideshows/MyShow.slideshow.json",
+            manifest_path.stat().st_size, "stable-hash",
+        )
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "MyShow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "stable-hash",
+            "size_bytes": 0,
+            "slides": [slide1, slide2],
+        }
+        # Override slide checksums to match pre-seeded files
+        slide1["checksum"] = _sha256(b1)
+        slide2["checksum"] = _sha256(b2)
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Nothing downloaded
+        assert fake_session.calls == []
+        # ACK still sent
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert any(m["type"] == "asset_ack" and m["checksum"] == "stable-hash" for m in sent)
+
+    @pytest.mark.asyncio
+    async def test_partial_cache_only_fetches_missing(self, cms_client):
+        b1, b2 = b"on-disk-bytes", b"need-this-bytes"
+        slide1 = _make_slide("cached.mp4", b1, asset_type="video")
+        slide2 = _make_slide("missing.mp4", b2, asset_type="video")
+        # Pre-seed slide1 only
+        (cms_client.settings.videos_dir / "cached.mp4").write_bytes(b1)
+        cms_client.asset_manager.register(
+            "cached.mp4", "videos/cached.mp4", len(b1), _sha256(b1),
+        )
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Mixed.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "mixed-hash",
+            "size_bytes": 0,
+            "slides": [slide1, slide2],
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({slide2["download_url"]: b2})
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Only the missing slide was fetched
+        assert fake_session.calls == [slide2["download_url"]]
+        assert cms_client.asset_manager.has_asset("missing.mp4", _sha256(b2))
+        assert cms_client.asset_manager.has_asset("Mixed.slideshow", "mixed-hash")
+
+    @pytest.mark.asyncio
+    async def test_slide_download_failure_aborts(self, cms_client):
+        """If any slide fails to download, no slideshow manifest is written
+        and a fetch_failed is sent. Already-downloaded slides remain cached."""
+        b1 = b"good-slide"
+        slide_ok = _make_slide("ok.mp4", b1, asset_type="video")
+        slide_bad = _make_slide("bad.mp4", b"never-served", asset_type="video")
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Broken.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "broken-hash",
+            "size_bytes": 0,
+            "slides": [slide_ok, slide_bad],
+        }
+        # Only ok.mp4 has a valid mapping; bad.mp4 → 404
+        fake_aiohttp, fake_session = _patch_aiohttp({slide_ok["download_url"]: b1})
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # ok.mp4 is still cached (kept for future retries)
+        assert cms_client.asset_manager.has_asset("ok.mp4", _sha256(b1))
+        # The slideshow itself was NOT registered
+        assert not cms_client.asset_manager.has_asset("Broken.slideshow")
+        # No manifest file written
+        assert not (cms_client.settings.slideshows_dir / "Broken.slideshow.json").exists()
+        # fetch_failed sent, no asset_ack
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        fails = [m for m in sent if m["type"] == "fetch_failed"]
+        assert len(fails) == 1
+        assert fails[0]["asset"] == "Broken.slideshow"
+        assert fails[0]["reason"] == "slide_download_failed"
+        assert fails[0]["slide_asset"] == "bad.mp4"
+        assert not [m for m in sent if m["type"] == "asset_ack"]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_slides_downloaded_once(self, cms_client):
+        b = b"reused-bytes"
+        slide_a = _make_slide("dup.mp4", b, asset_type="video", duration_ms=1000)
+        # Same name + checksum, different position → must dedupe
+        slide_b = dict(slide_a)
+        slide_b["duration_ms"] = 2500
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Repeat.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "repeat-hash",
+            "size_bytes": 0,
+            "slides": [slide_a, slide_b, slide_a],
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({slide_a["download_url"]: b})
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Downloaded exactly once
+        assert fake_session.calls == [slide_a["download_url"]]
+        # Manifest preserves all three positions in order with their durations
+        manifest = json.loads(
+            (cms_client.settings.slideshows_dir / "Repeat.slideshow.json").read_text()
+        )
+        assert [s["name"] for s in manifest["slides"]] == ["dup.mp4", "dup.mp4", "dup.mp4"]
+        assert [s["duration_ms"] for s in manifest["slides"]] == [1000, 2500, 1000]
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_no_slides(self, cms_client):
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Empty.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "empty-hash",
+            "size_bytes": 0,
+            "slides": [],
+        }
+        await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        fails = [m for m in sent if m["type"] == "fetch_failed"]
+        assert len(fails) == 1
+        assert fails[0]["reason"] == "invalid_slideshow_payload"
+
+
+class TestScheduleProtection:
+    """`_get_scheduled_asset_names` must expand slideshows so slide source
+    files are protected from LRU eviction while the slideshow is scheduled."""
+
+    def test_scheduled_slideshow_protects_slide_sources(self, cms_client):
+        # Create a slideshow manifest on disk
+        manifest = {
+            "name": "Promo.slideshow",
+            "checksum": "promo-hash",
+            "slides": [
+                {"name": "slideA.mp4", "asset_type": "video", "checksum": "a",
+                 "size_bytes": 100, "duration_ms": 1000, "play_to_end": False},
+                {"name": "slideB.jpg", "asset_type": "image", "checksum": "b",
+                 "size_bytes": 200, "duration_ms": 2000, "play_to_end": False},
+            ],
+        }
+        manifest_path = cms_client.settings.slideshows_dir / "Promo.slideshow.json"
+        manifest_path.write_text(json.dumps(manifest))
+        cms_client.asset_manager.register(
+            "Promo.slideshow", "slideshows/Promo.slideshow.json",
+            manifest_path.stat().st_size, "promo-hash",
+        )
+        # Schedule it
+        cms_client.settings.schedule_path.write_text(json.dumps({
+            "schedules": [{
+                "id": "s1", "name": "promo", "asset": "Promo.slideshow",
+                "asset_checksum": "promo-hash",
+                "start_time": "00:00", "end_time": "23:59", "priority": 0,
+            }],
+            "default_asset": None,
+            "timezone": "UTC",
+        }))
+
+        protected = cms_client._get_scheduled_asset_names()
+        assert "Promo.slideshow" in protected
+        assert "slideA.mp4" in protected
+        assert "slideB.jpg" in protected
+
+    def test_corrupt_slideshow_manifest_does_not_crash(self, cms_client):
+        # Slideshow registered, but its manifest is unparseable
+        bad_path = cms_client.settings.slideshows_dir / "Broken.slideshow.json"
+        bad_path.write_text("{not valid json")
+        cms_client.asset_manager.register(
+            "Broken.slideshow", "slideshows/Broken.slideshow.json",
+            bad_path.stat().st_size, "broken-hash",
+        )
+        cms_client.settings.schedule_path.write_text(json.dumps({
+            "schedules": [{
+                "id": "s1", "name": "broken", "asset": "Broken.slideshow",
+                "asset_checksum": "broken-hash",
+                "start_time": "00:00", "end_time": "23:59", "priority": 0,
+            }],
+            "default_asset": None,
+            "timezone": "UTC",
+        }))
+
+        protected = cms_client._get_scheduled_asset_names()
+        # Slideshow itself still protected; slides simply not expanded
+        assert protected == {"Broken.slideshow"}
+
+
+class TestCompletenessCheck:
+    """`_has_complete_slideshow` and the proactive refetch path."""
+
+    def test_complete_slideshow_returns_true(self, cms_client):
+        b = b"x" * 32
+        cms_client.asset_manager.register("s.mp4", "videos/s.mp4", len(b), _sha256(b))
+        manifest_path = cms_client.settings.slideshows_dir / "OK.slideshow.json"
+        manifest_path.write_text(json.dumps({
+            "name": "OK.slideshow",
+            "checksum": "ok-hash",
+            "slides": [{"name": "s.mp4", "asset_type": "video", "checksum": _sha256(b),
+                        "size_bytes": len(b), "duration_ms": 1000, "play_to_end": False}],
+        }))
+        cms_client.asset_manager.register(
+            "OK.slideshow", "slideshows/OK.slideshow.json",
+            manifest_path.stat().st_size, "ok-hash",
+        )
+        assert cms_client._has_complete_slideshow("OK.slideshow", "ok-hash") is True
+
+    def test_incomplete_slideshow_missing_slide_returns_false(self, cms_client):
+        # Register slideshow but never register the slide
+        manifest_path = cms_client.settings.slideshows_dir / "Half.slideshow.json"
+        manifest_path.write_text(json.dumps({
+            "name": "Half.slideshow",
+            "checksum": "half-hash",
+            "slides": [{"name": "missing.mp4", "asset_type": "video",
+                        "checksum": "abc", "size_bytes": 1, "duration_ms": 1000,
+                        "play_to_end": False}],
+        }))
+        cms_client.asset_manager.register(
+            "Half.slideshow", "slideshows/Half.slideshow.json",
+            manifest_path.stat().st_size, "half-hash",
+        )
+        assert cms_client._has_complete_slideshow("Half.slideshow", "half-hash") is False
+
+    def test_stale_slide_checksum_returns_false(self, cms_client):
+        # Slide cached with different checksum than the slideshow manifest expects
+        cms_client.asset_manager.register(
+            "stale.mp4", "videos/stale.mp4", 100, "old-checksum",
+        )
+        manifest_path = cms_client.settings.slideshows_dir / "Stale.slideshow.json"
+        manifest_path.write_text(json.dumps({
+            "name": "Stale.slideshow",
+            "checksum": "stale-hash",
+            "slides": [{"name": "stale.mp4", "asset_type": "video",
+                        "checksum": "new-checksum", "size_bytes": 100,
+                        "duration_ms": 1000, "play_to_end": False}],
+        }))
+        cms_client.asset_manager.register(
+            "Stale.slideshow", "slideshows/Stale.slideshow.json",
+            manifest_path.stat().st_size, "stale-hash",
+        )
+        assert cms_client._has_complete_slideshow("Stale.slideshow", "stale-hash") is False
+
+    @pytest.mark.asyncio
+    async def test_check_and_fetch_missing_refetches_incomplete_slideshow(self, cms_client):
+        """A registered slideshow whose slides are gone must trigger a fetch_request."""
+        # Slideshow registered with a manifest, but slide source not in asset_manager
+        manifest_path = cms_client.settings.slideshows_dir / "Incomplete.slideshow.json"
+        manifest_path.write_text(json.dumps({
+            "name": "Incomplete.slideshow",
+            "checksum": "inc-hash",
+            "slides": [{"name": "gone.mp4", "asset_type": "video",
+                        "checksum": "g", "size_bytes": 10, "duration_ms": 1000,
+                        "play_to_end": False}],
+        }))
+        cms_client.asset_manager.register(
+            "Incomplete.slideshow", "slideshows/Incomplete.slideshow.json",
+            manifest_path.stat().st_size, "inc-hash",
+        )
+
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        start = (now - timedelta(minutes=30)).strftime("%H:%M")
+        end = (now + timedelta(minutes=30)).strftime("%H:%M")
+        cms_client.settings.schedule_path.write_text(json.dumps({
+            "schedules": [{
+                "id": "s1", "name": "inc", "asset": "Incomplete.slideshow",
+                "asset_checksum": "inc-hash",
+                "start_time": start, "end_time": end, "priority": 0,
+            }],
+            "default_asset": None,
+            "timezone": "UTC",
+        }))
+
+        await cms_client._check_and_fetch_missing()
+
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        reqs = [m for m in sent if m["type"] == "fetch_request"]
+        assert len(reqs) == 1
+        assert reqs[0]["asset"] == "Incomplete.slideshow"

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -416,3 +416,94 @@ class TestPlayToEndIpcDriven:
         assert player._slideshow["pending_play_to_end"] is not None
         assert player._slideshow["index"] == before_idx
 
+
+
+class TestScheduledLoopCountIpcDriven:
+    """Phase 3: regular schedule finite loop_count via mpv native loop-file=inf.
+
+    Listener counts end-file events; on the Nth match we IPC-load splash.
+    No mpv respawn between loops.
+    """
+
+    def _arm(self, mpv_player, target_count=3):
+        player, svc = mpv_player
+        player._scheduled_pending = {
+            "entry_id": 17,
+            "generation": 5,
+            "asset_name": "video.mp4",
+            "target_count": target_count,
+            "completed_count": 0,
+        }
+        return player, svc
+
+    def test_eof_increments_count_below_target(self, mpv_player):
+        player, _ = self._arm(mpv_player, target_count=3)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 17, "_generation": 5,
+        })
+        assert player._scheduled_pending["completed_count"] == 1
+        player._show_splash.assert_not_called()
+
+    def test_eof_at_target_triggers_splash(self, mpv_player):
+        player, _ = self._arm(mpv_player, target_count=2)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 17, "_generation": 5,
+        })
+        assert player._scheduled_pending["completed_count"] == 1
+        player._show_splash.assert_not_called()
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 17, "_generation": 5,
+        })
+        assert player._scheduled_pending is None
+        player._show_splash.assert_called_once()
+
+    def test_eof_ignored_for_mismatched_entry_id(self, mpv_player):
+        player, _ = self._arm(mpv_player)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 99, "_generation": 5,
+        })
+        assert player._scheduled_pending["completed_count"] == 0
+        player._show_splash.assert_not_called()
+
+    def test_eof_ignored_for_stale_generation(self, mpv_player):
+        player, _ = self._arm(mpv_player)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 17, "_generation": 4,
+        })
+        assert player._scheduled_pending["completed_count"] == 0
+        player._show_splash.assert_not_called()
+
+    def test_stop_reason_ignored(self, mpv_player):
+        player, _ = self._arm(mpv_player)
+        for reason in ("stop", "quit", "redirect"):
+            player._on_mpv_event({
+                "event": "end-file", "reason": reason,
+                "playlist_entry_id": 17, "_generation": 5,
+            })
+        assert player._scheduled_pending["completed_count"] == 0
+        player._show_splash.assert_not_called()
+
+    def test_error_reason_clears_and_splashes(self, mpv_player):
+        player, _ = self._arm(mpv_player)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "error",
+            "playlist_entry_id": 17, "_generation": 5,
+        })
+        assert player._scheduled_pending is None
+        player._show_splash.assert_called_once()
+
+    def test_show_splash_clears_pending_defensively(self, mpv_player):
+        player, svc = mpv_player
+        player._scheduled_pending = {
+            "entry_id": 1, "generation": 1, "asset_name": "a.mp4",
+            "target_count": 5, "completed_count": 2,
+        }
+        player._stop_cage = MagicMock()
+        player._find_splash = MagicMock(return_value=None)
+        svc.AgoraPlayer._show_splash(player)
+        assert player._scheduled_pending is None

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -507,3 +507,72 @@ class TestScheduledLoopCountIpcDriven:
         player._find_splash = MagicMock(return_value=None)
         svc.AgoraPlayer._show_splash(player)
         assert player._scheduled_pending is None
+
+
+
+class TestMonitorMpvListenerSafetyNet:
+    """Phase 4: _monitor_mpv defensively clears stale listener-armed
+    pending records when mpv exits, so re-entrant transitions don't fire."""
+
+    def test_rc0_with_scheduled_pending_clears_and_logs(self, mpv_player, caplog):
+        player, svc = mpv_player
+        # Stub a finished mpv process.
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.stderr.read.return_value = b""
+        player._mpv_process = proc
+        player._scheduled_pending = {
+            "entry_id": 1, "generation": 1, "asset_name": "v.mp4",
+            "target_count": 5, "completed_count": 2,
+        }
+        player.current_desired = svc.DesiredState(
+            mode=svc.PlaybackMode.PLAY, asset="v.mp4",
+            loop=False, loop_count=None,
+        )
+        with caplog.at_level("WARNING"):
+            with patch.object(svc, "GLib"):
+                player._monitor_mpv("v.mp4")
+        assert player._scheduled_pending is None
+        assert any("listener missed events" in r.message for r in caplog.records)
+
+    def test_rc0_with_slideshow_pending_clears_arm(self, mpv_player):
+        player, svc = mpv_player
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.stderr.read.return_value = b""
+        player._mpv_process = proc
+        player._slideshow = {
+            "name": "S", "slides": [], "index": 1, "loop_count": None,
+            "loops_completed": 0, "epoch": 1,
+            "pending_play_to_end": {
+                "entry_id": 1, "generation": 1,
+                "slide_index": 1, "slide_name": "x.mp4",
+                "watchdog_id": 99,
+            },
+        }
+        player.current_desired = svc.DesiredState(
+            mode=svc.PlaybackMode.PLAY, asset="S",
+        )
+        player._play_next_slide = MagicMock()
+        with patch.object(svc, "GLib") as glib:
+            player._monitor_mpv("x.mp4")
+            glib.source_remove.assert_any_call(99)
+        assert player._slideshow["pending_play_to_end"] is None
+        player._play_next_slide.assert_called_once()
+
+    def test_error_rc_clears_stale_pendings(self, mpv_player):
+        player, svc = mpv_player
+        proc = MagicMock()
+        proc.poll.return_value = 1
+        proc.stderr.read.return_value = b"some error"
+        player._mpv_process = proc
+        player._scheduled_pending = {
+            "entry_id": 1, "generation": 1, "asset_name": "v.mp4",
+            "target_count": 3, "completed_count": 0,
+        }
+        player.current_desired = svc.DesiredState(
+            mode=svc.PlaybackMode.PLAY, asset="v.mp4",
+        )
+        with patch.object(svc, "GLib"):
+            player._monitor_mpv("v.mp4")
+        assert player._scheduled_pending is None

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -224,3 +224,195 @@ class TestApplyDesiredRoutes:
             player.apply_desired()
         glib.source_remove.assert_called_once_with(99)
         assert player._slideshow is None
+
+
+class TestPlayToEndIpcDriven:
+    """Phase 2: play_to_end advances via mpv IPC event listener.
+
+    When the listener is ready and IPC loadfile reports a
+    ``playlist_entry_id``, the slideshow should arm a
+    ``pending_play_to_end`` record and rely on ``_on_mpv_event`` to
+    advance — not respawn mpv.
+    """
+
+    def _arm(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 30000, "play_to_end": True},
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 5000, "play_to_end": False},
+        ])
+        # Pretend the IPC event listener is ready and the loadfile
+        # captured an entry_id.
+        import threading
+        player._mpv_event_connected = threading.Event()
+        player._mpv_event_connected.set()
+        player._mpv_generation = 7
+
+        def fake_loadfile(path, **kw):
+            player._mpv_active_entry_id = 42
+            return True
+        player._loadfile_mpv = MagicMock(side_effect=fake_loadfile)
+        return player, svc
+
+    def test_play_to_end_arms_pending_via_ipc(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1234
+            player._start_slideshow("Show", None)
+        # IPC path used, not respawn.
+        player._loadfile_mpv.assert_called_once()
+        kwargs = player._loadfile_mpv.call_args.kwargs
+        assert kwargs.get("loop") is False
+        assert kwargs.get("keep_open") is True
+        player._start_mpv.assert_not_called()
+        # pending_play_to_end armed with the captured entry_id and current gen.
+        pending = player._slideshow["pending_play_to_end"]
+        assert pending["entry_id"] == 42
+        assert pending["generation"] == 7
+        assert pending["watchdog_id"] == 1234
+
+    def test_on_mpv_event_advances_on_matching_eof(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1234
+            player._start_slideshow("Show", None)
+            # Reset the loadfile mock for the second slide call.
+            player._loadfile_mpv.reset_mock()
+            player._on_mpv_event({
+                "event": "end-file", "reason": "eof",
+                "playlist_entry_id": 42, "_generation": 7,
+            })
+            # Watchdog cancelled, pending cleared, advanced to slide 2.
+            glib.source_remove.assert_any_call(1234)
+        assert player._slideshow["pending_play_to_end"] is None
+        assert player._slideshow["index"] == 2
+
+    def test_on_mpv_event_ignores_mismatched_entry_id(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        before_idx = player._slideshow["index"]
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 99, "_generation": 7,
+        })
+        assert player._slideshow["pending_play_to_end"] is not None
+        assert player._slideshow["index"] == before_idx
+
+    def test_on_mpv_event_ignores_stale_generation(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        before_idx = player._slideshow["index"]
+        player._on_mpv_event({
+            "event": "end-file", "reason": "eof",
+            "playlist_entry_id": 42, "_generation": 6,
+        })
+        assert player._slideshow["pending_play_to_end"] is not None
+        assert player._slideshow["index"] == before_idx
+
+    def test_on_mpv_event_ignores_stop_reason(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        before_idx = player._slideshow["index"]
+        player._on_mpv_event({
+            "event": "end-file", "reason": "stop",
+            "playlist_entry_id": 42, "_generation": 7,
+        })
+        assert player._slideshow["pending_play_to_end"] is not None
+        assert player._slideshow["index"] == before_idx
+
+    def test_on_mpv_event_advances_on_error_reason(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        player._on_mpv_event({
+            "event": "end-file", "reason": "error",
+            "playlist_entry_id": 42, "_generation": 7,
+        })
+        assert player._slideshow["pending_play_to_end"] is None
+        assert player._slideshow["index"] == 2
+
+    def test_listener_not_ready_falls_back_to_respawn(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 30000, "play_to_end": True},
+        ])
+        # No _mpv_event_connected attribute → listener not ready.
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        # Legacy path: _start_mpv called, no pending_play_to_end armed.
+        player._start_mpv.assert_called_once()
+        assert player._slideshow["pending_play_to_end"] is None
+
+    def test_loadfile_failure_falls_back_to_respawn(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 30000, "play_to_end": True},
+        ])
+        import threading
+        player._mpv_event_connected = threading.Event()
+        player._mpv_event_connected.set()
+        player._loadfile_mpv = MagicMock(return_value=False)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        player._start_mpv.assert_called_once()
+        assert player._slideshow["pending_play_to_end"] is None
+
+    def test_loadfile_no_entry_id_falls_back_to_respawn(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 30000, "play_to_end": True},
+        ])
+        import threading
+        player._mpv_event_connected = threading.Event()
+        player._mpv_event_connected.set()
+        # loadfile reports success but never sets entry_id.
+        player._mpv_active_entry_id = None
+        player._loadfile_mpv = MagicMock(return_value=True)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        player._start_mpv.assert_called_once()
+        assert player._slideshow["pending_play_to_end"] is None
+
+    def test_clear_slideshow_cancels_watchdog(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1234
+            player._start_slideshow("Show", None)
+        with patch.object(svc, "GLib") as glib:
+            player._clear_slideshow()
+            # Watchdog id 1234 cancelled (timeout_id is None so only one call).
+            glib.source_remove.assert_called_once_with(1234)
+        assert player._slideshow is None
+
+    def test_watchdog_advances_when_event_never_arrives(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1234
+            player._start_slideshow("Show", None)
+        epoch = player._slideshow["epoch"]
+        player._on_play_to_end_watchdog(epoch)
+        assert player._slideshow["pending_play_to_end"] is None
+        assert player._slideshow["index"] == 2
+
+    def test_watchdog_drops_for_stale_epoch(self, mpv_player):
+        player, svc = self._arm(mpv_player)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        before_idx = player._slideshow["index"]
+        # Fire watchdog from a previous slideshow epoch — should be a no-op.
+        player._on_play_to_end_watchdog(player._slideshow["epoch"] - 1)
+        assert player._slideshow["pending_play_to_end"] is not None
+        assert player._slideshow["index"] == before_idx
+

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1,0 +1,226 @@
+"""Tests for the player-side slideshow sequencer (Commit 5c).
+
+Covers:
+- Slideshow manifest reading (good / missing / invalid).
+- apply_desired() with asset_type=slideshow routes to _start_slideshow
+  instead of single-asset resolution.
+- _play_next_slide() advances and loops, honouring slideshow-level
+  loop_count.
+- Mid-flight transition out of a slideshow cancels the slide timeout
+  and clears state.
+- mpv exit during a play_to_end video slide triggers next-slide advance.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.models import DesiredState, PlaybackMode
+
+
+@pytest.fixture
+def mpv_player(tmp_path):
+    """An AgoraPlayer wired up enough for slideshow sequencer tests."""
+    with patch.dict("sys.modules", {
+        "gi": MagicMock(),
+        "gi.repository": MagicMock(),
+    }):
+        import importlib
+        import player.service as svc
+        importlib.reload(svc)
+
+        p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
+        p.pipeline = None
+        p._mpv_process = None
+        p._cage_process = None
+        p.current_desired = None
+        p._plymouth_quit = False
+        p._current_path = None
+        p._current_mtime = None
+        p._health_retries = 0
+        p._error_retry_delay = 3
+        p._pending_error = None
+        p._loops_completed = 0
+        p._board = svc.Board.PI_5
+        p._player_backend = "mpv"
+        p._slideshow = None
+        p.assets_dir = tmp_path / "assets"
+        p.assets_dir.mkdir()
+        (p.assets_dir / "slideshows").mkdir()
+        (p.assets_dir / "images").mkdir()
+        (p.assets_dir / "videos").mkdir()
+        p.desired_path = tmp_path / "desired.json"
+        p.splash_config_path = tmp_path / "splash"
+        # Test scaffolding for what the sequencer touches.
+        p._update_current = MagicMock()
+        p._show_splash = MagicMock()
+        p._start_mpv = MagicMock()
+        p._loadfile_mpv = MagicMock(return_value=True)
+        yield p, svc
+
+
+def _write_manifest(player, name, slides):
+    path = player.assets_dir / "slideshows" / f"{name}.json"
+    import json
+    path.write_text(json.dumps({"name": name, "slides": slides}))
+    return path
+
+
+class TestManifestRead:
+    def test_returns_dict_when_valid(self, mpv_player):
+        player, _ = mpv_player
+        _write_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 1000},
+        ])
+        m = player._read_slideshow_manifest("Show")
+        assert m is not None
+        assert m["name"] == "Show"
+        assert len(m["slides"]) == 1
+
+    def test_returns_none_when_missing(self, mpv_player):
+        player, _ = mpv_player
+        assert player._read_slideshow_manifest("Nope") is None
+
+    def test_returns_none_for_empty_slides(self, mpv_player):
+        player, _ = mpv_player
+        _write_manifest(player, "Show", [])
+        assert player._read_slideshow_manifest("Show") is None
+
+    def test_returns_none_for_malformed_json(self, mpv_player):
+        player, _ = mpv_player
+        path = player.assets_dir / "slideshows" / "Show.json"
+        path.write_text("{not json")
+        assert player._read_slideshow_manifest("Show") is None
+
+
+class TestStartSlideshow:
+    def test_missing_manifest_falls_back_to_splash(self, mpv_player):
+        player, _ = mpv_player
+        player._start_slideshow("Nope", None)
+        player._show_splash.assert_called_once()
+        assert player._slideshow is None
+
+    def test_valid_manifest_kicks_off_first_slide(self, mpv_player):
+        player, svc = mpv_player
+        # Image slide → _loadfile_mpv path + GLib timeout
+        (player.assets_dir / "images" / "a.png").touch()
+        _write_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 5000, "play_to_end": False},
+        ])
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 42
+            player._start_slideshow("Show", None)
+        assert player._slideshow is not None
+        assert player._slideshow["name"] == "Show"
+        # Index advanced past slide 0
+        assert player._slideshow["index"] == 1
+        # Image slide → IPC loadfile + timeout for duration_ms
+        player._loadfile_mpv.assert_called_once()
+        glib.timeout_add.assert_called_once()
+        ms_arg, _cb = glib.timeout_add.call_args[0]
+        assert ms_arg == 5000
+        assert player._slideshow["timeout_id"] == 42
+
+
+class TestSlideAdvance:
+    def test_advance_loops_back_until_count_exceeded(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        (player.assets_dir / "images" / "b.png").touch()
+        _write_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 100, "play_to_end": False},
+            {"name": "b.png", "asset_type": "image",
+             "duration_ms": 100, "play_to_end": False},
+        ])
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", loop_count=2)
+            # 1st slide already shown via _start_slideshow.
+            # Walk: a → b → (loop1 incr) a → b → (loop2 incr ≥ target) splash
+            for _ in range(4):
+                player._on_slide_timeout()
+        # After 2nd full loop completes we should be on splash.
+        player._show_splash.assert_called_once()
+        assert player._slideshow is None
+
+    def test_missing_slide_file_skips_to_next(self, mpv_player):
+        player, svc = mpv_player
+        # Only second slide exists on disk
+        (player.assets_dir / "images" / "b.png").touch()
+        _write_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 100, "play_to_end": False},
+            {"name": "b.png", "asset_type": "image",
+             "duration_ms": 100, "play_to_end": False},
+        ])
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", loop_count=1)
+        # First slide skipped, second slide loaded
+        player._loadfile_mpv.assert_called_once()
+        loaded_path = player._loadfile_mpv.call_args[0][0]
+        assert loaded_path.name == "b.png"
+
+    def test_play_to_end_video_uses_start_mpv_no_loop(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video",
+             "duration_ms": 30000, "play_to_end": True},
+        ])
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        # play_to_end videos go through _start_mpv with loop=False
+        # (mpv exit then advances via _monitor_mpv path).
+        player._start_mpv.assert_called_once()
+        kwargs = player._start_mpv.call_args.kwargs
+        assert kwargs.get("loop") is False
+        # No timeout scheduled — exit drives the advance.
+        assert player._slideshow["timeout_id"] is None
+
+
+class TestApplyDesiredRoutes:
+    def test_slideshow_asset_type_routes_to_start_slideshow(self, mpv_player):
+        player, _ = mpv_player
+        desired = DesiredState(
+            mode=PlaybackMode.PLAY,
+            asset="Show",
+            asset_type="slideshow",
+        )
+        from shared.state import write_state
+        write_state(player.desired_path, desired)
+        with patch.object(player, "_start_slideshow") as start:
+            player.apply_desired()
+        start.assert_called_once_with("Show", None)
+
+    def test_same_slideshow_already_running_is_noop(self, mpv_player):
+        player, _ = mpv_player
+        player._slideshow = {"name": "Show", "slides": [], "index": 0,
+                             "loops_completed": 0, "loop_count": None,
+                             "timeout_id": None}
+        desired = DesiredState(
+            mode=PlaybackMode.PLAY,
+            asset="Show",
+            asset_type="slideshow",
+        )
+        from shared.state import write_state
+        write_state(player.desired_path, desired)
+        with patch.object(player, "_start_slideshow") as start:
+            player.apply_desired()
+        start.assert_not_called()
+
+    def test_transition_to_splash_clears_slideshow(self, mpv_player):
+        player, svc = mpv_player
+        player._slideshow = {"name": "Show", "slides": [], "index": 0,
+                             "loops_completed": 0, "loop_count": None,
+                             "timeout_id": 99}
+        desired = DesiredState(mode=PlaybackMode.SPLASH)
+        from shared.state import write_state
+        write_state(player.desired_path, desired)
+        with patch.object(svc, "GLib") as glib:
+            player.apply_desired()
+        glib.source_remove.assert_called_once_with(99)
+        assert player._slideshow is None


### PR DESCRIPTION
## Summary

Rebuilds the player around a **persistent mpv process driven by IPC** so that
slide→slide and slide→video transitions no longer flash black. Previously every
asset change tore mpv down and respawned it, costing 1–3 s of dead frames for
each transition. The new stack keeps a single mpv alive and uses
`loadfile` + `keep-open=yes` + an event listener on `eof-reached` to drive all
transitions on the same hardware decoder.

## What ships

Six phases on the same long-running branch (this PR), most squashed into the
named commits below:

- **Phase 0** — `_loadfile_mpv` IPC hardening: `request_id` correlation so
  events broadcast on the IPC socket can no longer be mistaken for command
  responses, with timeout-based fallback to legacy respawn.
- **Phase 1** — persistent mpv IPC event listener thread: reconnects on
  socket close, stamps every event with `_generation`, drains via
  `GLib.idle_add` so consumers run on the main loop without locks.
- **Phase 2** — slideshow `play_to_end` driven off real `end-file{reason=eof}`
  events instead of duration timers; identity-matched against
  `playlist_entry_id` so a stale event from a previous slide cannot advance
  the next one.
- **Phase 3** — scheduled-asset `loop_count` driven off the same listener:
  count completed `end-file` events on the active entry and switch to splash
  exactly when the requested loop count is reached.
- **Phase 4** — when the mpv monitor sees mpv exit (rc=0 or error), clear
  any stale listener arms (`_scheduled_pending`, slideshow
  `pending_play_to_end`) so the monitor can drive the next transition
  cleanly without a re-entrant double-fire.
- **Phase 5** — observe `eof-reached` (the event-listener subscription) and
  unconditionally `set_property pause=False` before every IPC `loadfile`.
  `keep-open=yes` causes mpv to *suppress* `end-file{reason=eof}` and pause
  on the last frame instead, so we observe the property flip; the unpause is
  needed when loading a video over a paused splash image.
- **Phase 6** — three pieces of lifecycle hardening surfaced by a parity
  review (see [Phase 6 fixes](#phase-6-fixes) below).

## Phase 6 fixes

These three commits address real failure modes that were masked by the
visual smoke test (which never crossed a mode boundary or hit a transient
IPC error). All three are caught by new focused unit tests.

1. **Stop killing the listener from `_teardown()`.** `_teardown` runs from
   many normal-operation paths (mode switches, splash fallback, pipeline
   error/health-retry, stream start). The listener thread is started exactly
   once at `run()` startup, so any non-shutdown teardown was permanently
   stranding the listener — and silently demoting all subsequent slideshow
   `play_to_end` and scheduled `loop_count` arms to the legacy
   duration/respawn paths. Move the stop call into the `run()` signal
   handler and `finally` clause, which are the only true shutdown sites.

2. **Make `pause=False` IPC failure fatal in `_loadfile_mpv`.** Phase 5
   added this command precisely to unstick a video loaded over a paused
   splash image; if mpv refuses it we should fall back to a fresh respawn
   rather than press on with a possibly-paused mpv that may never advance —
   defeating the very fix this command exists for.

3. **Self-heal the listener on unexpected exceptions.** Wrap
   `_mpv_event_loop` in an outer try/except so a bad event from a buggy
   downstream consumer cannot kill the listener thread permanently and
   strand finite `loop_count` or slideshow `play_to_end` consumers. On
   exception we clear the connected flag, sleep one reconnect interval,
   and retry — consumers see us as not-ready and fall back to legacy
   paths until reconnected.

## Compatibility

- **Pi 4 / Pi 5**: mpv backend, full new behavior.
- **Pi Zero 2 W / UNKNOWN**: still on the GStreamer respawn-per-asset
  backend (`shared/board.player_backend()`). Tracked separately in
  [#151](https://github.com/sslivins/agora/issues/151).
- **CMS**: no protocol or schema changes. The slideshow protocol
  extension landed in agora-cms#466 (also includes the `display_ports`
  fix; the squash subject is misleading but the body is correct).

## Verification

- `pytest tests/test_player_service.py tests/test_slideshow_player.py`
  (170 tests) — all pass locally.
- Visual smoke on a real Pi 5 against a 6-slide mixed image+video
  slideshow — slide-to-slide and slide-to-video transitions are now
  seamless ("flawless" per @sslivins's review).

## Risk

- The listener-fallback story means that even if any new IPC path
  regresses, we degrade to the existing legacy duration/respawn behavior
  rather than getting stuck. `is_mpv_event_listener_ready()` is the
  fallback gate.
- Pi Zero / UNKNOWN boards are unaffected because `player_backend()`
  picks GStreamer for them.
- mpv version requirement: needs the `playlist_entry_id` field on
  `loadfile` responses (mpv 0.36+) for identity matching, but consumers
  fall back to non-identity matching if the field is missing on older
  versions.

## Follow-ups (separate issues / PRs)

- [#151](https://github.com/sslivins/agora/issues/151) Pi Zero 2 W on
  the mpv path (smoothness investigation).
- Audio-only asset support (`audio` asset_type, currently `play_to_end`
  is gated to `video`).
- Per-slide / per-asset clip points (start/stop offsets within an asset).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
