### PR TITLE
provision: wait for ethernet link before falling through to AP mode

### DIFF
--- a/provision/service.py
+++ b/provision/service.py
@@ -78,6 +78,7 @@ CMS_STATUS_PATH = STATE_DIR / "cms_status.json"
 
 WIFI_CONNECT_TIMEOUT = 60   # seconds to wait for Wi-Fi on boot
 AP_SESSION_TIMEOUT = 600    # 10 minutes in AP mode before retrying Wi-Fi
+ETHERNET_LINK_WAIT_S = 30   # seconds to wait for ethernet link/DHCP after boot
 PORTAL_PORT = 80
 
 WIFI_RETRY_COUNT = 3        # attempts before returning to AP mode
@@ -686,6 +687,24 @@ async def run_service(force_oobe: bool = False) -> None:
     # ── Ethernet fast-path ───────────────────────────────────────────
     # If ethernet is connected (Pi 4, Pi 5, CM5), skip OOBE entirely.
     # The device is immediately reachable on the LAN.
+    #
+    # On boards with no Wi-Fi (e.g. CM5 Lite), we MUST take this path —
+    # falling through to the AP-mode branch will fail because there is
+    # no Wi-Fi interface to host the captive portal. NetworkManager may
+    # take a few seconds after boot to bring the link up and assign an
+    # IP, so wait briefly for `is_ethernet_connected()` to become true
+    # if an ethernet interface is present.
+    if run_oobe and get_ethernet_interface() and not is_ethernet_connected():
+        logger.info(
+            "Ethernet interface present but not yet connected — waiting up to %ds",
+            ETHERNET_LINK_WAIT_S,
+        )
+        for _ in range(ETHERNET_LINK_WAIT_S):
+            await asyncio.sleep(1)
+            if is_ethernet_connected():
+                logger.info("Ethernet link came up")
+                break
+
     if run_oobe and is_ethernet_connected():
         logger.info("Ethernet connected on first boot — skipping Wi-Fi OOBE")
 

--- a/tests/test_oobe_flow.py
+++ b/tests/test_oobe_flow.py
@@ -127,7 +127,99 @@ class TestOobeServicePrestart:
         assert "agora-player" not in wifi_to_phase2
 
 
-class TestOobePhase2NoFallthrough:
+class TestEthernetLinkWait:
+    """Verify the ethernet fast-path waits for the link to come up.
+
+    Boards with ethernet but no Wi-Fi (e.g. CM5 Lite) MUST take the
+    ethernet fast-path. NetworkManager often takes a few seconds to
+    bring the link up after boot, so falling through to the AP-mode
+    branch immediately would be a fatal race.
+    """
+
+    def test_constant_defined(self):
+        """ETHERNET_LINK_WAIT_S must be a positive integer."""
+        from provision import service
+        assert isinstance(service.ETHERNET_LINK_WAIT_S, int)
+        assert service.ETHERNET_LINK_WAIT_S > 0
+
+    def test_run_service_waits_for_ethernet_before_falling_through(self):
+        """The fast-path must include a wait loop on get_ethernet_interface()."""
+        import inspect
+        from provision import service
+
+        source = inspect.getsource(service.run_service)
+
+        # The fast-path block should reference both ETHERNET_LINK_WAIT_S
+        # and get_ethernet_interface() *before* the is_ethernet_connected
+        # fast-path entry, so we wait for the link before falling through.
+        eth_section = source.split("Ethernet fast-path")[1].split("Ethernet connected on first boot")[0]
+        assert "ETHERNET_LINK_WAIT_S" in eth_section, \
+            "Ethernet fast-path must wait for link before checking is_ethernet_connected"
+        assert "get_ethernet_interface" in eth_section, \
+            "Ethernet fast-path must check get_ethernet_interface before waiting"
+
+    @pytest.mark.asyncio
+    async def test_takes_ethernet_path_when_link_comes_up_late(self):
+        """If ethernet interface exists but link is initially down, the
+        wait loop should poll until is_ethernet_connected() becomes true,
+        and the run should take the ethernet fast-path (NOT enter AP mode)."""
+        from provision import service
+
+        connected_calls = {"n": 0}
+        def fake_is_ethernet_connected():
+            connected_calls["n"] += 1
+            return connected_calls["n"] > 3
+
+        ap_attempted = {"v": False}
+        def fake_start_ap(*args, **kwargs):
+            ap_attempted["v"] = True
+            return False
+
+        # Stub Windows-incompatible signal hooks before importing path runs
+        sig_patches = [
+            patch("signal.signal"),
+            patch.object(service.signal, "SIGHUP", 1, create=True),
+            patch.object(service.signal, "SIGTERM", 15, create=True),
+            patch.object(service.signal, "SIGINT", 2, create=True),
+        ]
+
+        fake_loop = MagicMock()
+        fake_loop.add_signal_handler = MagicMock()
+
+        with patch.object(service, "is_provisioned", return_value=False), \
+             patch.object(service, "get_ethernet_interface", return_value="eth0"), \
+             patch.object(service, "is_ethernet_connected", side_effect=fake_is_ethernet_connected), \
+             patch.object(service, "is_wifi_disabled", return_value=True), \
+             patch.object(service, "get_wifi_interface", return_value=None), \
+             patch.object(service, "ProvisionDisplay", MagicMock()), \
+             patch.object(service, "_wait_for_cms_adoption", AsyncMock(return_value="no_cms")), \
+             patch.object(service, "get_device_ip", return_value="192.168.1.50"), \
+             patch.object(service, "get_device_serial_suffix", return_value="ABCD"), \
+             patch.object(service, "_get_cms_host", return_value="cms.example.com"), \
+             patch.object(service, "_try_mdns_discovery", return_value=None), \
+             patch.object(service, "start_ap", side_effect=fake_start_ap), \
+             patch.object(service, "PROVISION_FLAG", MagicMock()), \
+             patch("asyncio.create_subprocess_exec", AsyncMock(return_value=MagicMock(
+                 wait=AsyncMock(return_value=0), returncode=0,
+             ))), \
+             patch("asyncio.sleep", AsyncMock(return_value=None)), \
+             patch("asyncio.get_event_loop", return_value=fake_loop):
+
+            for p in sig_patches:
+                p.start()
+            try:
+                await service.run_service(force_oobe=False)
+            finally:
+                for p in sig_patches:
+                    p.stop()
+
+        assert connected_calls["n"] >= 4, \
+            f"Expected wait loop to poll ethernet at least 4 times, got {connected_calls['n']}"
+        assert not ap_attempted["v"], \
+            "AP mode must not be attempted when ethernet interface is present"
+
+
+
     """Verify that Phase 2 never falls through to player on CMS failure."""
 
     def test_phase2_no_unconditional_break_on_failure(self):


### PR DESCRIPTION
## Summary

Fixes an OOBE crash on ethernet-only boards (e.g. CM5 Lite without WiFi) where `agora-provision` would attempt AP-mode startup at boot before NetworkManager had assigned an IP to eth0.

## Root cause

`run_service` checks `is_ethernet_connected()` (which requires both interface presence AND an IP) for its ethernet fast-path. The "no network at all" fall-through branch uses `not get_ethernet_interface()` (interface existence only). At boot on a board with eth0 present but DHCP not yet completed, neither branch fires correctly and the code falls through to AP-mode startup. On boards without WiFi, AP startup fails:

```
Connection activation failed: No suitable device found for this connection
(device eth0 not available because profile is not compatible with device
(mismatching interface name))
```

## Fix

Add a 30s wait loop before the fast-path check: if an ethernet interface exists but `is_ethernet_connected()` returns False, poll once per second up to `ETHERNET_LINK_WAIT_S` (30s). Boards that already have an IP at boot are unaffected (loop exits on first iteration).

## Verification

Built on a Pi5 CM5 Lite (no WiFi) with the patched service.py installed at `/opt/agora/src/provision/service.py`. After factory reset + reboot:

```
Apr 26 20:34:52 agora bash[861]: Loaded RGB565 helper
Apr 26 20:34:52 agora bash[861]: Display ready: 1920x1080 @ 16bpp
Apr 26 20:34:52 agora bash[861]: Ethernet interface present but not yet connected -- waiting up to 30s
Apr 26 20:34:58 agora bash[861]: Ethernet link came up
```

Provision service stays active, no AP-mode attempt, OOBE proceeds normally.

## Tests

3 new tests in `tests/test_oobe_flow.py::TestEthernetLinkWait`:
- `test_constant_defined` — `ETHERNET_LINK_WAIT_S` exists with sane value
- `test_run_service_waits_for_ethernet_before_falling_through` — source structure check
- `test_takes_ethernet_path_when_link_comes_up_late` — end-to-end behavioral test: sets up `is_ethernet_connected()` to return False for first 3 calls, verifies the loop polls and the ethernet fast-path is taken (no AP mode)

Full `tests/test_oobe_flow.py` suite passes (10/10).
