### PR TITLE
player: bundled-event buffer + slideshow default_asset routing

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1257,18 +1257,34 @@ class CMSClient:
                     self._last_eval_state = ("waiting", default_asset, default_checksum)
                 return
 
-            state_key = ("default", default_asset, default_checksum)
+            # Detect slideshow defaults from local asset registry — the sync
+            # payload doesn't carry a default_asset_type, but the asset
+            # manager records the storage subdir, so a slideshow manifest
+            # registered as `slideshows/<name>/...` is recognizable here.
+            default_asset_type = "slideshow" if self._is_slideshow_asset(default_asset) else None
+
+            state_key = ("default", default_asset, default_checksum, default_asset_type)
             if self._last_eval_state == state_key:
                 return
 
             # Leaving a scheduled playback → default asset
             self._end_current_playback()
 
-            desired = DesiredState(mode=PlaybackMode.PLAY, asset=default_asset, loop=True, expected_checksum=default_checksum)
+            desired = DesiredState(
+                mode=PlaybackMode.PLAY,
+                asset=default_asset,
+                asset_type=default_asset_type,
+                loop=True,
+                expected_checksum=default_checksum,
+            )
             write_state(self.settings.desired_state_path, desired)
             self.asset_manager.touch(default_asset)
             self._last_eval_state = state_key
-            logger.info("Schedule: playing default asset %s", default_asset)
+            logger.info(
+                "Schedule: playing default asset %s%s",
+                default_asset,
+                f" (asset_type={default_asset_type})" if default_asset_type else "",
+            )
         else:
             state_key = ("splash", None)
             if self._last_eval_state == state_key:

--- a/player/service.py
+++ b/player/service.py
@@ -734,6 +734,7 @@ class AgoraPlayer:
     # Per-command IPC timeout (seconds). mpv responds promptly under
     # normal conditions; we'd rather log + fail than block forever.
     _IPC_CMD_TIMEOUT_S = 1.5
+    _MPV_LOAD_WAIT_S = 0.75
 
     def _ipc_call(self, sock, recv_buf: bytes, command: list, *,
                   timeout_s: Optional[float] = None):
@@ -748,6 +749,12 @@ class AgoraPlayer:
         ``recv_buf`` carries any bytes already read but not yet parsed across
         successive calls on the same socket so partial JSON lines are not
         lost.
+
+        Events seen while waiting for the response are appended to
+        ``self._mpv_event_buf`` rather than discarded, so a subsequent
+        ``_wait_for_mpv_load_complete`` (which runs after several IPC calls)
+        can still observe ``start-file`` / ``file-loaded`` / ``end-file``
+        events that arrived bundled with an earlier response chunk.
         """
         req_id = next(self._mpv_ipc_counter)
         msg = json.dumps({"command": command, "request_id": req_id}).encode() + b"\n"
@@ -771,7 +778,13 @@ class AgoraPlayer:
                 except (UnicodeDecodeError, json.JSONDecodeError):
                     continue
                 if "event" in resp:
-                    # mpv broadcasts events on every IPC client; drop
+                    # mpv broadcasts events on every IPC client. Stash
+                    # them so _wait_for_mpv_load_complete can replay them
+                    # after the multi-call IPC sequence completes.
+                    try:
+                        self._mpv_event_buf.append(resp)
+                    except AttributeError:
+                        self._mpv_event_buf = [resp]
                     continue
                 if resp.get("request_id") == req_id:
                     return resp.get("error") == "success", resp.get("data"), recv_buf
@@ -788,6 +801,101 @@ class AgoraPlayer:
                 return False, None, recv_buf
             if not chunk:
                 return False, None, recv_buf
+            recv_buf += chunk
+
+    def _wait_for_mpv_load_complete(self, sock, recv_buf: bytes, *,
+                                     expected_entry_id: Optional[int],
+                                     expected_path: Path,
+                                     timeout_s: float = 0.5) -> tuple[bool, bytes]:
+        """Wait for mpv to finish loading the file just submitted via ``loadfile``.
+
+        Returns ``(loaded, new_recv_buf)``. ``loaded`` is True when mpv emits a
+        ``file-loaded`` event for our load (matched on ``playlist_entry_id`` if
+        present, or implicitly on the next file-loaded after a matching
+        ``start-file``). False on timeout or on ``end-file`` with an error
+        reason matching our entry_id.
+
+        Reads newline-delimited JSON from the same socket the loadfile was
+        submitted on. Command responses for unrelated request_ids are dropped.
+        Other events (video-reconfig, property-change, etc.) are skipped.
+
+        This avoids the GLib-loop deadlock that would occur if we waited on
+        the persistent listener thread's queue, since that queue is drained
+        on the GLib main loop and ``_loadfile_mpv`` blocks the main loop.
+        """
+        start_file_seen = (expected_entry_id is None)
+        deadline = time.monotonic() + timeout_s
+
+        # Replay any events captured by prior _ipc_calls on this socket —
+        # mpv often emits start-file / file-loaded in the same chunk as
+        # the loadfile success response, so the post-load mute call may
+        # have already consumed those event lines from the wire.
+        replay = list(getattr(self, "_mpv_event_buf", ()) or ())
+        try:
+            self._mpv_event_buf.clear()
+        except AttributeError:
+            self._mpv_event_buf = []
+        for msg in replay:
+            ev = msg.get("event")
+            if ev is None:
+                continue
+            eid = msg.get("playlist_entry_id")
+            if ev == "start-file":
+                if expected_entry_id is None or eid == expected_entry_id:
+                    start_file_seen = True
+            elif ev == "end-file":
+                if (expected_entry_id is None or eid == expected_entry_id) \
+                        and msg.get("reason") == "error":
+                    logger.warning(
+                        "mpv: load failed for %s (entry_id=%s, reason=error, file_error=%s)",
+                        expected_path.name, eid, msg.get("file_error"),
+                    )
+                    return False, recv_buf
+            elif ev == "file-loaded":
+                if expected_entry_id is None or eid == expected_entry_id or eid is None:
+                    if start_file_seen:
+                        return True, recv_buf
+
+        while True:
+            while b"\n" in recv_buf:
+                line, recv_buf = recv_buf.split(b"\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line.decode())
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    continue
+                ev = msg.get("event")
+                if ev is None:
+                    continue
+                eid = msg.get("playlist_entry_id")
+                if ev == "start-file":
+                    if expected_entry_id is None or eid == expected_entry_id:
+                        start_file_seen = True
+                elif ev == "end-file":
+                    if (expected_entry_id is None or eid == expected_entry_id) \
+                            and msg.get("reason") == "error":
+                        logger.warning(
+                            "mpv: load failed for %s (entry_id=%s, reason=error, file_error=%s)",
+                            expected_path.name, eid, msg.get("file_error"),
+                        )
+                        return False, recv_buf
+                elif ev == "file-loaded":
+                    if expected_entry_id is None or eid == expected_entry_id or eid is None:
+                        if start_file_seen:
+                            return True, recv_buf
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False, recv_buf
+            try:
+                sock.settimeout(min(remaining, 0.25))
+                chunk = sock.recv(4096)
+            except OSError:
+                return False, recv_buf
+            if not chunk:
+                return False, recv_buf
             recv_buf += chunk
 
     def _loadfile_mpv(self, path: Path, *, loop: bool = False,
@@ -825,6 +933,8 @@ class AgoraPlayer:
         # Fresh request_id sequence per IPC session — responses on this
         # socket are single-shot, no need for global uniqueness.
         self._mpv_ipc_counter = itertools.count()
+        # Fresh event capture for this load — see _ipc_call docstring.
+        self._mpv_event_buf = []
 
         sock = None
         try:
@@ -920,14 +1030,31 @@ class AgoraPlayer:
             if not ok:
                 logger.warning("mpv IPC: set mute (post-load) failed (continuing)")
 
-            # When loading an image, toggle fullscreen to force DRM plane refresh.
-            # Don't fail the whole call if a toggle drops; best-effort.
-            if is_image:
-                for _ in range(3):
-                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
-                        ["set_property", "fullscreen", False])
-                    _, _, recv_buf = self._ipc_call(sock, recv_buf,
-                        ["set_property", "fullscreen", True])
+            # Wait briefly for mpv to actually finish loading the new file,
+            # then toggle fullscreen 3× to force a DRM plane refresh. Without
+            # the wait, under rapid successive loadfile calls the toggle can
+            # fire before mpv has decoded the new content. Without the
+            # toggle, image→video and image→image transitions can leave the
+            # previous frame committed to the connector's primary plane even
+            # though mpv has internally swapped to the new file. The toggle
+            # is best-effort; don't fail the call on a dropped command.
+            loaded, recv_buf = self._wait_for_mpv_load_complete(
+                sock, recv_buf,
+                expected_entry_id=entry_id,
+                expected_path=path,
+                timeout_s=self._MPV_LOAD_WAIT_S,
+            )
+            if not loaded:
+                logger.warning(
+                    "mpv IPC: timed out waiting for file-loaded for %s "
+                    "(entry_id=%s); forcing refresh anyway",
+                    path.name, entry_id,
+                )
+            for _ in range(3):
+                _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "fullscreen", False])
+                _, _, recv_buf = self._ipc_call(sock, recv_buf,
+                    ["set_property", "fullscreen", True])
 
             logger.info(
                 "mpv IPC loadfile succeeded for %s (mute=%s keep_open=%s entry_id=%s)",
@@ -2181,28 +2308,68 @@ class AgoraPlayer:
     # ── State file watcher ──
 
     def _setup_inotify(self) -> bool:
-        """Watch desired.json via inotify. Returns True on success."""
+        """Watch desired.json and the splash config file via inotify.
+
+        Returns True on success.
+
+        Two directories are watched because the two files live in
+        different parents: ``desired.json`` is in ``state_dir`` while the
+        splash config is in ``persist_dir``. Without watching the splash
+        config, CMS-driven splash changes (which only rewrite that file)
+        would never wake the player and the new splash would not appear
+        until the next service restart.
+        """
         try:
             from inotify_simple import INotify, flags as inotify_flags
 
             inotify = INotify()
-            inotify.add_watch(
-                str(self.state_dir),
-                inotify_flags.CLOSE_WRITE | inotify_flags.MOVED_TO,
-            )
+            mask = inotify_flags.CLOSE_WRITE | inotify_flags.MOVED_TO
+            state_wd = inotify.add_watch(str(self.state_dir), mask)
+            self.persist_dir.mkdir(parents=True, exist_ok=True)
+            persist_wd = inotify.add_watch(str(self.persist_dir), mask)
+            splash_name = self.splash_config_path.name
 
             def on_inotify_event(fd, condition):
                 for event in inotify.read():
-                    if event.name == "desired.json":
+                    if event.wd == state_wd and event.name == "desired.json":
                         logger.debug("desired.json changed (inotify)")
                         GLib.idle_add(self.apply_desired)
+                    elif event.wd == persist_wd and event.name == splash_name:
+                        logger.debug("splash config changed (inotify)")
+                        GLib.idle_add(self._on_splash_config_changed)
                 return True
 
             GLib.io_add_watch(inotify.fd, GLib.IO_IN, on_inotify_event)
-            logger.info("Watching state dir via inotify")
+            logger.info("Watching state and persist dirs via inotify")
             return True
         except ImportError:
             return False
+
+    def _on_splash_config_changed(self) -> bool:
+        """Re-render the splash if it's currently the on-screen content.
+
+        Called from inotify when the splash config file is rewritten
+        (e.g. via the CMS ``/assets/{name}/set-splash`` API). When the
+        player is currently in SPLASH or STOP mode, re-invoke
+        :meth:`_show_splash` so the new splash appears immediately via
+        the seamless mpv IPC path. When the player is currently in PLAY
+        mode, do nothing — the schedule keeps running and the new splash
+        will be picked up automatically the next time we transition to
+        splash.
+
+        Returns False so GLib.idle_add does not repeat.
+        """
+        cd = self.current_desired
+        mode = cd.mode if cd is not None else None
+        if mode in (PlaybackMode.SPLASH, PlaybackMode.STOP, None):
+            logger.info("Splash config changed — re-rendering splash")
+            self._show_splash()
+        else:
+            logger.info(
+                "Splash config changed — current mode is %s, "
+                "deferring until next transition", mode,
+            )
+        return False
 
     def _poll_state(self) -> bool:
         """Poll-based fallback for state changes."""

--- a/tests/test_play_without_asset.py
+++ b/tests/test_play_without_asset.py
@@ -208,3 +208,80 @@ class TestPlayWithoutAsset:
         sync_data = _make_schedule_data([_active_entry("video.mp4", "abc123")])
         cms_client._evaluate_schedule(sync_data)
         # Should not raise
+
+
+class TestSlideshowDefaultAsset:
+    """Default asset that is a slideshow must be played as a slideshow.
+
+    The sync payload doesn't carry default_asset_type, but the asset
+    manager records the storage subdir locally.  _evaluate_schedule
+    must consult that to set asset_type='slideshow' on DesiredState,
+    otherwise the player falls through to single-asset playback and
+    the slideshow never renders.
+    """
+
+    def test_slideshow_default_sets_asset_type(self, cms_client):
+        from shared.models import DesiredState
+        from shared.state import read_state
+
+        cms_client.asset_manager.has_asset.return_value = True
+        # Asset manager registers the default as a slideshow manifest
+        cms_client.asset_manager.get.return_value = {"path": "slideshows/myshow/myshow.json"}
+
+        sync_data = _make_schedule_data(
+            schedules=[],
+            default_asset="myshow",
+            default_asset_checksum="abc",
+        )
+        cms_client._evaluate_schedule(sync_data)
+
+        desired = read_state(cms_client.settings.desired_state_path, DesiredState)
+        assert desired.mode == "play"
+        assert desired.asset == "myshow"
+        assert desired.asset_type == "slideshow"
+
+    def test_non_slideshow_default_has_no_asset_type(self, cms_client):
+        """Image/video defaults must not get a spurious asset_type."""
+        from shared.models import DesiredState
+        from shared.state import read_state
+
+        cms_client.asset_manager.has_asset.return_value = True
+        # Registered as an image, not a slideshow
+        cms_client.asset_manager.get.return_value = {"path": "images/photo.jpg"}
+
+        sync_data = _make_schedule_data(
+            schedules=[],
+            default_asset="photo.jpg",
+            default_asset_checksum="def",
+        )
+        cms_client._evaluate_schedule(sync_data)
+
+        desired = read_state(cms_client.settings.desired_state_path, DesiredState)
+        assert desired.mode == "play"
+        assert desired.asset == "photo.jpg"
+        # Either unset (None) or the empty string — must NOT be 'slideshow'
+        assert desired.asset_type != "slideshow"
+
+    def test_slideshow_state_key_includes_asset_type(self, cms_client):
+        """Switching default from image→slideshow at the same name should rewrite state."""
+        from shared.models import DesiredState
+        from shared.state import read_state
+
+        cms_client.asset_manager.has_asset.return_value = True
+
+        # First eval: registered as image
+        cms_client.asset_manager.get.return_value = {"path": "images/myasset"}
+        sync_data = _make_schedule_data(
+            schedules=[],
+            default_asset="myasset",
+            default_asset_checksum="abc",
+        )
+        cms_client._evaluate_schedule(sync_data)
+        first = read_state(cms_client.settings.desired_state_path, DesiredState)
+        assert first.asset_type != "slideshow"
+
+        # Same asset name + checksum, but now registered as slideshow
+        cms_client.asset_manager.get.return_value = {"path": "slideshows/myasset/myasset.json"}
+        cms_client._evaluate_schedule(sync_data)
+        second = read_state(cms_client.settings.desired_state_path, DesiredState)
+        assert second.asset_type == "slideshow"

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1927,23 +1927,23 @@ class TestLoadfileMpv:
         mock_socket_mod.AF_UNIX = 1
         mock_socket_mod.SOCK_STREAM = 1
         # recv: loop-file(0), loop-playlist(1), mute(2), pause(3), hwdec(4),
-        # loadfile(5), mute (post-load)(6)
+        # loadfile(5), mute (post-load)(6), 6x fullscreen toggles(7..12)
         mock_sock.recv.side_effect = [
             self._ok(0),                       # loop-file
             self._ok(1),                       # loop-playlist
             self._ok(2),                       # mute (pre-load)
             self._ok(3),                       # pause=False (pre-load)
             self._ok(4),                       # hwdec
-            self._make_success_response(5),    # loadfile
+            self._make_success_response(5),    # loadfile (carries start-file/file-loaded events)
             self._ok(6),                       # mute (post-load)
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]  # 3x toggle (off+on)
 
         result = mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
         assert result is True
         mock_sock.close.assert_called_once()
 
         # Should have sent: set loop-file, loop-playlist, mute, pause,
-        # hwdec drm-copy, loadfile (post-load mute too)
+        # hwdec drm-copy, loadfile, mute (post-load), 6x fullscreen
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
         assert b'"loop-file"' in sends[0]
         assert b'"inf"' in sends[0]  # loop=True → inf
@@ -2031,8 +2031,14 @@ class TestLoadfileMpv:
                     assert b"true" in s
 
     @patch("player.service.socket")
-    def test_video_loadfile_no_fullscreen_toggle(self, mock_socket_mod, mpv_player):
-        """Video loadfile should NOT trigger fullscreen toggle."""
+    def test_video_loadfile_triggers_fullscreen_toggle(self, mock_socket_mod, mpv_player):
+        """Video loadfile must also trigger the 3× fullscreen toggle.
+
+        Originally images-only — extended to videos because mpv with
+        ``vo=drm`` does not always commit the first video frame to the
+        connector primary plane after an image→video swap until the
+        toggle nudges it (see fix/splash-config-watch).
+        """
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
         mpv_player._mpv_process = mock_proc
@@ -2049,16 +2055,21 @@ class TestLoadfileMpv:
             self._ok(4),                       # hwdec
             self._make_success_response(5),    # loadfile
             self._ok(6),                       # mute (post-load)
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]  # 3x toggle
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True)
 
         sends = [c[0][0] for c in mock_sock.sendall.call_args_list]
-        # 7 commands: loop-file, loop-playlist, mute, pause, hwdec, loadfile,
-        # mute (post-load) — no fullscreen
-        assert len(sends) == 7
-        for s in sends:
-            assert b'"fullscreen"' not in s
+        # 13 commands: loop-file, loop-playlist, mute, pause, hwdec,
+        # loadfile, mute (post-load), 6x fullscreen
+        assert len(sends) == 13
+        fullscreen_sends = [s for s in sends if b'"fullscreen"' in s]
+        assert len(fullscreen_sends) == 6
+        for i, s in enumerate(fullscreen_sends):
+            if i % 2 == 0:
+                assert b"false" in s
+            else:
+                assert b"true" in s
 
     @patch("player.service.socket")
     def test_loadfile_returns_false_on_no_success(self, mock_socket_mod, mpv_player):
@@ -2165,7 +2176,7 @@ class TestLoadfileMpv:
             self._ok(4),                       # hwdec
             self._make_success_response(5),    # loadfile
             self._ok(6),                       # mute (post-load)
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]  # 3x toggle
 
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
 
@@ -2215,9 +2226,12 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),                                       # mute (pre-load)
             self._ok(3),                                       # pause=False
             self._ok(4),                                       # hwdec
-            self._ok(5),                                       # loadfile
+            # loadfile response + start-file/file-loaded events for entry_id=1
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             self._ok(6),                                       # mute (post-load)
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]                # 3x toggle
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=True) is True
 
     @patch("player.service.socket")
@@ -2235,9 +2249,11 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),
             self._ok(3),
             self._ok(4),
-            self._ok(5),
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             self._ok(6),
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
 
     @patch("player.service.socket")
@@ -2252,9 +2268,11 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),
             self._ok(3),
             self._ok(4),
-            self._ok(5),
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             self._ok(6),
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]
         assert mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False) is True
 
     @patch("player.service.socket")
@@ -2284,9 +2302,11 @@ class TestLoadfileMpvIpcHardening:
             self._ok(2),
             self._ok(3),
             self._ok(4),
-            self._ok(5),
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             self._ok(6),
-        ]
+        ] + [self._ok(7 + i) for i in range(6)]
         mpv_player._loadfile_mpv(Path("/tmp/test.mp4"), loop=False)
         sends = [c[0][0] for c in sock.sendall.call_args_list]
         for s in sends:
@@ -2627,9 +2647,15 @@ class TestStartMpvIpcFallback:
             b'{"request_id":2,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":3,"error":"success"}\n',  # pause=False
             b'{"request_id":4,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":2},"request_id":5,"error":"success"}\n',  # loadfile
+            # loadfile response + start-file/file-loaded events for entry_id=2
+            b'{"data":{"playlist_entry_id":2},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":2}\n'
+            b'{"event":"file-loaded","playlist_entry_id":2}\n',
             b'{"request_id":6,"error":"success"}\n',  # mute (post-load)
-        ]
+        ] + [
+            b'{"request_id":' + str(7 + i).encode() + b',"error":"success"}\n'
+            for i in range(6)
+        ]  # 3x fullscreen toggle
 
         with patch.object(mpv_player, "_update_current"), \
              patch("player.service.subprocess") as mock_subprocess:
@@ -2698,9 +2724,15 @@ class TestMutePolicy:
             b'{"request_id":2,"error":"success"}\n',  # mute (pre-load)
             b'{"request_id":3,"error":"success"}\n',  # pause=False
             b'{"request_id":4,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n',  # loadfile
+            # loadfile response + start-file/file-loaded events for entry_id=1
+            b'{"data":{"playlist_entry_id":1},"request_id":5,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             b'{"request_id":6,"error":"success"}\n',  # mute (post-load)
-        ]
+        ] + [
+            f'{{"request_id":{7+i},"error":"success"}}\n'.encode()
+            for i in range(6)
+        ]  # 3x fullscreen toggle
 
         result = mpv_player._loadfile_mpv(Path("/tmp/video.mp4"), loop=True, muted=False)
         assert result is True
@@ -2729,7 +2761,10 @@ class TestMutePolicy:
             b'{"request_id":3,"error":"success"}\n',  # pause=False
             b'{"request_id":4,"error":"success"}\n',  # image-display-duration
             b'{"request_id":5,"error":"success"}\n',  # hwdec
-            b'{"data":{"playlist_entry_id":1},"request_id":6,"error":"success"}\n',  # loadfile
+            # loadfile response + start-file/file-loaded events for entry_id=1
+            b'{"data":{"playlist_entry_id":1},"request_id":6,"error":"success"}\n'
+            b'{"event":"start-file","playlist_entry_id":1}\n'
+            b'{"event":"file-loaded","playlist_entry_id":1}\n',
             b'{"request_id":7,"error":"success"}\n',  # mute (post-load)
         ] + [
             b'{"request_id":8,"error":"success"}\n',
@@ -2989,3 +3024,44 @@ class TestChromiumLowMemFlags:
         # Baseline flags still present
         assert "--kiosk" in cmd
         assert "https://example.com" in cmd
+
+
+class TestSplashConfigWatch:
+    """Tests for the inotify-driven splash config re-render path.
+
+    The CMS rewrites the splash config file (persist_dir/splash) when the
+    user picks a new splash. Before the fix, inotify only watched
+    state_dir, so this rewrite was invisible to the running player and
+    the new splash never appeared until a service restart. The fix adds
+    a watch on persist_dir and triggers _on_splash_config_changed, which
+    re-renders the splash if SPLASH/STOP is currently active.
+    """
+
+    def test_splash_mode_rerenders(self, mpv_player):
+        mpv_player.current_desired = DesiredState(mode=PlaybackMode.SPLASH)
+        with patch.object(mpv_player, "_show_splash") as show:
+            result = mpv_player._on_splash_config_changed()
+        assert result is False
+        show.assert_called_once_with()
+
+    def test_stop_mode_rerenders(self, mpv_player):
+        mpv_player.current_desired = DesiredState(mode=PlaybackMode.STOP)
+        with patch.object(mpv_player, "_show_splash") as show:
+            mpv_player._on_splash_config_changed()
+        show.assert_called_once_with()
+
+    def test_play_mode_defers(self, mpv_player):
+        mpv_player.current_desired = DesiredState(
+            mode=PlaybackMode.PLAY, asset="vid.mp4", loop=False,
+        )
+        with patch.object(mpv_player, "_show_splash") as show:
+            mpv_player._on_splash_config_changed()
+        show.assert_not_called()
+
+    def test_no_current_desired_rerenders(self, mpv_player):
+        # Defensive: at boot before apply_desired runs, current_desired
+        # may still be None. Re-render so the new splash is honoured.
+        mpv_player.current_desired = None
+        with patch.object(mpv_player, "_show_splash") as show:
+            mpv_player._on_splash_config_changed()
+        show.assert_called_once_with()


### PR DESCRIPTION
Two related player-side fixes exposed by the slideshow refactor work:

## 1. Player: capture mpv events during IPC calls so post-load wait sees them

mpv's JSON IPC socket carries both command responses and broadcast events.
_ipc_call previously dropped any line with an vent key while waiting
for its matching equest_id response. That worked for isolated commands
but broke _wait_for_mpv_load_complete because mpv typically bundles the
loadfile success response together with the start-file and ile-loaded
events for the new entry into a single wire chunk. The post-load mute IPC
call read that chunk, kept its own response, and silently discarded the
events. The wait that ran next then timed out, the fullscreen toggle fired
before mpv had really swapped frames, and the user saw stale content stuck
on screen.

Fix: _ipc_call now appends events to self._mpv_event_buf.
_wait_for_mpv_load_complete replays (and clears) that buffer before
reading more from the socket. _loadfile_mpv resets the buffer at the
start of each call.

User confirmed visually that splash transitions are noticeably better with
this fix in place.

## 2. cms_client: route default_asset to slideshow path when it is a slideshow

The default-asset branch built a DesiredState(mode=PLAY, asset=default_asset)
without setting sset_type. The player only routes a desired state to
`_start_slideshow` when `asset_type == 'slideshow'`, so a slideshow set
as the default asset silently fell through to single-asset playback and
never rendered.

No CMS schema change needed — the device already knows locally via the
asset registry that slideshows live under slideshows/. Use the existing
_is_slideshow_asset helper to set sset_type on the DesiredState. Also
include sset_type in the desired-state cache key tuple so a type change
invalidates the cache.

## Tests

- 140 `test_player_service.py` tests pass (extended existing IPC
  hardening, mute, image and video loadfile tests to reflect that loadfile
  responses now bundle start-file/file-loaded events and that the post-load
  fullscreen toggle now fires for video too).
- 3 new `TestSlideshowDefaultAsset` tests in `test_play_without_asset.py`
  covering both the slideshow and non-slideshow default-asset paths plus
  the cache-invalidation case.
- Full runnable suite: 720 pass / 30 skip (no regressions).

## Companion PR

- agora-cms #469 (DRAFT) hides slideshows from the splash dropdowns since
  the player has never supported slideshows as a splash anyway.
