### PR TITLE
ci(images): auto-publish base-image catalog on release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,9 +30,24 @@ on:
         required: false
         default: false
         type: boolean
+  # Auto-build all boards when a stable release is published. The image is
+  # left tenant-agnostic (no CMS URL, no WiFi pre-config) — downstream CMS
+  # instances pull these via the catalog manifest and inject their own
+  # agora-fleet.env at provisioning time.
+  #
+  # We trigger on `prereleased` (not `released`) because create-release.yml
+  # publishes new releases as pre-releases. The publish-catalog job below
+  # promotes to a normal release at the end of a successful build.
+  release:
+    types: [prereleased]
 
 permissions:
   contents: write
+
+# Don't kick off two concurrent runs for the same release tag.
+concurrency:
+  group: build-image-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
 
 env:
   # Pin pi-gen to latest arm64 branch commit (Mar 17, 2026)
@@ -42,18 +57,36 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 120
+    timeout-minutes: 180
+    # Skip if somehow a non-prerelease event slipped through (legacy release-published etc.).
+    # Manual builds (workflow_dispatch) always run.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     strategy:
       fail-fast: false
       matrix:
-        board: ${{ github.event.inputs.board == 'all' && fromJSON('["zero2w","pi4","pi5"]') || fromJSON(format('["{0}"]', github.event.inputs.board)) }}
+        # On release events, always build all 3 boards.
+        # On workflow_dispatch, honor the input ('all' or single board).
+        board: ${{ (github.event_name == 'release' || github.event.inputs.board == 'all') && fromJSON('["zero2w","pi4","pi5"]') || fromJSON(format('["{0}"]', github.event.inputs.board)) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Read version
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          version=$(python3 -c "exec(open('api/__init__.py').read()); print(__version__)")
+          set -euo pipefail
+          # On release events the tag (e.g. v1.11.32) is authoritative.
+          # On workflow_dispatch fall back to api/__init__.py.
+          if [ -n "${RELEASE_TAG}" ]; then
+            version="${RELEASE_TAG#v}"
+            echo "Source: release event tag (${RELEASE_TAG})"
+          else
+            version=$(python3 -c "exec(open('api/__init__.py').read()); print(__version__)")
+            echo "Source: api/__init__.py"
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Building image for Agora v$version (${{ matrix.board }})"
 
@@ -161,15 +194,16 @@ jobs:
       - name: Find and rename built image
         id: find-image
         run: |
-          SRC_PATH=$(find /tmp/pi-gen/deploy -name '*.img.xz' -o -name '*.img.gz' -o -name '*.img.zip' -o -name '*.img' | head -1)
+          set -euo pipefail
+          SRC_PATH=$(find /tmp/pi-gen/deploy -name '*.img.xz' | head -1)
           if [ -z "$SRC_PATH" ]; then
-            echo "ERROR: No image found in /tmp/pi-gen/deploy/"
+            echo "::error::No .img.xz produced. pi-gen DEPLOY_COMPRESSION must be xz."
             ls -laR /tmp/pi-gen/deploy/ || true
             exit 1
           fi
           echo "Found image: $SRC_PATH"
 
-          # Rename to version-based name: agora-v0.9.0-pi-zero2w.img.xz
+          # Rename to version-based name: agora-v<ver>-<image-board>.img.xz
           VERSION="${{ steps.version.outputs.version }}"
           BOARD="${{ matrix.board }}"
           # Map board short names to image names
@@ -179,30 +213,232 @@ jobs:
             pi5)    IMAGE_BOARD="pi5" ;;
             *)      IMAGE_BOARD="$BOARD" ;;
           esac
-          EXT="${SRC_PATH#*.img}"
-          FINAL_NAME="agora-v${VERSION}-${IMAGE_BOARD}.img${EXT}"
+          FINAL_NAME="agora-v${VERSION}-${IMAGE_BOARD}.img.xz"
           FINAL_PATH="/tmp/pi-gen/deploy/${FINAL_NAME}"
           mv "$SRC_PATH" "$FINAL_PATH"
           echo "Renamed to: $FINAL_NAME"
           echo "image-path=$FINAL_PATH" >> "$GITHUB_OUTPUT"
           echo "image-board=$IMAGE_BOARD" >> "$GITHUB_OUTPUT"
 
+      - name: Compute SHA256 + manifest entry
+        id: manifest
+        env:
+          IMG: ${{ steps.find-image.outputs.image-path }}
+          IMAGE_BOARD: ${{ steps.find-image.outputs.image-board }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          COMPRESSED=$(stat -c '%s' "$IMG")
+          SHA256=$(sha256sum "$IMG" | awk '{print $1}')
+          BASENAME=$(basename "$IMG")
+          # Standard sidecar format (sha256sum -c compatible)
+          echo "${SHA256}  ${BASENAME}" > "${IMG}.sha256"
+
+          # Uncompressed size from xz metadata. `xz -l --robot` prints a
+          # tab-separated 'totals' row; field 5 is uncompressed bytes.
+          UNCOMPRESSED=$(xz -l --robot "$IMG" | awk -F '\t' '$1 == "totals" {print $5}')
+          if ! [[ "$UNCOMPRESSED" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not determine uncompressed size (got: '${UNCOMPRESSED}')"
+            xz -l --robot "$IMG"
+            exit 1
+          fi
+
+          # Generate per-variant manifest entry via Python (safe escaping).
+          mkdir -p /tmp/manifests
+          python3 - <<'PY' > "/tmp/manifests/${IMAGE_BOARD}.json"
+          import json, os
+          entry = {
+              "variant":          os.environ["IMAGE_BOARD"],
+              "version":          "v" + os.environ["VERSION"],
+              "filename":         os.environ["BASENAME"],
+              "sha256":           os.environ["SHA256"],
+              "compressedBytes":   int(os.environ["COMPRESSED"]),
+              "uncompressedBytes": int(os.environ["UNCOMPRESSED"]),
+          }
+          print(json.dumps(entry, indent=2, sort_keys=True))
+          PY
+          echo "--- manifest entry ---"
+          cat "/tmp/manifests/${IMAGE_BOARD}.json"
+        # Re-export env vars for the python heredoc above
+        # (already in `env:` block but listed again here to make explicit
+        # which variables the manifest script reads)
+
       - name: Upload image as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: agora-v${{ steps.version.outputs.version }}-${{ steps.find-image.outputs.image-board }}
-          path: ${{ steps.find-image.outputs.image-path }}
-          retention-days: 30
+          name: image-${{ steps.find-image.outputs.image-board }}
+          path: |
+            ${{ steps.find-image.outputs.image-path }}
+            ${{ steps.find-image.outputs.image-path }}.sha256
+          retention-days: 14
 
-      - name: Attach image to latest release
+      - name: Upload manifest entry
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-${{ steps.find-image.outputs.image-board }}
+          path: /tmp/manifests/${{ steps.find-image.outputs.image-board }}.json
+          retention-days: 14
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Validate the full variant set, generate catalog.json + SHA256SUMS,
+  # and upload everything (images, sidecars, catalog, sums) to the
+  # release in a single atomic step.
+  #
+  # Then promote the release: clear `prerelease`, mark `latest`. The
+  # release was created as prerelease by create-release.yml so consumers
+  # using /releases/latest/ see the previous stable release until the
+  # catalog is fully published. Graceful degradation; no broken-latest.
+  #
+  # Skipped on workflow_dispatch — manual builds produce artifacts only.
+  # ─────────────────────────────────────────────────────────────────────
+  publish-catalog:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Download all image artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: image-*
+          path: /tmp/images
+          merge-multiple: true
+
+      - name: Download per-variant manifest entries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: manifest-*
+          path: /tmp/manifests
+          merge-multiple: true
+
+      - name: Generate and validate catalog.json + SHA256SUMS
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "=== inputs ==="
+          ls -la /tmp/images/ /tmp/manifests/
+
+          export BASE_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+          export GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          python3 <<'PY'
+          import json, os, glob, sys, hashlib
+
+          tag           = os.environ["RELEASE_TAG"]
+          base_url      = os.environ["BASE_URL"]
+          generated_at  = os.environ["GENERATED_AT"]
+
+          EXPECTED_VARIANTS = {"pi-zero2w", "pi4", "pi5"}
+
+          variants = []
+          for path in sorted(glob.glob("/tmp/manifests/*.json")):
+              with open(path) as f:
+                  entry = json.load(f)
+              entry["url"] = f"{base_url}/{entry['filename']}"
+              variants.append(entry)
+
+          actual = {v["variant"] for v in variants}
+          if actual != EXPECTED_VARIANTS:
+              missing = EXPECTED_VARIANTS - actual
+              extra   = actual - EXPECTED_VARIANTS
+              print(f"::error::variant set mismatch. expected={sorted(EXPECTED_VARIANTS)} got={sorted(actual)} missing={sorted(missing)} extra={sorted(extra)}", file=sys.stderr)
+              sys.exit(1)
+
+          # Cross-check: actual image file SHA256 matches manifest claim,
+          # and the file is present on disk before we publish to release.
+          for v in variants:
+              img_path = os.path.join("/tmp/images", v["filename"])
+              if not os.path.exists(img_path):
+                  print(f"::error::image file missing: {img_path}", file=sys.stderr)
+                  sys.exit(1)
+              h = hashlib.sha256()
+              with open(img_path, "rb") as f:
+                  for chunk in iter(lambda: f.read(1 << 20), b""):
+                      h.update(chunk)
+              actual_sha = h.hexdigest()
+              if actual_sha != v["sha256"]:
+                  print(f"::error::sha256 mismatch for {v['filename']}: manifest={v['sha256']} actual={actual_sha}", file=sys.stderr)
+                  sys.exit(1)
+
+          # Stable canonical variant order.
+          variant_order = ["pi-zero2w", "pi4", "pi5"]
+          variants.sort(key=lambda v: variant_order.index(v["variant"]))
+
+          catalog = {
+              "schemaVersion": 1,
+              "generatedAt": generated_at,
+              "version": tag,
+              "variants": variants,
+          }
+          with open("/tmp/catalog.json", "w") as f:
+              json.dump(catalog, f, indent=2, sort_keys=True)
+              f.write("\n")
+          print("--- catalog.json ---")
+          print(json.dumps(catalog, indent=2, sort_keys=True))
+
+          with open("/tmp/SHA256SUMS", "w") as f:
+              for v in variants:
+                  f.write(f"{v['sha256']}  {v['filename']}\n")
+          PY
+
+          echo "--- SHA256SUMS ---"
+          cat /tmp/SHA256SUMS
+
+          # Independent verification using the standard tool.
+          (cd /tmp/images && sha256sum -c /tmp/SHA256SUMS)
+
+      - name: Refuse to overwrite existing release assets
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          # Find the latest release
-          TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || true)
-          if [ -n "$TAG" ]; then
-            echo "Uploading image to release $TAG"
-            gh release upload "$TAG" "${{ steps.find-image.outputs.image-path }}" --clobber
-          else
-            echo "No release found — image available as workflow artifact only"
+          set -euo pipefail
+          # Per-tag URLs are advertised as immutable. Fail fast if any
+          # asset we're about to upload already exists. To re-publish a
+          # release deliberately, manually delete the assets first.
+          existing=$(gh release view "${RELEASE_TAG}" --json assets -q '.assets[].name' || true)
+          conflicts=""
+          for fn in catalog.json SHA256SUMS $(ls /tmp/images/); do
+            if echo "$existing" | grep -qx "$fn"; then
+              conflicts="${conflicts}  - ${fn}\n"
+            fi
+          done
+          if [ -n "$conflicts" ]; then
+            printf "::error::Release ${RELEASE_TAG} already has assets we'd overwrite:\n%b\n" "$conflicts"
+            echo "::error::Delete them manually if you intend to re-publish: gh release delete-asset"
+            exit 1
           fi
+          echo "No existing-asset conflicts."
+
+      - name: Upload images + sidecars + catalog + SHA256SUMS to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            /tmp/images/* \
+            /tmp/catalog.json \
+            /tmp/SHA256SUMS
+
+      - name: Promote release out of pre-release (publish to /latest/)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          gh release edit "${RELEASE_TAG}" --prerelease=false --latest
+          echo ""
+          echo "Per-version manifest:"
+          echo "  https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}/catalog.json"
+          echo ""
+          echo "Auto-resolving 'latest' pointer (consumed by tenant CMSes):"
+          echo "  https://github.com/${{ github.repository }}/releases/latest/download/catalog.json"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -194,7 +194,7 @@ jobs:
           echo "📋 Generated changelog:"
           cat /tmp/release_body.md
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (as pre-release; build-image promotes)
         if: steps.check-branch.outputs.is-main == 'true'
         uses: softprops/action-gh-release@v2
         with:
@@ -202,6 +202,12 @@ jobs:
           name: Agora ${{ steps.version.outputs.tag }}
           body_path: /tmp/release_body.md
           files: build/*.deb
+          # Published as pre-release so /releases/latest/ resolves to the
+          # previous stable release until build-image.yml has uploaded
+          # all Pi images + catalog.json. The build-image workflow flips
+          # this to a normal release at the very end (publish-catalog
+          # job's "Promote release" step).
+          prerelease: true
 
   publish-apt:
     needs: build

--- a/docs/image-catalog.md
+++ b/docs/image-catalog.md
@@ -1,0 +1,105 @@
+# Pi Image Catalog
+
+Every published Agora release includes a `catalog.json` manifest
+describing the bootable Pi images attached to that release. Downstream
+consumers (e.g. the Agora CMS imager service) use this manifest to
+discover available images and verify their integrity before importing
+them into their own storage.
+
+## Where to find it
+
+Two URL patterns are stable and supported:
+
+| Use case                     | URL                                                                                |
+|---                           |---                                                                                 |
+| **Latest stable** (rolling)  | `https://github.com/sslivins/agora/releases/latest/download/catalog.json`         |
+| **Pinned version** (immutable) | `https://github.com/sslivins/agora/releases/download/<tag>/catalog.json`        |
+
+`releases/latest/...` auto-resolves to the most recent non-prerelease
+on GitHub.
+
+> **Publish ordering:** When a release is first cut, it is created as a
+> *pre-release*. The Pi image build is long (~1–2 h) and runs after the
+> tag is created. Only when **all three image variants build, verify,
+> and upload successfully** is the release promoted to a normal release
+> (and thus to `releases/latest/`). This means:
+>
+> - During the build window, `releases/latest/download/catalog.json`
+>   continues to resolve to the **previous stable release** — never to
+>   a half-published one.
+> - If the image build fails (any variant), the release stays a
+>   pre-release. `releases/latest/...` is never broken; consumers see
+>   no transition until the next successful release.
+> - Per-version URLs (`releases/download/<tag>/...`) only become
+>   resolvable after the catalog publish step succeeds.
+
+## Schema
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-04-29T14:23:01Z",
+  "version": "v1.11.32",
+  "variants": [
+    {
+      "variant": "pi5",
+      "version": "v1.11.32",
+      "filename": "agora-v1.11.32-pi5.img.xz",
+      "url": "https://github.com/sslivins/agora/releases/download/v1.11.32/agora-v1.11.32-pi5.img.xz",
+      "sha256": "abc123...def",
+      "compressedBytes": 612345678,
+      "uncompressedBytes": 8589934592
+    },
+    { "variant": "pi4", ... },
+    { "variant": "pi-zero2w", ... }
+  ]
+}
+```
+
+### Field semantics
+
+| Field               | Type    | Notes                                                           |
+|---                  |---      |---                                                              |
+| `schemaVersion`     | int     | Bumped only on breaking schema changes                          |
+| `generatedAt`       | string  | RFC 3339 UTC timestamp                                          |
+| `version`           | string  | Release tag (with `v` prefix)                                   |
+| `variants[].variant`| string  | One of `pi5`, `pi4`, `pi-zero2w`                                |
+| `variants[].url`    | string  | Direct download URL for the `.img.xz`                           |
+| `variants[].sha256` | string  | Hex SHA256 of the compressed `.img.xz` bytes                    |
+| `variants[].compressedBytes` | int | Size of the `.img.xz` on disk                              |
+| `variants[].uncompressedBytes` | int | Size of the underlying `.img` after `xz -d` (from xz metadata) |
+
+### Sidecar files
+
+Each release also publishes:
+
+- `<filename>.sha256` — single-line `<sha>  <basename>` per image
+- `SHA256SUMS` — concatenated for the whole release; `sha256sum -c` compatible
+
+## Consumer expectations
+
+Consumers MUST:
+1. Fetch the catalog over HTTPS
+2. Verify `schemaVersion == 1` (or warn and treat unknown variants as opaque)
+3. Pin downloaded images by SHA256 — do not trust URLs alone
+4. Treat `releases/latest/download/catalog.json` as the rolling stable
+   pointer (changes on every published release)
+
+## Immutability guarantees
+
+Per-tag asset URLs (`releases/download/<tag>/...`) are treated as
+**immutable**: once the catalog publish job has succeeded for a tag,
+re-running the workflow for that tag will fail rather than silently
+overwrite the existing assets. Re-publishing a release deliberately
+requires manually deleting the existing assets first
+(`gh release delete-asset <tag> <name>`) — and bumping the version is
+strongly preferred.
+
+## Image properties
+
+The published images are **tenant-agnostic**. They contain the
+firmware, services, and dependencies for the target board, but no
+CMS URL, no WiFi credentials, and no device identity. Downstream
+provisioning systems are expected to inject `/boot/firmware/agora-fleet.env`
+into the FAT boot partition before flashing — typically via `mcopy`
+on the offset reported by `parted -s -j`.


### PR DESCRIPTION
## What

Adds a release-driven Pi image build pipeline that auto-publishes a stable **catalog manifest** (`catalog.json` + `SHA256SUMS`) alongside the three `.img.xz` variants on every release.

This is **PR 0** of the [browser-driven Pi imager](https://github.com/sslivins/agora-cms) feature in `agora-cms`. Downstream CMS instances will read `catalog.json`, import images into their own private blob storage, and inject a per-tenant `agora-fleet.env` at provisioning time — no upstream-side coordination per tenant.

## URLs (after first release with this lands)

| Use case | URL |
|---|---|
| **Latest stable** (rolling) | `https://github.com/sslivins/agora/releases/latest/download/catalog.json` |
| **Pinned version** (immutable) | `https://github.com/sslivins/agora/releases/download/<tag>/catalog.json` |

## How it works

1. `create-release.yml` cuts a tag and creates the release as a **pre-release** (so `releases/latest/...` keeps resolving to the *previous* stable).
2. `build-image.yml` triggers on `release: prereleased`, builds all three boards in parallel.
3. Each build job produces an `.img.xz`, a `.sha256` sidecar, and a per-variant manifest entry — all uploaded as artifacts (NOT to the release yet).
4. The new `publish-catalog` job:
   - Validates the variant set is exactly `{pi-zero2w, pi4, pi5}` (no partial publishes)
   - Re-verifies every SHA256 against the actual file bytes
   - Generates `catalog.json` and `SHA256SUMS`
   - **Refuses to overwrite existing release assets** (per-tag URLs are immutable)
   - Uploads everything atomically
   - Promotes the release out of pre-release → `releases/latest/...` flips to the new release

If **any** board fails, the release stays a pre-release. `releases/latest/` is never broken; consumers see no transition until a successful release lands.

## What changed

- `.github/workflows/build-image.yml` — restructured to produce artifacts during the matrix and upload everything atomically from a single `publish-catalog` job; new `release: prereleased` trigger; per-image SHA256 + manifest entry; `workflow_dispatch` path now produces artifacts only (never publishes to a release, since it can take user-supplied WiFi / CMS URL inputs).
- `.github/workflows/create-release.yml` — release is now created as `prerelease: true`; `build-image.yml` promotes it at the end.
- `docs/image-catalog.md` — full schema + consumer expectations + immutability + publish-ordering notes.

## Catalog schema (v1)

```json
{
  "schemaVersion": 1,
  "generatedAt": "2026-04-29T14:23:01Z",
  "version": "v1.11.32",
  "variants": [
    {
      "variant": "pi-zero2w",
      "version": "v1.11.32",
      "filename": "agora-v1.11.32-pi-zero2w.img.xz",
      "url": "https://github.com/sslivins/agora/releases/download/v1.11.32/agora-v1.11.32-pi-zero2w.img.xz",
      "sha256": "…",
      "compressedBytes": 612345678,
      "uncompressedBytes": 8589934592
    },
    { "variant": "pi4", "...": "..." },
    { "variant": "pi5", "...": "..." }
  ]
}
```

## Safety properties

| Concern | Mitigation |
|---|---|
| Half-published release breaks consumers | Pre-release until all 3 images uploaded + verified; `releases/latest` graceful-degrades to previous |
| Per-tag URL claims to be immutable but isn't | `publish-catalog` fails fast if assets already exist for the tag |
| Manual `workflow_dispatch` build leaks WiFi / CMS URL into public catalog | `workflow_dispatch` produces artifacts only — never uploads to release |
| Stale `.deb` baked into image | **Pre-existing risk**, not addressed here. The pi-gen `stage-agora` step pulls `agora` from the gh-pages APT repo, which is published by a parallel `publish-apt` job in `create-release.yml`. Race possible. To be addressed in a follow-up — install the `.deb` directly from the release tag instead of from the APT mirror. |

## Risks

- **First run of a release after this lands** will hit the new code path. We've validated YAML syntax and matrix expressions, but the actual GHA execution will be the real test. The matrix expression in particular is dense and worth eyes:
  ```yaml
  board: ${{ (github.event_name == 'release' || github.event.inputs.board == 'all') && fromJSON('["zero2w","pi4","pi5"]') || fromJSON(format('["{0}"]', github.event.inputs.board)) }}
  ```
- The image build itself is unchanged — same pi-gen invocation, same stage-agora steps. The only differences are: filename now includes `agora-v<ver>-`, and we generate a SHA256 sidecar + per-variant manifest entry.
- `concurrency.group` is set per-tag with `cancel-in-progress: false` so we don't kill an in-flight 90-min build.

## Out of scope (separate work)

- The `stage-agora` APT install race (filed as a follow-up).
- Tenant-side import / provisioning logic — that's PRs 2-5 in [`sslivins/agora-cms`](https://github.com/sslivins/agora-cms). PR 1 (build-pipeline pure-function + tests) is already open as #502.

## Validation

- `python -c "yaml.safe_load(...)"` on both workflow files: ✅ parses
- Matrix expression manually traced for all 3 trigger paths (release / dispatch-all / dispatch-single): ✅ correct

This was reviewed by an independent rubber-duck pass before pushing; 5 blocking issues were identified and fixed (workflow_dispatch leak, latest-pointer race, partial-publish, --clobber breaking immutability, and the JSON-from-shell-heredoc safety). Two remaining non-blocking duck issues (APT race, tag-format enforcement) deferred to follow-ups.
