### PR TITLE
chore: trigger v1.11.32 release for catalog publish smoke test

### DIFF
--- a/player/main.py
+++ b/player/main.py
@@ -1,4 +1,8 @@
-"""Entry point for the Agora Player service."""
+"""Entry point for the Agora Player service.
+
+See ``docs/image-catalog.md`` for the release-driven base-image catalog
+publishing pipeline (consumed by agora-cms's Imager feature).
+"""
 
 import logging
 import os


### PR DESCRIPTION
## What

No-op docstring update on `player/main.py` to trigger the post-#157 release chain end-to-end for the first time.

## Why

#157 wired up the release-driven `catalog.json` + `SHA256SUMS` publish flow, but it has never run because no release has been cut since #157 merged. `create-release.yml` has a `paths-ignore` filter that excludes `.github/**`, `docs/**`, `*.md`, and `tests/**` — so #157 itself (purely under `.github/`) didn't trigger it. This PR touches a single docstring outside the ignore list to wake up the chain.

Downstream goal: `https://github.com/sslivins/agora/releases/latest/download/catalog.json` exists, so agora-cms's Imager UI's **'Import from catalog…'** button stops returning 503.

## Expected chain on merge to main

1. `create-release.yml` runs (push event not in path-ignore)
2. Cuts tag `v1.11.32` as a **prerelease** (per #157)
3. `build-image.yml` fires on `release: prereleased`  
4. Matrix builds `zero2w` / `pi4` / `pi5` `.img.xz` in parallel (~14m each)
5. `publish-catalog` job verifies SHA256s, generates `catalog.json` + `SHA256SUMS`, uploads atomically, promotes prerelease → latest
6. Latest-pointer flips: `releases/latest/download/catalog.json` is now consumable

## Risk

Low — single-line docstring, no runtime behavior change. The image build itself is unchanged from #157; this PR exists only to fire the trigger.