### PR TITLE
ci(build-image): export shell vars so python heredoc sees them

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -229,15 +229,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          COMPRESSED=$(stat -c '%s' "$IMG")
-          SHA256=$(sha256sum "$IMG" | awk '{print $1}')
-          BASENAME=$(basename "$IMG")
+          export COMPRESSED=$(stat -c '%s' "$IMG")
+          export SHA256=$(sha256sum "$IMG" | awk '{print $1}')
+          export BASENAME=$(basename "$IMG")
           # Standard sidecar format (sha256sum -c compatible)
           echo "${SHA256}  ${BASENAME}" > "${IMG}.sha256"
 
           # Uncompressed size from xz metadata. `xz -l --robot` prints a
           # tab-separated 'totals' row; field 5 is uncompressed bytes.
-          UNCOMPRESSED=$(xz -l --robot "$IMG" | awk -F '\t' '$1 == "totals" {print $5}')
+          export UNCOMPRESSED=$(xz -l --robot "$IMG" | awk -F '\t' '$1 == "totals" {print $5}')
           if ! [[ "$UNCOMPRESSED" =~ ^[0-9]+$ ]]; then
             echo "::error::Could not determine uncompressed size (got: '${UNCOMPRESSED}')"
             xz -l --robot "$IMG"


### PR DESCRIPTION
Fixes the `Compute SHA256 + manifest entry` step in build-image.yml.

The step assigns BASENAME, SHA256, COMPRESSED, UNCOMPRESSED as shell locals, but the python heredoc reads them via `os.environ`. Without `export` they aren't inherited by the subprocess, causing:

```n  File "<stdin>", line 5, in <module>
KeyError: 'BASENAME'
```

Observed in build-image run #50 (workflow_dispatch on main, version v1.11.33). Other Compute-step variables would have hit the same KeyError on the next `os.environ[...]` lookup.

Not covered by CI since this step only runs on workflow_dispatch / prerelease.

Note: agora does not have auto-merge enabled; user will merge manually.