### PR TITLE
ci: use VERSION_BUMP_TOKEN to fire release event for build-image chain

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -208,6 +208,16 @@ jobs:
           # this to a normal release at the very end (publish-catalog
           # job's "Promote release" step).
           prerelease: true
+          # Use a PAT (VERSION_BUMP_TOKEN) so the `release` event fires
+          # downstream workflows. Releases created with the default
+          # GITHUB_TOKEN do NOT trigger `release: types: [prereleased]`
+          # listeners (GitHub blocks workflow recursion), which would
+          # break the chain into build-image.yml and prevent
+          # catalog.json / Pi images from being published. Falls back
+          # to GITHUB_TOKEN if the PAT is not configured (chain will
+          # not auto-trigger; build-image must then be dispatched
+          # manually).
+          token: ${{ secrets.VERSION_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish-apt:
     needs: build


### PR DESCRIPTION
Releases created with the default GITHUB_TOKEN do **not** trigger elease events on other workflows (GitHub's workflow-recursion guard). This silently broke the create-release → uild-image → publish-catalog chain — v1.11.32 and v1.11.33 were created as prereleases but `build-image` never fired, so no Pi images or `catalog.json` were published to those tags.

## Fix

Pass secrets.VERSION_BUMP_TOKEN (already in repo secrets, already used for the version-bump push step in this same workflow) as the 	oken for softprops/action-gh-release. Releases created with a PAT correctly fire the `release: types: [prereleased]` event that `build-image.yml` listens to.

Falls back to GITHUB_TOKEN if the PAT isn't configured — in that fallback case the chain still won't auto-trigger and `build-image` must be dispatched manually (current behavior).

## Verification

After merge, the next push to `main` (or a manual dispatch of `create-release`) will fire `build-image` automatically, which in turn runs the `publish-catalog` job and uploads `catalog.json` + `.img.xz` + `SHA256SUMS` to the release, then promotes it from prerelease to `latest`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>