### PR TITLE
chore: collapse fleet provisioning into single first-boot entry point

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,27 +13,11 @@ on:
           - zero2w
           - pi4
           - pi5
-      cms_url:
-        description: 'Pre-configure CMS WebSocket URL (e.g. wss://cms.example.com/ws/device)'
-        required: false
-        type: string
-      wifi_ssid:
-        description: 'Pre-configure WiFi network name'
-        required: false
-        type: string
-      wifi_password:
-        description: 'WiFi password (required if wifi_ssid is set)'
-        required: false
-        type: string
-      disable_wifi:
-        description: 'Disable WiFi support entirely (ethernet-only image)'
-        required: false
-        default: false
-        type: boolean
   # Auto-build all boards when a stable release is published. The image is
-  # left tenant-agnostic (no CMS URL, no WiFi pre-config) — downstream CMS
-  # instances pull these via the catalog manifest and inject their own
-  # agora-fleet.env at provisioning time.
+  # fully tenant-agnostic — no CMS URL, no WiFi creds, no fleet identity
+  # baked in. The CMS imager stamps /boot/firmware/agora-fleet.env at
+  # imaging time with deployment-specific values, and
+  # agora-fleet-provision.sh (in the firmware) consumes it at first boot.
   #
   # We trigger on `prereleased` (not `released`) because create-release.yml
   # publishes new releases as pre-releases. The publish-catalog job below
@@ -105,11 +89,6 @@ jobs:
           git checkout ${{ env.PI_GEN_COMMIT }}
 
       - name: Configure pi-gen
-        env:
-          INPUT_CMS_URL: ${{ inputs.cms_url }}
-          INPUT_WIFI_SSID: ${{ inputs.wifi_ssid }}
-          INPUT_WIFI_PASS: ${{ inputs.wifi_password }}
-          INPUT_DISABLE_WIFI: ${{ inputs.disable_wifi }}
         run: |
           TIMEZONE="Etc/UTC"
 
@@ -146,26 +125,6 @@ jobs:
           ENABLE_CLOUD_INIT=0
           export AGORA_BOARD=${{ matrix.board }}
           EOF
-
-          # Append optional build-time configuration
-          # Custom AGORA_* variables must use 'export' so pi-gen passes them
-          # through to stage scripts (00-run.sh) that run as subprocesses.
-          # Values are single-quoted to handle special characters (e.g. apostrophes in SSIDs)
-          if [ -n "${INPUT_CMS_URL}" ]; then
-            ESCAPED=$(printf '%s' "${INPUT_CMS_URL}" | sed "s/'/'\\\\''/g")
-            echo "export AGORA_CMS_URL='${ESCAPED}'" >> /tmp/pi-gen/config
-          fi
-          if [ -n "${INPUT_WIFI_SSID}" ]; then
-            ESCAPED=$(printf '%s' "${INPUT_WIFI_SSID}" | sed "s/'/'\\\\''/g")
-            echo "export AGORA_WIFI_SSID='${ESCAPED}'" >> /tmp/pi-gen/config
-          fi
-          if [ -n "${INPUT_WIFI_PASS}" ]; then
-            ESCAPED=$(printf '%s' "${INPUT_WIFI_PASS}" | sed "s/'/'\\\\''/g")
-            echo "export AGORA_WIFI_PASS='${ESCAPED}'" >> /tmp/pi-gen/config
-          fi
-          if [ "${INPUT_DISABLE_WIFI}" = "true" ]; then
-            echo "export AGORA_DISABLE_WIFI=1" >> /tmp/pi-gen/config
-          fi
 
           # Remove leading whitespace from heredoc
           sed -i 's/^          //' /tmp/pi-gen/config

--- a/pi-gen/stage-agora/00-install-agora/00-run.sh
+++ b/pi-gen/stage-agora/00-install-agora/00-run.sh
@@ -3,10 +3,12 @@
 #
 # Build-time variables (set in pi-gen config):
 #   AGORA_BOARD        — zero2w, pi4, pi5 (default: zero2w)
-#   AGORA_CMS_URL      — Pre-configure CMS WebSocket URL (optional)
-#   AGORA_WIFI_SSID    — Pre-configure WiFi network (optional)
-#   AGORA_WIFI_PASS    — WiFi password (optional, required if SSID set)
-#   AGORA_DISABLE_WIFI — Set to 1 to disable WiFi entirely (optional)
+#
+# This stage is fully tenant-agnostic. All deployment-specific
+# configuration (CMS URL, fleet credentials, WiFi creds) is supplied
+# at first boot by /opt/agora/src/scripts/agora-fleet-provision.sh,
+# which consumes /boot/firmware/agora-fleet.env stamped by the CMS
+# imager. See scripts/agora-fleet-provision.sh for the recognized keys.
 
 on_chroot <<'CHEOF'
 
@@ -22,6 +24,8 @@ apt-get install -y agora
 touch /etc/cloud/cloud-init.disabled
 
 # ── Ensure device boots into captive portal (no provisioned flag) ──
+# The agora-fleet-provision script will write this flag at first boot
+# if a CMS URL is supplied via the boot drop-in.
 rm -f /opt/agora/persist/provisioned
 
 # ── Disable Pi OS first-boot wizard (user already configured by pi-gen) ──
@@ -86,28 +90,22 @@ esac
 mkdir -p "${ROOTFS_DIR}/opt/agora/persist"
 echo "${BOARD}" > "${ROOTFS_DIR}/opt/agora/persist/board"
 
-# ── WiFi configuration ──
-if [ "${AGORA_DISABLE_WIFI:-0}" = "1" ]; then
-  echo "Agora: WiFi disabled by build config"
-  # Write flag so provisioning service knows WiFi is disabled by policy
-  echo "1" > "${ROOTFS_DIR}/opt/agora/persist/wifi_disabled"
-  # Skip OOBE — the captive portal requires WiFi to function, so it's
-  # useless on a WiFi-disabled build.  The device will boot straight into
-  # player mode and either connect to a pre-configured CMS URL or wait
-  # for one to be set via SSH / local API.
-  echo "1" > "${ROOTFS_DIR}/opt/agora/persist/provisioned"
-  # Don't install the rfkill-unblock service — keep WiFi blocked
-else
-  # Unblock WiFi radio (Pi OS soft-blocks it via rfkill + NM state file)
-  mkdir -p "${ROOTFS_DIR}/var/lib/NetworkManager"
-  cat > "${ROOTFS_DIR}/var/lib/NetworkManager/NetworkManager.state" <<'NMSTATE'
+# ── Unblock WiFi radio at every boot ──
+# Pi OS soft-blocks wifi via rfkill + the NetworkManager state file.
+# Always install the unblock; agora-fleet-provision.sh decides at first
+# boot whether a wifi profile actually gets installed (based on CMS-supplied
+# creds and presence of wifi hardware). On wifi-less hardware this is a
+# harmless noop — `rfkill unblock wifi` does nothing when no wifi switch
+# exists.
+mkdir -p "${ROOTFS_DIR}/var/lib/NetworkManager"
+cat > "${ROOTFS_DIR}/var/lib/NetworkManager/NetworkManager.state" <<'NMSTATE'
 [main]
 NetworkingEnabled=true
 WirelessEnabled=true
 WWANEnabled=true
 NMSTATE
 
-  cat > "${ROOTFS_DIR}/etc/systemd/system/rfkill-unblock-wifi.service" <<'RFKSVC'
+cat > "${ROOTFS_DIR}/etc/systemd/system/rfkill-unblock-wifi.service" <<'RFKSVC'
 [Unit]
 Description=Unblock WiFi radio
 After=systemd-udevd.service systemd-rfkill.service
@@ -123,63 +121,7 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 RFKSVC
-  on_chroot <<'EOF'
+on_chroot <<'EOF'
 systemctl enable rfkill-unblock-wifi
 rm -f /var/lib/systemd/rfkill/*
 EOF
-
-  # Pre-configure WiFi credentials if provided
-  if [ -n "${AGORA_WIFI_SSID:-}" ]; then
-    echo "Agora: pre-configuring WiFi network '${AGORA_WIFI_SSID}'"
-    CON_FILE="${ROOTFS_DIR}/etc/NetworkManager/system-connections/wifi-${AGORA_WIFI_SSID}.nmconnection"
-    cat > "${CON_FILE}" <<WIFICFG
-[connection]
-id=wifi-${AGORA_WIFI_SSID}
-type=wifi
-autoconnect=true
-autoconnect-priority=10
-
-[wifi]
-ssid=${AGORA_WIFI_SSID}
-mode=infrastructure
-
-[wifi-security]
-key-mgmt=wpa-psk
-psk=${AGORA_WIFI_PASS:-}
-
-[ipv4]
-method=auto
-
-[ipv6]
-method=auto
-WIFICFG
-    chmod 600 "${CON_FILE}"
-  fi
-fi
-
-# ── CMS URL pre-configuration ──
-if [ -n "${AGORA_CMS_URL:-}" ]; then
-  echo "Agora: pre-configuring CMS URL '${AGORA_CMS_URL}'"
-  # Parse host:port from ws://host:port/path or wss://host:port/path
-  CMS_HOST=$(echo "${AGORA_CMS_URL}" | sed -E 's|^wss?://([^:/]+).*|\1|')
-  CMS_PORT=$(echo "${AGORA_CMS_URL}" | sed -E 's|^wss?://[^:]+:([0-9]+).*|\1|')
-  [ "${CMS_PORT}" = "${AGORA_CMS_URL}" ] && CMS_PORT="8080"
-
-  mkdir -p "${ROOTFS_DIR}/opt/agora/persist"
-  cat > "${ROOTFS_DIR}/opt/agora/persist/cms_config.json" <<CMSCFG
-{
-  "cms_host": "${CMS_HOST}",
-  "cms_port": ${CMS_PORT},
-  "cms_url": "${AGORA_CMS_URL}"
-}
-CMSCFG
-fi
-
-# ── Mark provisioned if both network and CMS are pre-configured ──
-# If WiFi creds or ethernet+CMS are baked in, skip OOBE on first boot
-if [ -n "${AGORA_CMS_URL:-}" ]; then
-  if [ -n "${AGORA_WIFI_SSID:-}" ] || [ "${BOARD}" = "pi4" ] || [ "${BOARD}" = "pi5" ]; then
-    echo "Agora: network + CMS pre-configured — marking as provisioned"
-    echo "1" > "${ROOTFS_DIR}/opt/agora/persist/provisioned"
-  fi
-fi

--- a/provision/service.py
+++ b/provision/service.py
@@ -72,7 +72,6 @@ except OSError:
 PERSIST_DIR = Path("/opt/agora/persist")
 STATE_DIR = Path("/opt/agora/state")
 PROVISION_FLAG = PERSIST_DIR / "provisioned"
-WIFI_DISABLED_FLAG = PERSIST_DIR / "wifi_disabled"
 PAIRING_SECRET_PATH = PERSIST_DIR / "pairing_secret"
 CMS_STATUS_PATH = STATE_DIR / "cms_status.json"
 
@@ -108,11 +107,6 @@ from provision.pairing import read_pairing_secret as _read_pairing_secret  # noq
 def is_provisioned() -> bool:
     """Check if the device has completed initial provisioning."""
     return PROVISION_FLAG.exists()
-
-
-def is_wifi_disabled() -> bool:
-    """Check if WiFi was disabled at image build time."""
-    return WIFI_DISABLED_FLAG.exists()
 
 
 def _ap_ssid() -> str:
@@ -812,8 +806,8 @@ async def run_service(force_oobe: bool = False) -> None:
         logger.info("Ethernet OOBE complete — handing off to player")
         return
 
-    # ── No network at all (CM5 with no WiFi and no ethernet, or WiFi disabled) ──
-    has_wifi = not is_wifi_disabled() and get_wifi_interface()
+    # ── No network at all (CM5 with no WiFi and no ethernet) ──
+    has_wifi = bool(get_wifi_interface())
     if run_oobe and not has_wifi and not get_ethernet_interface():
         logger.error("No WiFi adapter and no Ethernet interface — cannot provision")
         proc = await asyncio.create_subprocess_exec(
@@ -1073,8 +1067,8 @@ async def run_service(force_oobe: bool = False) -> None:
         logger.info("OOBE complete — handing off to player")
     else:
         # ── Provisioned device boot ──────────────────────────────────
-        # Handle WiFi-provisioned, Ethernet-provisioned, and WiFi-disabled devices.
-        iface = None if is_wifi_disabled() else get_wifi_interface()
+        # Handle WiFi-provisioned and Ethernet-provisioned devices.
+        iface = get_wifi_interface()
         if iface:
             logger.info("Device provisioned — waiting for Wi-Fi (%ds)", WIFI_CONNECT_TIMEOUT)
         elif is_ethernet_connected():

--- a/scripts/agora-fleet-provision.sh
+++ b/scripts/agora-fleet-provision.sh
@@ -7,15 +7,37 @@
 # Run as root by agora-fleet-provision.service, before agora-cms-client.
 # Idempotent: safe to re-run on every boot.
 #
-# Responsibilities:
-#   1. Ensure /etc/agora/environment exists with AGORA_BOOTSTRAP_V2=1 default.
-#   2. If /boot/firmware/agora-fleet.env (or /boot/agora-fleet.env on older
-#      Pi OS) is present, install its AGORA_FLEET_ID / AGORA_FLEET_SECRET_HEX
-#      values into /etc/agora/environment (0600 root), then shred the source
-#      so a lost SD card cannot leak the fleet secret.
-#   3. Ensure /opt/agora/persist is owned by root:root (bootstrap v2 files
-#      require it; other persist files are mode 0644 and remain readable
-#      by agora-api / agora-player running as user agora).
+# This script is the SINGLE entry point for deployment-specific
+# configuration. The pi-gen catalog image is fully tenant-agnostic;
+# everything that used to be baked in at build time now arrives via
+# the CMS imager's boot drop-in (/boot/firmware/agora-fleet.env).
+#
+# Recognized keys in the boot drop-in:
+#
+#   /etc/agora/environment (mode 0600 root:root)
+#       AGORA_FLEET_ID              fleet identifier
+#       AGORA_FLEET_SECRET_HEX      fleet shared secret (hex)
+#       AGORA_BOOTSTRAP_V2          bootstrap protocol toggle (default 1)
+#       AGORA_CMS_TRANSPORT         direct | wps
+#
+#   /opt/agora/persist/cms_config.json (mode 0644 root:root)
+#       AGORA_CMS_URL               wss://host[:port]/path
+#                                   (host/port parsed from URL)
+#       Also writes /opt/agora/persist/provisioned to skip OOBE.
+#
+#   /etc/NetworkManager/system-connections/wifi-<ssid>.nmconnection
+#   (mode 0600 root:root) — only if device has wifi hardware
+#       AGORA_WIFI_SSID             wifi network name
+#       AGORA_WIFI_PASS             wifi password (PSK)
+#                                   blank SSID = "do not use wifi"
+#
+# Critical write ordering: the boot drop-in is shredded LAST, after
+# every persistent write (env file, cms_config.json, provisioned flag,
+# NetworkManager profile) has been flushed to disk. If the script
+# crashes mid-way, the drop-in remains and the next boot retries
+# cleanly. Shredding before the writes would brick the device on
+# crash (secret material gone, no fleet config, no recovery short
+# of re-flash).
 #
 # Operators wanting to re-provision a device with a different fleet id
 # can drop a fresh agora-fleet.env on the boot partition and reboot.
@@ -26,6 +48,9 @@ ENV_FILE="/etc/agora/environment"
 BOOT_FLEET_FILE="/boot/firmware/agora-fleet.env"
 LEGACY_BOOT_FLEET_FILE="/boot/agora-fleet.env"
 PERSIST_DIR="/opt/agora/persist"
+CMS_CONFIG_FILE="${PERSIST_DIR}/cms_config.json"
+PROVISIONED_FLAG="${PERSIST_DIR}/provisioned"
+NM_CONNECTIONS_DIR="/etc/NetworkManager/system-connections"
 
 mkdir -p /etc/agora
 chmod 0755 /etc/agora 2>/dev/null || true
@@ -53,8 +78,14 @@ fi
 
 if [ -n "$src" ]; then
     echo "agora-fleet-provision: installing fleet config from $src"
-    # Allow-listed keys only; ignore anything else in the drop-in to
-    # keep the attack surface tight (no arbitrary env vars).
+
+    # Capture out-of-band values into shell vars; allow-listed env-file
+    # keys append to $ENV_FILE in the loop. Anything else is silently
+    # ignored to keep the attack surface tight.
+    captured_cms_url=""
+    captured_wifi_ssid=""
+    captured_wifi_pass=""
+
     while IFS='=' read -r key val; do
         # skip blanks and comments
         case "$key" in
@@ -66,23 +97,122 @@ if [ -n "$src" ]; then
         val="${val%\"}"
         val="${val#\"}"
         case "$key" in
-            AGORA_FLEET_ID|AGORA_FLEET_SECRET_HEX|AGORA_BOOTSTRAP_V2)
+            AGORA_FLEET_ID|AGORA_FLEET_SECRET_HEX|AGORA_BOOTSTRAP_V2|AGORA_CMS_TRANSPORT)
                 sed -i "/^${key}=/d" "$ENV_FILE"
                 echo "${key}=${val}" >> "$ENV_FILE"
                 echo "agora-fleet-provision: set ${key}"
+                ;;
+            AGORA_CMS_URL)
+                captured_cms_url="$val"
+                ;;
+            AGORA_WIFI_SSID)
+                captured_wifi_ssid="$val"
+                ;;
+            AGORA_WIFI_PASS)
+                captured_wifi_pass="$val"
                 ;;
         esac
     done < "$src"
     chmod 0600 "$ENV_FILE" 2>/dev/null || true
     chown root:root "$ENV_FILE" 2>/dev/null || true
-    # Shred the boot-partition copy so a stolen SD card doesn't leak
-    # the fleet secret. shred is a no-op on FAT (no overwrite possible),
+    sync
+
+    # ── CMS URL → cms_config.json + provisioned flag ──
+    # The CMS client reads cms_config.json (NOT $ENV_FILE) for host/port,
+    # and the provisioned flag bypasses OOBE captive portal so the device
+    # boots straight into player mode against the fleet CMS.
+    if [ -n "$captured_cms_url" ]; then
+        echo "agora-fleet-provision: configuring CMS URL '${captured_cms_url}'"
+        mkdir -p "$PERSIST_DIR"
+        # Parse host:port from ws://host:port/path or wss://host:port/path.
+        # If no explicit port in the URL, default to 8080 (matches pi-gen
+        # historical behavior).
+        cms_host=$(echo "$captured_cms_url" | sed -E 's|^wss?://([^:/]+).*|\1|')
+        cms_port=$(echo "$captured_cms_url" | sed -E 's|^wss?://[^:]+:([0-9]+).*|\1|')
+        if [ "$cms_port" = "$captured_cms_url" ]; then
+            cms_port="8080"
+        fi
+        cat > "$CMS_CONFIG_FILE" <<CMSCFG
+{
+  "cms_host": "${cms_host}",
+  "cms_port": ${cms_port},
+  "cms_url": "${captured_cms_url}"
+}
+CMSCFG
+        chown root:root "$CMS_CONFIG_FILE" 2>/dev/null || true
+        chmod 0644 "$CMS_CONFIG_FILE" 2>/dev/null || true
+        sync
+
+        # Mark provisioned so OOBE is skipped on first boot. Without
+        # this, the captive portal still starts and steals the wifi
+        # interface even though we have the CMS config.
+        echo "1" > "$PROVISIONED_FLAG"
+        chown root:root "$PROVISIONED_FLAG" 2>/dev/null || true
+        chmod 0644 "$PROVISIONED_FLAG" 2>/dev/null || true
+        sync
+        echo "agora-fleet-provision: marked provisioned"
+    fi
+
+    # ── WiFi creds → NetworkManager .nmconnection ──
+    # Hardware-detect via sysfs (NOT nmcli — fleet-provision runs
+    # before NetworkManager.service, so nmcli would always return
+    # nothing on a fresh boot). cfg80211 populates /sys/class/ieee80211
+    # during udev coldplug, well before local-fs.target succeeds.
+    if [ -n "$captured_wifi_ssid" ]; then
+        if ls /sys/class/ieee80211/*/ >/dev/null 2>&1 \
+           || [ -d /sys/class/net/wlan0 ]; then
+            echo "agora-fleet-provision: configuring WiFi network '${captured_wifi_ssid}'"
+            mkdir -p "$NM_CONNECTIONS_DIR"
+            con_file="${NM_CONNECTIONS_DIR}/wifi-${captured_wifi_ssid}.nmconnection"
+            cat > "$con_file" <<WIFICFG
+[connection]
+id=wifi-${captured_wifi_ssid}
+type=wifi
+autoconnect=true
+autoconnect-priority=10
+
+[wifi]
+ssid=${captured_wifi_ssid}
+mode=infrastructure
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=${captured_wifi_pass}
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+WIFICFG
+            chown root:root "$con_file" 2>/dev/null || true
+            chmod 0600 "$con_file" 2>/dev/null || true
+            sync
+
+            # Best-effort live activation. NetworkManager may not be
+            # running yet (we're ordered before it for cms-client
+            # ordering reasons), in which case it'll pick the file up
+            # at its own startup since it lives in the canonical
+            # location. On devices that already have a working
+            # ethernet link, NM will not switch off it mid-boot —
+            # the wifi profile takes effect on next boot or on link
+            # loss. Tolerate failure.
+            nmcli connection reload 2>/dev/null || true
+            nmcli connection up "wifi-${captured_wifi_ssid}" 2>/dev/null || true
+        else
+            echo "agora-fleet-provision: no wifi hardware detected, skipping WiFi config"
+        fi
+    fi
+
+    # Shred the boot-partition copy LAST, after every persistent write
+    # has been flushed. shred is a no-op on FAT (no overwrite possible),
     # but it still unlinks the file.
     if command -v shred >/dev/null 2>&1; then
         shred -u "$src" 2>/dev/null || rm -f "$src"
     else
         rm -f "$src"
     fi
+    sync
     echo "agora-fleet-provision: fleet config installed; boot drop-in removed"
 fi
 

--- a/tests/test_oobe_flow.py
+++ b/tests/test_oobe_flow.py
@@ -189,7 +189,6 @@ class TestEthernetLinkWait:
         with patch.object(service, "is_provisioned", return_value=False), \
              patch.object(service, "get_ethernet_interface", return_value="eth0"), \
              patch.object(service, "is_ethernet_connected", side_effect=fake_is_ethernet_connected), \
-             patch.object(service, "is_wifi_disabled", return_value=True), \
              patch.object(service, "get_wifi_interface", return_value=None), \
              patch.object(service, "ProvisionDisplay", MagicMock()), \
              patch.object(service, "_wait_for_cms_adoption", AsyncMock(return_value="no_cms")), \


### PR DESCRIPTION
## Why

`AGORA_CMS_URL` and `AGORA_CMS_TRANSPORT` were silently dropped by the firmware first-boot provisioner — the allow-list in `agora-fleet-provision.sh` only recognized `AGORA_FLEET_ID`, `AGORA_FLEET_SECRET_HEX`, and `AGORA_BOOTSTRAP_V2`. Devices flashed with a CMS-imaged image landed in the OOBE captive portal loop because `cms_config.json` was never written.

PR #533 (CMS-side) fixed the matching half (the `AGORA_FLEET_SECRET_HEX` key name). This PR fixes the firmware half — and goes further: it removes ALL build-time per-deployment configuration from pi-gen + CI so the image is fully tenant-agnostic.

After this PR the catalog images contain zero deployment-specific values. Everything (CMS URL, fleet identity, WiFi creds) flows in at first boot via `/boot/firmware/agora-fleet.env`, which the CMS imager stamps into the .img.xz at imaging time and `agora-fleet-provision.sh` consumes.

## What

### `scripts/agora-fleet-provision.sh` (the new single entry point)

- Allow-list now also accepts `AGORA_CMS_TRANSPORT` (env-file write).
- Captures `AGORA_CMS_URL`, `AGORA_WIFI_SSID`, `AGORA_WIFI_PASS` out-of-band into shell vars during the parse loop.
- When CMS URL supplied: writes `/opt/agora/persist/cms_config.json` (host/port parsed from `wss://host[:port]/path`, default port 8080) **and** `/opt/agora/persist/provisioned` so the device skips OOBE.
- When SSID supplied AND wifi hardware detected via sysfs (`/sys/class/ieee80211` or `/sys/class/net/wlan0`): writes `/etc/NetworkManager/system-connections/wifi-<ssid>.nmconnection` (mode 0600). Best-effort `nmcli reload + up` (tolerated to fail; NM picks file up at next boot on devices already on ethernet).
- Sysfs (not `nmcli`) for hardware detection because `agora-fleet-provision.service` runs **before** `NetworkManager.service`.
- **Critical write ordering**: capture all values → perform every persistent write with `sync` → shred the boot drop-in **last**. A crash mid-flow leaves the drop-in intact for retry on next boot, rather than bricking the device with secret material gone.
- Blank SSID = "do not use wifi" = noop. Same for blank CMS URL. Wifi-less hardware (Compute Module without antenna) = noop.

### `pi-gen/stage-agora/00-install-agora/00-run.sh`

- Strip `AGORA_DISABLE_WIFI` branch — wifi-on-or-off is now a runtime/per-fleet decision. `rfkill-unblock-wifi.service` is now installed unconditionally (harmless on wifi-less hardware).
- Strip WiFi pre-config block (`.nmconnection` writer).
- Strip CMS URL pre-config block (`cms_config.json` writer).
- Strip "mark provisioned if both network and CMS are pre-configured" block.
- Header comment updated: only `AGORA_BOARD` remains as a build-time variable.

### `.github/workflows/build-image.yml`

- Remove `workflow_dispatch` inputs: `cms_url`, `wifi_ssid`, `wifi_password`, `disable_wifi`.
- Remove their plumbing in the "Configure pi-gen" step (env block + four conditional echoes).
- `board` input retained (needed for matrix override on manual single-board builds).
- Auto-build-on-release comment updated to reflect the fully tenant-agnostic model.

### `provision/service.py` + `tests/test_oobe_flow.py`

- Delete `WIFI_DISABLED_FLAG` constant and `is_wifi_disabled()` helper. Sole writer (pi-gen line 93) is gone in 2b above; the function would always return `False`. Two call sites inline to `bool(get_wifi_interface())`.
- Drop `is_wifi_disabled` patch from the ethernet-only OOBE test — the test still exercises the same code path via `get_wifi_interface=None`.

## Image-uniformity observation (not in this PR)

After this PR all 3 same-release images are functionally identical to each other (Pi OS Lite arm64 is board-agnostic; per-board `config.txt` tweak is just a comment; `/opt/agora/persist/board` is written but never read). Could collapse to a single image, but the CMS imager has a deep `variant` concept (catalog schema, API, worker handlers, UI dropdown, DB) that needs a paired change. **Tracked as follow-up — not in this PR.**

## Tests

- Local: 79 provision/oobe/fleet tests pass.
- Bash syntax check on the rewritten script: clean.
- Pi-gen build will verify on PR CI.

## Manual verification plan (post-merge)

1. Cut next firmware patch tag → release.yml chain builds + publishes catalog.
2. Trigger CMS imager build for test fleet (no CMS-side changes needed; PR #533 wrote the right env keys).
3. Download → flash 192.168.1.100.
4. Verify clean adoption against prod CMS (no captive portal, `cms_config.json` written by provisioner, `agora-cms-client` connects on first boot).
