### PR TITLE
pi-gen: bump chromium-rpi-hevc to v0.2.6 (4K HEVC on Pi 5)

### DIFF
--- a/pi-gen/stage-agora/00-install-chromium-hevc/00-run.sh
+++ b/pi-gen/stage-agora/00-install-chromium-hevc/00-run.sh
@@ -25,13 +25,13 @@
 #         "https://github.com/sslivins/chromium-rpi-hevc/releases/download/<TAG>/chromium-l10n_<VER>_all.deb"
 #       sha256sum /tmp/chromium-l10n.deb
 
-CHROMIUM_HEVC_TAG="v0.2.4"
+CHROMIUM_HEVC_TAG="v0.2.6"
 CHROMIUM_HEVC_DEB_VERSION="147.0.7727.116-1.deb13u1+rpt1"
 
 # SHA256 digests, pinned to detect mutated/replaced release assets.
 # Format: <sha256>  <filename>
 CHROMIUM_HEVC_DIGESTS="$(cat <<'DIGESTS'
-d8a817d3ea6d88d8c9d5eed3820869cfb2be99ff0adf0e31aa6e1e25085c6f7d  chromium_147.0.7727.116-1.deb13u1+rpt1_arm64.deb
+21827cece0a8900f4a0fad818d477c894ea56fd6aa3147754651da5a0eaff7db  chromium_147.0.7727.116-1.deb13u1+rpt1_arm64.deb
 400db4672bd42d005b519f6b29557462ae261a7ba25c37b447f545ea8f100cda  chromium-common_147.0.7727.116-1.deb13u1+rpt1_arm64.deb
 72c7ec30b0fded95a1feb77ef1b711c9040ecaf618894442cf460f1e7502f73a  chromium-sandbox_147.0.7727.116-1.deb13u1+rpt1_arm64.deb
 f16cfc35557e19715d8f62eb81dc631cb60b4e2d60129f9b76e15b968e650a85  chromium-l10n_147.0.7727.116-1.deb13u1+rpt1_all.deb


### PR DESCRIPTION
Bumps the pi-gen chromium-rpi-hevc install stage from v0.2.4 to v0.2.6.

**What v0.2.6 adds**: patch 0014 (4l2-probe-max-via-try-fmt) lifts the 1920x1088 cap on Pi 5's pi-hevc-dec V4L2 stateless decoder, which doesn't implement VIDIOC_ENUM_FRAMESIZES. Now probes the real max with VIDIOC_TRY_FMT(8192x8192) and lets chromium add 4K (3840x2160) HEVC to its supported_configs_. Without this, all 4K HEVC streams were rejected at ideo_decoder_pipeline.cc:629 with `Video configuration is not supported`.

**Pi 4 / Zero 2 W behavior**: unchanged. The probe override is gated on TRY_FMT returning dimensions strictly larger than the current default. On a 1080p-capped HEVC decoder the probe clips back down and the override is skipped.

**Validation**: 4K HEVC Main 10 BT2020/PQ HDR clip plays via cage+chromium on Pi 5 (HW path, fourcc S265, zero rejections, ~810 MB PSS chromium+cage tree). 1080p HDR + 1080p SDR no-regression. Full notes: https://github.com/sslivins/chromium-rpi-hevc/releases/tag/v0.2.6

**Hash diff**: only the main chromium deb hash changes; chromium-common, chromium-sandbox, chromium-l10n are byte-identical to v0.2.4 (patch 0014 only modifies code that compiles into the main browser binary).