### PR TITLE
feat(slot-mgr): A/B slot management library + CLI for Phase 1 OTA

### DIFF
--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -77,6 +77,13 @@ cp "${REPO_ROOT}/systemd/agora-cms-client.service" "${BUILD_DIR}/etc/systemd/sys
 cp "${REPO_ROOT}/systemd/agora-provision.service" "${BUILD_DIR}/etc/systemd/system/"
 cp "${REPO_ROOT}/systemd/agora-fleet-provision.service" "${BUILD_DIR}/etc/systemd/system/"
 
+# ── CLI wrappers (thin shells that exec `python3 -m <pkg>` with the right PYTHONPATH) ──
+mkdir -p "${BUILD_DIR}/usr/local/sbin"
+for wrapper in "${REPO_ROOT}/packaging/cli-wrappers"/*; do
+    [[ -f "$wrapper" ]] || continue
+    install -m 755 "$wrapper" "${BUILD_DIR}/usr/local/sbin/$(basename "$wrapper")"
+done
+
 # ── Plymouth theme ──
 if [[ -f "${REPO_ROOT}/config/boot-splash.png" ]]; then
     cp "${REPO_ROOT}/config/boot-splash.png" \

--- a/packaging/cli-wrappers/agora-slot-mgr
+++ b/packaging/cli-wrappers/agora-slot-mgr
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# /usr/local/sbin/agora-slot-mgr - thin shell wrapper around `python3 -m slot_mgr`.
+#
+# Installed by packaging/build-deb.sh so operators can run `agora-slot-mgr <verb>`
+# directly without having to know the PYTHONPATH dance.
+set -euo pipefail
+exec env \
+  PYTHONPATH=/opt/agora/src \
+  AGORA_BASE=/opt/agora \
+  python3 -m slot_mgr "$@"

--- a/slot_mgr/__init__.py
+++ b/slot_mgr/__init__.py
@@ -1,0 +1,52 @@
+"""A/B slot manager for the Pi 5 tryboot-based update path.
+
+Public API:
+
+    slot_state() -> SlotStatus
+        Report the currently-running slot, the default slot, and whether
+        the device is on a tentative tryboot.
+
+    trigger_tryboot(target_slot, *, reboot=True) -> None
+        Stage a tryboot to ``target_slot`` and (by default) reboot the
+        device so the bootloader picks up the [tryboot] section once.
+
+    promote_slot(target_slot) -> None
+        Make ``target_slot`` the new permanent default. Resets the strike
+        counter for that slot, updates last_success_at, and writes the
+        forward-migration-allowed sentinel.
+
+    unpin() -> None
+        Clear the "pinned" flag set after three consecutive failed
+        trybooots. Operator-only escape hatch.
+
+    SlotStatus
+        Frozen snapshot returned by ``slot_state()``.
+
+    SlotState
+        Pydantic model persisted to /data/agora/slot-state.json.
+"""
+
+from slot_mgr.core import (
+    PinnedError,
+    SlotStatus,
+    promote_slot,
+    record_tryboot_strike,
+    slot_state,
+    trigger_tryboot,
+    unpin,
+)
+from slot_mgr.state import SlotState, load_state, save_state
+
+__version__ = "0.1.0"
+__all__ = [
+    "PinnedError",
+    "SlotState",
+    "SlotStatus",
+    "load_state",
+    "promote_slot",
+    "record_tryboot_strike",
+    "save_state",
+    "slot_state",
+    "trigger_tryboot",
+    "unpin",
+]

--- a/slot_mgr/__main__.py
+++ b/slot_mgr/__main__.py
@@ -1,0 +1,6 @@
+"""``python3 -m slot_mgr`` entry point."""
+
+from slot_mgr.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slot_mgr/autoboot.py
+++ b/slot_mgr/autoboot.py
@@ -1,0 +1,252 @@
+"""Parser and rewriter for Pi 5 ``autoboot.txt``.
+
+The file is small and INI-like, but we cannot use stdlib :mod:`configparser`
+because we want to *preserve* in-line comments and blank lines so the file
+stays readable for whoever has to debug a brick by mounting the SD card on
+their laptop.
+
+Strategy: tokenize the file into an ordered list of ``Line`` records
+(comment / blank / section header / key=value), mutate the records in
+place, and emit the file by re-joining them. Unknown sections / keys are
+left untouched.
+
+The only operations slot_mgr performs are:
+
+* ``read_autoboot`` / ``parse_autoboot`` - introspect ``[all] boot_partition``
+* ``set_default_partition(part)`` - rewrite ``[all] boot_partition=N``
+* ``set_tryboot_partition(part)`` - rewrite ``[tryboot] boot_partition=N``
+* ``write_autoboot(...)`` - persist with byte-for-byte mirroring to boot-B
+
+Pi 5 autoboot.txt section semantics (from the Raspberry Pi bootloader docs):
+``[all]`` is the default boot config; ``[tryboot]`` is consulted for exactly
+one boot when triggered via ``reboot '0 tryboot'`` or
+``vcgencmd reboot_to_tryboot``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# Partition numbers in the Phase 0 GPT layout (see plan.md).
+PART_BOOT_A = 1
+PART_BOOT_B = 3
+
+# Slot numbers used at the API surface.
+SLOT_A = 1
+SLOT_B = 2
+
+#: Mapping from user-facing slot number -> GPT partition number of its boot fs.
+SLOT_TO_BOOT_PARTITION = {SLOT_A: PART_BOOT_A, SLOT_B: PART_BOOT_B}
+BOOT_PARTITION_TO_SLOT = {v: k for k, v in SLOT_TO_BOOT_PARTITION.items()}
+
+SECTION_ALL = "all"
+SECTION_TRYBOOT = "tryboot"
+
+
+class AutobootError(ValueError):
+    """Raised for malformed autoboot.txt content or invalid edits."""
+
+
+@dataclass
+class _Line:
+    """One physical line in autoboot.txt, classified."""
+
+    kind: str  # "comment" | "blank" | "section" | "kv" | "raw"
+    text: str  # original text (without trailing newline)
+    section: str | None = None  # section this line belongs to
+    key: str | None = None
+    value: str | None = None
+
+
+@dataclass
+class Autoboot:
+    """Parsed autoboot.txt with the ability to mutate and re-emit."""
+
+    lines: list[_Line] = field(default_factory=list)
+    trailing_newline: bool = True
+
+    # -- introspection ------------------------------------------------------
+
+    def get(self, section: str, key: str) -> str | None:
+        """Return the value of ``key`` in ``section``, or ``None`` if absent."""
+        for line in self.lines:
+            if line.kind == "kv" and line.section == section and line.key == key:
+                return line.value
+        return None
+
+    def default_partition(self) -> int | None:
+        raw = self.get(SECTION_ALL, "boot_partition")
+        return None if raw is None else int(raw)
+
+    def tryboot_partition(self) -> int | None:
+        raw = self.get(SECTION_TRYBOOT, "boot_partition")
+        return None if raw is None else int(raw)
+
+    def default_slot(self) -> int | None:
+        part = self.default_partition()
+        return None if part is None else BOOT_PARTITION_TO_SLOT.get(part)
+
+    # -- mutation -----------------------------------------------------------
+
+    def set_default_partition(self, partition: int) -> None:
+        """Rewrite ``[all] boot_partition=N``, creating the section if needed."""
+        self._set(SECTION_ALL, "boot_partition", str(partition))
+
+    def set_tryboot_partition(self, partition: int) -> None:
+        """Rewrite ``[tryboot] boot_partition=N``, creating the section if needed."""
+        self._set(SECTION_TRYBOOT, "boot_partition", str(partition))
+
+    def _set(self, section: str, key: str, value: str) -> None:
+        for line in self.lines:
+            if line.kind == "kv" and line.section == section and line.key == key:
+                line.value = value
+                line.text = f"{key}={value}"
+                return
+
+        # Key not present - find or create the section and append the kv at its
+        # end (just before the next section header, or at the end of the file).
+        section_start = self._find_section_start(section)
+        if section_start is None:
+            self._append_section(section)
+            section_start = self._find_section_start(section)
+            assert section_start is not None  # we just created it
+
+        insert_at = self._find_section_end(section_start)
+        self.lines.insert(
+            insert_at,
+            _Line(kind="kv", text=f"{key}={value}", section=section, key=key, value=value),
+        )
+
+    def _find_section_start(self, section: str) -> int | None:
+        for idx, line in enumerate(self.lines):
+            if line.kind == "section" and line.section == section:
+                return idx
+        return None
+
+    def _find_section_end(self, start: int) -> int:
+        """Return the insertion index for a new kv at the end of the section
+        whose header is at ``start``. Walks until the next section header (or EOF).
+        """
+        idx = start + 1
+        last_meaningful = start
+        while idx < len(self.lines):
+            line = self.lines[idx]
+            if line.kind == "section":
+                break
+            if line.kind in ("kv", "comment"):
+                last_meaningful = idx
+            idx += 1
+        return last_meaningful + 1
+
+    def _append_section(self, section: str) -> None:
+        if self.lines and self.lines[-1].kind != "blank":
+            self.lines.append(_Line(kind="blank", text=""))
+        self.lines.append(_Line(kind="section", text=f"[{section}]", section=section))
+
+    # -- emit ---------------------------------------------------------------
+
+    def to_string(self) -> str:
+        body = "\n".join(line.text for line in self.lines)
+        if self.trailing_newline and not body.endswith("\n"):
+            body += "\n"
+        return body
+
+
+# -- module-level helpers ---------------------------------------------------
+
+
+def parse_autoboot(text: str) -> Autoboot:
+    """Tokenize raw autoboot.txt content into an :class:`Autoboot` object.
+
+    Raises :class:`AutobootError` on a kv line that appears before any section
+    header (the Pi bootloader treats those as part of ``[all]``, but we'd
+    rather refuse to round-trip a file with implicit-section keys because the
+    re-emit would change semantics).
+    """
+    lines: list[_Line] = []
+    current_section: str | None = None
+    raw_lines = text.split("\n")
+    trailing_newline = text.endswith("\n")
+    # When the file ends with a newline ``str.split`` yields an empty trailing
+    # entry; drop it so we don't emit a phantom blank line on round-trip.
+    if trailing_newline and raw_lines and raw_lines[-1] == "":
+        raw_lines = raw_lines[:-1]
+
+    for raw in raw_lines:
+        stripped = raw.strip()
+        if not stripped:
+            lines.append(_Line(kind="blank", text=raw))
+            continue
+        if stripped.startswith("#"):
+            lines.append(_Line(kind="comment", text=raw))
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped[1:-1].strip()
+            current_section = section
+            lines.append(_Line(kind="section", text=raw, section=section))
+            continue
+        if "=" in stripped:
+            key, _, value = stripped.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if current_section is None:
+                raise AutobootError(
+                    f"key {key!r} appears before any [section] header; refusing to parse"
+                )
+            lines.append(
+                _Line(
+                    kind="kv",
+                    text=raw,
+                    section=current_section,
+                    key=key,
+                    value=value,
+                )
+            )
+            continue
+        # Unknown line shape - keep it but flag it as raw so we don't lose data.
+        lines.append(_Line(kind="raw", text=raw, section=current_section))
+
+    return Autoboot(lines=lines, trailing_newline=trailing_newline)
+
+
+def read_autoboot(path: Path) -> Autoboot:
+    """Read and parse an autoboot.txt from disk."""
+    return parse_autoboot(path.read_text())
+
+
+def write_autoboot(
+    autoboot: Autoboot,
+    path: Path,
+    mirrors: Iterable[Path] = (),
+) -> None:
+    """Persist ``autoboot`` to ``path`` and every entry in ``mirrors``.
+
+    Writes are atomic per-file (tempfile + rename). On a mirror failing
+    (e.g. boot-B not mounted), the primary write is still committed and the
+    exception is re-raised so the caller can log it.
+    """
+    text = autoboot.to_string()
+    _atomic_write_text(path, text)
+    for mirror in mirrors:
+        _atomic_write_text(mirror, text)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    import os
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/slot_mgr/cli.py
+++ b/slot_mgr/cli.py
@@ -1,0 +1,158 @@
+"""argparse CLI for ``agora-slot-mgr``.
+
+Verbs implemented in this PR:
+
+* ``status``           - report current slot + tentative + pin + strikes
+* ``trigger-tryboot N`` - rewrite [tryboot] in autoboot.txt and reboot
+* ``promote N``         - rewrite [all] in autoboot.txt, reset strikes
+* ``unpin``             - clear the 3-strikes pin
+* ``record-strike N``   - bump the strike counter (used by slot-confirm
+  and watchdog services to mark a failed tentative boot)
+
+Slot operands accept both numeric form (``1`` / ``2``) and letter form
+(``A`` / ``B``) for friendliness on the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from typing import Sequence
+
+from slot_mgr import __version__
+from slot_mgr import core
+
+
+def _parse_slot(raw: str) -> int:
+    raw = raw.strip()
+    if raw in ("1", "A", "a"):
+        return core.SLOT_A
+    if raw in ("2", "B", "b"):
+        return core.SLOT_B
+    raise argparse.ArgumentTypeError(
+        f"slot must be one of 1, 2, A, B (got {raw!r})"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="agora-slot-mgr",
+        description="Manage A/B boot slots on a Pi 5 agora device.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"agora-slot-mgr {__version__}",
+    )
+    sub = parser.add_subparsers(dest="verb", required=True)
+
+    p_status = sub.add_parser("status", help="print current slot state")
+    p_status.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-parsable JSON instead of human text",
+    )
+
+    p_tryboot = sub.add_parser(
+        "trigger-tryboot",
+        help="stage a one-shot tryboot of the target slot and reboot",
+    )
+    p_tryboot.add_argument("slot", type=_parse_slot, help="target slot (1, 2, A, B)")
+    p_tryboot.add_argument(
+        "--no-reboot",
+        action="store_true",
+        help="write autoboot.txt + persist state but do not actually reboot",
+    )
+
+    p_promote = sub.add_parser(
+        "promote",
+        help="make the target slot the permanent default (rewrites [all])",
+    )
+    p_promote.add_argument("slot", type=_parse_slot, help="target slot (1, 2, A, B)")
+
+    sub.add_parser("unpin", help="clear the three-strikes pin")
+
+    p_strike = sub.add_parser(
+        "record-strike",
+        help="record a failed tryboot for a slot (used by slot-confirm / watchdog)",
+    )
+    p_strike.add_argument("slot", type=_parse_slot, help="slot whose tryboot failed")
+    p_strike.add_argument(
+        "--reason",
+        default="tryboot failed",
+        help="free-form annotation written to slot-state.json on pin",
+    )
+
+    return parser
+
+
+def _status_to_dict(status: core.SlotStatus) -> dict:
+    d = asdict(status)
+    # Make the strikes dict JSON-friendly (str keys).
+    d["strikes"] = {str(k): int(v) for k, v in status.strikes.items()}
+    return d
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.verb == "status":
+            status = core.slot_state()
+            if args.json:
+                print(json.dumps(_status_to_dict(status), indent=2, sort_keys=True))
+            else:
+                print(core.format_status_human(status))
+            return 0
+
+        if args.verb == "trigger-tryboot":
+            state = core.trigger_tryboot(args.slot, reboot=not args.no_reboot)
+            print(
+                f"staged tryboot of slot {args.slot}; "
+                f"last_tryboot_at={state.last_tryboot_at}"
+            )
+            if args.no_reboot:
+                print("--no-reboot set; not invoking `reboot '0 tryboot'`")
+            return 0
+
+        if args.verb == "promote":
+            state = core.promote_slot(args.slot)
+            print(
+                f"promoted slot {args.slot} to default; "
+                f"strikes={state.strikes}; "
+                f"last_success_at={state.last_success_at}"
+            )
+            return 0
+
+        if args.verb == "unpin":
+            state = core.unpin()
+            print(
+                f"unpinned; pinned={state.pinned}; strikes={state.strikes}"
+            )
+            return 0
+
+        if args.verb == "record-strike":
+            state = core.record_tryboot_strike(args.slot, reason=args.reason)
+            print(
+                f"recorded strike for slot {args.slot}; "
+                f"strikes={state.strikes}; pinned={state.pinned}"
+            )
+            return 0
+
+        # argparse with required=True keeps us from reaching here, but keep the
+        # branch so mypy is happy.
+        parser.error(f"unknown verb {args.verb!r}")
+        return 2
+
+    except core.PinnedError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+    except core.InvalidSlotError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except core.SlotMgrError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1

--- a/slot_mgr/core.py
+++ b/slot_mgr/core.py
@@ -1,0 +1,334 @@
+"""Core slot-management primitives used by both the library API and the CLI.
+
+This module implements the Phase 1 deliverables:
+
+* :func:`slot_state` - derive the current active slot + tentative flag
+* :func:`trigger_tryboot` - stage a tryboot of the inactive slot and reboot
+* :func:`promote_slot` - make a slot the permanent default (resets strikes,
+  writes the forward-migration sentinel)
+* :func:`record_tryboot_strike` - increment the failure counter for a slot
+  and pin the device if the counter hits ``STRIKE_LIMIT``
+* :func:`unpin` - clear the pinned flag (operator escape hatch)
+
+All disk side-effects route through configurable paths in :mod:`slot_mgr.paths`
+so the whole module is testable on a developer laptop without a Pi.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from slot_mgr import autoboot as ab
+from slot_mgr import paths
+from slot_mgr.state import (
+    STRIKE_LIMIT,
+    SlotState,
+    load_state,
+    save_state,
+    utc_now_iso,
+)
+
+# Public re-exports for type-completeness
+SLOT_A = ab.SLOT_A
+SLOT_B = ab.SLOT_B
+VALID_SLOTS = (SLOT_A, SLOT_B)
+
+#: ``reboot '0 tryboot'`` is the Pi 5 syntax that tells the bootloader to use
+#: ``[tryboot]`` for exactly one boot. The single-token argument matters - the
+#: bootloader sees it via the kernel "reboot reason" field.
+REBOOT_TRYBOOT_CMD = ("sudo", "reboot", "0 tryboot")
+
+#: When the kernel cmdline says we booted via ``root=PARTLABEL=root-A|B`` we
+#: map the label to a slot number.
+_PARTLABEL_RE = re.compile(r"root=PARTLABEL=root-([AB])\b", re.IGNORECASE)
+
+
+class SlotMgrError(RuntimeError):
+    """Base class for all expected slot-mgr failures."""
+
+
+class PinnedError(SlotMgrError):
+    """trigger_tryboot refused because the device is pinned to last-known-good."""
+
+
+class InvalidSlotError(SlotMgrError):
+    """A non-{1, 2} slot identifier was supplied."""
+
+
+@dataclass(frozen=True)
+class SlotStatus:
+    """Snapshot returned by :func:`slot_state`.
+
+    ``running_slot``
+        The slot we actually booted into (parsed from /proc/cmdline). ``None``
+        if we cannot determine it (typically: dev host without a real cmdline).
+
+    ``default_slot``
+        The slot the bootloader would pick by default on the next normal
+        boot (parsed from ``[all] boot_partition`` of autoboot.txt). ``None``
+        if autoboot.txt is missing or malformed.
+
+    ``tentative``
+        ``True`` iff ``running_slot != default_slot`` - i.e., we're on a
+        tryboot. ``slot_state()`` derives this rather than reading any marker
+        file; the kernel cmdline and autoboot.txt are the single source of
+        truth (no extra state to get out of sync).
+
+    ``pinned`` / ``strikes`` / ``last_tryboot_target``
+        Pulled straight from slot-state.json for convenience.
+    """
+
+    running_slot: Optional[int]
+    default_slot: Optional[int]
+    tentative: bool
+    pinned: bool
+    strikes: dict[int, int]
+    last_tryboot_target: Optional[int]
+    last_tryboot_at: Optional[str]
+    last_success_at: Optional[str]
+
+
+def _validate_slot(slot: int) -> int:
+    if slot not in VALID_SLOTS:
+        raise InvalidSlotError(f"slot must be 1 or 2, got {slot!r}")
+    return slot
+
+
+def _read_cmdline(path: Optional[Path] = None) -> str:
+    p = path or paths.proc_cmdline_path()
+    try:
+        return p.read_text()
+    except FileNotFoundError:
+        return ""
+
+
+def _detect_running_slot(cmdline_text: str) -> Optional[int]:
+    """Parse ``/proc/cmdline`` for ``root=PARTLABEL=root-A|B``."""
+    m = _PARTLABEL_RE.search(cmdline_text)
+    if not m:
+        return None
+    return SLOT_A if m.group(1).upper() == "A" else SLOT_B
+
+
+def _read_default_slot(autoboot_path: Optional[Path] = None) -> Optional[int]:
+    """Parse ``[all] boot_partition=N`` from autoboot.txt."""
+    p = autoboot_path or paths.autoboot_path()
+    try:
+        parsed = ab.read_autoboot(p)
+    except (FileNotFoundError, ab.AutobootError):
+        return None
+    return parsed.default_slot()
+
+
+def slot_state() -> SlotStatus:
+    """Derive the current slot configuration.
+
+    Reads /proc/cmdline + /boot/firmware/autoboot.txt + /data/agora/slot-state.json.
+    Cheap; safe to call repeatedly.
+    """
+    state = load_state()
+    running = _detect_running_slot(_read_cmdline())
+    default = _read_default_slot()
+    return SlotStatus(
+        running_slot=running,
+        default_slot=default,
+        tentative=(running is not None and default is not None and running != default),
+        pinned=state.pinned,
+        strikes={int(k): int(v) for k, v in state.strikes.items()},
+        last_tryboot_target=state.last_tryboot_target,
+        last_tryboot_at=state.last_tryboot_at,
+        last_success_at=state.last_success_at,
+    )
+
+
+def _autoboot_mirrors() -> tuple[Path, ...]:
+    """Return the mirror paths that should also receive autoboot.txt writes.
+
+    A mirror is only included when its parent directory exists - on a dev
+    host or in a test fixture with no boot-B mountpoint we don't want to
+    blow up the operation; the primary write is what guards against bricking.
+    """
+    mirror = paths.autoboot_mirror_path()
+    if mirror.parent.exists():
+        return (mirror,)
+    return ()
+
+
+def trigger_tryboot(
+    target_slot: int,
+    *,
+    reboot: bool = True,
+    reboot_fn: Optional[Callable[[], None]] = None,
+) -> SlotState:
+    """Stage a one-shot tryboot of ``target_slot`` and (by default) reboot.
+
+    Sequence (in order, with persistence between steps so a crash mid-flow
+    leaves the device in a recoverable state):
+
+    1. Refuse if the device is pinned. Operator must ``unpin`` first.
+    2. Rewrite ``[tryboot] boot_partition`` in autoboot.txt to the target
+       slot's boot partition. Mirror the file to boot-B if mounted.
+    3. Record ``last_tryboot_target`` + ``last_tryboot_at`` in slot-state.json
+       *before* issuing the reboot, so on next boot ``record_tryboot_strike``
+       can attribute a failed boot to this target.
+    4. Execute ``sudo reboot '0 tryboot'`` (unless ``reboot=False``).
+
+    Returns the updated :class:`SlotState` (for tests and CLI output).
+
+    Parameters
+    ----------
+    reboot:
+        When ``False``, every disk side-effect happens but the actual reboot
+        is skipped. Useful for unit tests and for ``--dry-run`` flows.
+    reboot_fn:
+        Override the reboot invocation - tests pass a recorder. Defaults to
+        ``_default_reboot`` which execs ``sudo reboot '0 tryboot'``.
+    """
+    _validate_slot(target_slot)
+    state = load_state()
+    if state.pinned:
+        raise PinnedError(
+            "device is pinned to last-known-good after repeated tryboot failures; "
+            f"reason={state.pinned_reason!r}; run `agora-slot-mgr unpin` to clear"
+        )
+
+    parsed = ab.read_autoboot(paths.autoboot_path())
+    parsed.set_tryboot_partition(ab.SLOT_TO_BOOT_PARTITION[target_slot])
+    ab.write_autoboot(parsed, paths.autoboot_path(), mirrors=_autoboot_mirrors())
+
+    state.last_tryboot_target = target_slot
+    state.last_tryboot_at = utc_now_iso()
+    save_state(state)
+
+    if reboot:
+        (reboot_fn or _default_reboot)()
+
+    return state
+
+
+def _default_reboot() -> None:
+    """Issue ``sudo reboot '0 tryboot'`` to the host kernel."""
+    subprocess.run(REBOOT_TRYBOOT_CMD, check=True)
+
+
+def promote_slot(target_slot: int) -> SlotState:
+    """Make ``target_slot`` the permanent default.
+
+    Steps:
+
+    1. Rewrite ``[all] boot_partition`` in autoboot.txt to the target slot's
+       boot partition. Mirror to boot-B if available.
+    2. Clear ``[tryboot] boot_partition`` so a stray ``reboot '0 tryboot'``
+       can't accidentally re-enter the old tentative configuration. (We
+       point ``[tryboot]`` at the *other* slot, the new candidate, so the
+       file remains valid and future trybooot calls behave.)
+    3. Reset the strike counter for the promoted slot.
+    4. Update ``last_success_at`` and clear ``last_tryboot_target``.
+    5. Write ``/data/agora/migration-allowed`` so the new agora.service can
+       run forward migrations on /data. (The forward-migration fence reader
+       is implemented by ``p1-forward-migration-fence``.)
+    """
+    _validate_slot(target_slot)
+    other_slot = SLOT_B if target_slot == SLOT_A else SLOT_A
+
+    parsed = ab.read_autoboot(paths.autoboot_path())
+    parsed.set_default_partition(ab.SLOT_TO_BOOT_PARTITION[target_slot])
+    parsed.set_tryboot_partition(ab.SLOT_TO_BOOT_PARTITION[other_slot])
+    ab.write_autoboot(parsed, paths.autoboot_path(), mirrors=_autoboot_mirrors())
+
+    state = load_state()
+    state.set_strikes(target_slot, 0)
+    state.last_success_at = utc_now_iso()
+    state.last_tryboot_target = None
+    state.last_tryboot_at = None
+    save_state(state)
+
+    _write_migration_sentinel(target_slot)
+    return state
+
+
+def _write_migration_sentinel(slot: int) -> None:
+    sentinel = paths.migration_allowed_sentinel_path()
+    sentinel.parent.mkdir(parents=True, exist_ok=True)
+    body = (
+        f"slot={slot}\n"
+        f"promoted_at={utc_now_iso()}\n"
+    )
+    from shared.state import atomic_write
+
+    atomic_write(sentinel, body)
+
+
+def record_tryboot_strike(
+    slot: int,
+    *,
+    reason: str = "tryboot failed",
+) -> SlotState:
+    """Increment the strike counter for ``slot``; pin the device if it hits the limit.
+
+    Called by ``p1-slot-confirm`` when slot-confirm fails on a tentative boot,
+    and by ``p1-watchdog`` when a watchdog reset rolls a tryboot back to the
+    previous slot.
+
+    Returns the updated state.
+    """
+    _validate_slot(slot)
+    state = load_state()
+    new_count = state.get_strikes(slot) + 1
+    state.set_strikes(slot, new_count)
+
+    if new_count >= STRIKE_LIMIT and not state.pinned:
+        state.pinned = True
+        state.pinned_at = utc_now_iso()
+        state.pinned_reason = (
+            f"slot {slot} reached {new_count} consecutive tryboot failures: {reason}"
+        )
+
+    save_state(state)
+    return state
+
+
+def unpin(*, reason: str = "operator unpin") -> SlotState:
+    """Clear the pinned flag and reset both strike counters.
+
+    Equivalent to "operator has decided the device is recovered." Resets
+    both counters because the pin condition was a global "we don't trust
+    tryboot right now" - re-trusting one slot means re-trusting the
+    mechanism, not just that slot's history.
+    """
+    state = load_state()
+    state.pinned = False
+    state.pinned_at = None
+    state.pinned_reason = None
+    state.strikes = {"1": 0, "2": 0}
+    state.last_tryboot_target = None
+    state.last_tryboot_at = None
+    save_state(state)
+    return state
+
+
+def format_status_human(status: SlotStatus) -> str:
+    """Human-readable rendering for ``agora-slot-mgr status``."""
+    lines = []
+    lines.append(f"running slot:        {status.running_slot}")
+    lines.append(f"default slot:        {status.default_slot}")
+    lines.append(f"tentative tryboot:   {status.tentative}")
+    lines.append(f"pinned:              {status.pinned}")
+    lines.append(
+        f"strikes:             slot1={status.strikes.get(1, 0)} "
+        f"slot2={status.strikes.get(2, 0)}"
+    )
+    lines.append(f"last_tryboot_target: {status.last_tryboot_target}")
+    lines.append(f"last_tryboot_at:     {status.last_tryboot_at}")
+    lines.append(f"last_success_at:     {status.last_success_at}")
+    return "\n".join(lines)
+
+
+def quote_cmd(cmd: tuple[str, ...]) -> str:
+    """Render a command tuple as a shell-quoted string (for log lines)."""
+    return " ".join(shlex.quote(part) for part in cmd)

--- a/slot_mgr/paths.py
+++ b/slot_mgr/paths.py
@@ -1,0 +1,66 @@
+"""File paths used by slot_mgr.
+
+Every path is resolved at call time from an environment variable so that
+unit tests can point the library at a fake /boot/firmware and /data tree
+without monkey-patching module-level constants.
+
+Defaults match the Bookworm / Phase 0 layout:
+
+* /boot/firmware/autoboot.txt - the one we mutate to switch slots
+* /boot/firmware-b/autoboot.txt - the mirror on boot-B (kept in sync)
+* /data/agora/slot-state.json - persistent strike counter + history
+* /data/agora/migration-allowed - forward-migration fence sentinel
+* /proc/cmdline - inspected to detect the running slot
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: Layout of the two boot partitions when both are mounted simultaneously.
+#: Phase 0 mounts boot-A at /boot/firmware (the kernel-standard path); the
+#: B-side mirror is exposed at /boot/firmware-b so slot_mgr can write the
+#: same autoboot.txt to both copies (F6).
+DEFAULT_AUTOBOOT_PATH = "/boot/firmware/autoboot.txt"
+DEFAULT_AUTOBOOT_MIRROR_PATH = "/boot/firmware-b/autoboot.txt"
+
+DEFAULT_DATA_DIR = "/data/agora"
+DEFAULT_PROC_CMDLINE = "/proc/cmdline"
+
+
+def autoboot_path() -> Path:
+    """Primary autoboot.txt on the active boot partition (boot-A by default)."""
+    return Path(os.environ.get("AGORA_AUTOBOOT_PATH", DEFAULT_AUTOBOOT_PATH))
+
+
+def autoboot_mirror_path() -> Path:
+    """Mirror autoboot.txt on the inactive boot partition (boot-B by default).
+
+    Phase 0 ships byte-identical copies on both boot partitions so the device
+    isn't single-point-of-failure on boot-A; slot_mgr is responsible for
+    keeping the two in sync on every promote/tryboot rewrite.
+    """
+    return Path(os.environ.get("AGORA_AUTOBOOT_MIRROR_PATH", DEFAULT_AUTOBOOT_MIRROR_PATH))
+
+
+def data_dir() -> Path:
+    """Persistent slot-mgr state directory (lives on /data so it survives slot switches)."""
+    return Path(os.environ.get("AGORA_SLOT_DATA_DIR", DEFAULT_DATA_DIR))
+
+
+def slot_state_path() -> Path:
+    """JSON file holding the strike counter and tryboot history."""
+    return data_dir() / "slot-state.json"
+
+
+def migration_allowed_sentinel_path() -> Path:
+    """Sentinel written by ``promote_slot()`` to tell agora.service that running
+    forward-migrations on /data is safe (the running slot is now the permanent one).
+    """
+    return data_dir() / "migration-allowed"
+
+
+def proc_cmdline_path() -> Path:
+    """The kernel command line - parsed to detect the running slot via PARTLABEL."""
+    return Path(os.environ.get("AGORA_PROC_CMDLINE", DEFAULT_PROC_CMDLINE))

--- a/slot_mgr/state.py
+++ b/slot_mgr/state.py
@@ -1,0 +1,85 @@
+"""Persistent slot-manager state: ``/data/agora/slot-state.json``.
+
+Lives on the shared ``/data`` partition so it survives a slot switch (the
+whole point of the strike counter is that slot B's first boot still knows
+how many times it has already failed).
+
+Schema is versioned. v1 fields:
+
+``schema_version``
+    Bump on any breaking change. We migrate forward at load time.
+
+``strikes``
+    ``{slot: count}`` map. A "strike" is one consecutive failed tryboot to
+    that slot. Resets to 0 on a successful ``promote_slot``. Three strikes
+    pin the device (see ``pinned``).
+
+``last_tryboot_target`` / ``last_tryboot_at``
+    The slot we most recently asked the bootloader to try and the ISO-8601
+    timestamp of the request.
+
+``last_success_at``
+    ISO-8601 timestamp of the most recent ``promote_slot`` call.
+
+``pinned`` / ``pinned_at`` / ``pinned_reason``
+    Set when ``record_tryboot_strike`` raises the count for a slot to 3.
+    While pinned, ``trigger_tryboot`` refuses to run; an operator must call
+    ``agora-slot-mgr unpin`` to clear.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from shared.state import atomic_write
+from slot_mgr import paths
+
+SCHEMA_VERSION = 1
+
+# Maximum consecutive failed tryboots before we pin the device and require
+# operator unpin. (Per Phase 1 acceptance: "3 consecutive failed tryboots
+# leave the device pinned to last-known-good".)
+STRIKE_LIMIT = 3
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time formatted as a Zulu ISO-8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class SlotState(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int = SCHEMA_VERSION
+    strikes: dict[str, int] = Field(default_factory=lambda: {"1": 0, "2": 0})
+    last_tryboot_target: Optional[int] = None
+    last_tryboot_at: Optional[str] = None
+    last_success_at: Optional[str] = None
+    pinned: bool = False
+    pinned_at: Optional[str] = None
+    pinned_reason: Optional[str] = None
+
+    def get_strikes(self, slot: int) -> int:
+        return int(self.strikes.get(str(slot), 0))
+
+    def set_strikes(self, slot: int, value: int) -> None:
+        self.strikes[str(slot)] = int(value)
+
+
+def load_state(path: Optional[Path] = None) -> SlotState:
+    """Read slot-state.json, returning a fresh ``SlotState`` if missing."""
+    p = path or paths.slot_state_path()
+    try:
+        return SlotState.model_validate_json(p.read_text())
+    except (FileNotFoundError, ValueError):
+        return SlotState()
+
+
+def save_state(state: SlotState, path: Optional[Path] = None) -> None:
+    """Write slot-state.json atomically."""
+    p = path or paths.slot_state_path()
+    atomic_write(p, state.model_dump_json(indent=2))

--- a/tests/test_slot_mgr_autoboot.py
+++ b/tests/test_slot_mgr_autoboot.py
@@ -1,0 +1,164 @@
+"""Unit tests for ``slot_mgr.autoboot``: parser round-trips and section edits."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from slot_mgr import autoboot as ab
+
+
+SAMPLE = textwrap.dedent("""\
+    # autoboot.txt - Pi 5 A/B boot configuration for agora.
+    # Managed by agora-slot-mgr; mirrored on both boot-A and boot-B.
+
+    [all]
+    tryboot_a_b=1
+    boot_partition=1
+
+    [tryboot]
+    boot_partition=3
+""")
+
+
+class TestParse:
+    def test_round_trip_preserves_bytes(self):
+        """Parsing and re-emitting yields the same content."""
+        parsed = ab.parse_autoboot(SAMPLE)
+        assert parsed.to_string() == SAMPLE
+
+    def test_read_default_and_tryboot_partitions(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        assert parsed.default_partition() == ab.PART_BOOT_A
+        assert parsed.tryboot_partition() == ab.PART_BOOT_B
+
+    def test_default_slot_maps_partition_to_slot_number(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        assert parsed.default_slot() == ab.SLOT_A
+
+    def test_get_returns_none_for_unknown_key(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        assert parsed.get("all", "no_such_key") is None
+        assert parsed.get("nonexistent", "boot_partition") is None
+
+    def test_preserves_comments(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        emitted = parsed.to_string()
+        assert "# autoboot.txt" in emitted
+        assert "# Managed by agora-slot-mgr" in emitted
+
+    def test_implicit_section_key_rejected(self):
+        """A kv line before any [section] header is a malformed file we refuse."""
+        bad = "boot_partition=1\n[all]\n"
+        with pytest.raises(ab.AutobootError):
+            ab.parse_autoboot(bad)
+
+    def test_handles_missing_trailing_newline(self):
+        no_newline = "[all]\nboot_partition=1"
+        parsed = ab.parse_autoboot(no_newline)
+        # Re-emit without forcing a trailing newline
+        assert parsed.to_string() == no_newline
+
+    def test_trailing_newline_is_preserved_on_round_trip(self):
+        with_newline = "[all]\nboot_partition=1\n"
+        parsed = ab.parse_autoboot(with_newline)
+        assert parsed.to_string() == with_newline
+
+
+class TestSetDefaultPartition:
+    def test_mutates_existing_value_only(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        parsed.set_default_partition(ab.PART_BOOT_B)
+        assert parsed.default_partition() == ab.PART_BOOT_B
+        # tryboot must NOT change
+        assert parsed.tryboot_partition() == ab.PART_BOOT_B
+
+    def test_emit_after_mutation_keeps_structure(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        parsed.set_default_partition(ab.PART_BOOT_B)
+        emitted = parsed.to_string()
+        # The [all] block still exists; the value flipped
+        assert "[all]" in emitted
+        assert "boot_partition=3" in emitted
+        # Comment block still intact
+        assert "# autoboot.txt" in emitted
+
+    def test_inserts_missing_key(self):
+        """If [all] exists but lacks boot_partition we add it inside [all]."""
+        text = "[all]\ntryboot_a_b=1\n\n[tryboot]\nboot_partition=3\n"
+        parsed = ab.parse_autoboot(text)
+        parsed.set_default_partition(ab.PART_BOOT_A)
+        emitted = parsed.to_string()
+        # boot_partition must land between [all] and [tryboot]
+        all_idx = emitted.index("[all]")
+        tryboot_idx = emitted.index("[tryboot]")
+        bp_idx = emitted.index("boot_partition=1")
+        assert all_idx < bp_idx < tryboot_idx
+
+    def test_appends_section_if_missing(self):
+        text = "[tryboot]\nboot_partition=3\n"
+        parsed = ab.parse_autoboot(text)
+        parsed.set_default_partition(ab.PART_BOOT_A)
+        emitted = parsed.to_string()
+        assert "[all]" in emitted
+        assert "boot_partition=1" in emitted
+        # Original [tryboot] line preserved
+        assert "boot_partition=3" in emitted
+
+
+class TestSetTrybootPartition:
+    def test_can_flip_tryboot_target(self):
+        parsed = ab.parse_autoboot(SAMPLE)
+        parsed.set_tryboot_partition(ab.PART_BOOT_A)
+        assert parsed.tryboot_partition() == ab.PART_BOOT_A
+        # [all] unchanged
+        assert parsed.default_partition() == ab.PART_BOOT_A
+
+
+class TestReadWrite:
+    def test_write_creates_file_atomically(self, tmp_path):
+        target = tmp_path / "boot" / "firmware" / "autoboot.txt"
+        ab.write_autoboot(ab.parse_autoboot(SAMPLE), target)
+        assert target.read_text() == SAMPLE
+
+    def test_write_with_mirror_writes_both(self, tmp_path):
+        primary = tmp_path / "boot-A" / "autoboot.txt"
+        mirror = tmp_path / "boot-B" / "autoboot.txt"
+        primary.parent.mkdir(parents=True)
+        mirror.parent.mkdir(parents=True)
+        ab.write_autoboot(ab.parse_autoboot(SAMPLE), primary, mirrors=[mirror])
+        # The whole point of mirroring is that the two on-disk copies are
+        # byte-identical (so the bootloader sees the same autoboot.txt no
+        # matter which boot partition it lands on). We deliberately do NOT
+        # compare against ``SAMPLE.encode()`` here: text-mode write on
+        # Windows substitutes ``\r\n`` for ``\n``, but the primary/mirror
+        # pair is still identical to each other, which is the invariant
+        # the production code is responsible for.
+        assert primary.read_bytes() == mirror.read_bytes()
+        # And the *content* still round-trips through the parser.
+        assert ab.read_autoboot(primary).default_partition() == ab.PART_BOOT_A
+
+    def test_read_autoboot_roundtrips_from_disk(self, tmp_path):
+        target = tmp_path / "autoboot.txt"
+        target.write_text(SAMPLE)
+        parsed = ab.read_autoboot(target)
+        assert parsed.default_partition() == ab.PART_BOOT_A
+        assert parsed.to_string() == SAMPLE
+
+    def test_mirror_failure_does_not_corrupt_primary(self, tmp_path):
+        """If the mirror path can't be written (parent missing), the primary
+        write has already committed when the mirror attempt raises."""
+        primary = tmp_path / "primary" / "autoboot.txt"
+        primary.parent.mkdir(parents=True)
+        # Mirror parent does not exist and is a *file* not a directory, so
+        # mkdir() raises a NotADirectoryError. Verify the primary already
+        # contains the new content before the exception bubbles.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        mirror = blocker / "subdir" / "autoboot.txt"
+
+        with pytest.raises((NotADirectoryError, FileExistsError, OSError)):
+            ab.write_autoboot(ab.parse_autoboot(SAMPLE), primary, mirrors=[mirror])
+        # Primary committed regardless
+        assert primary.read_text() == SAMPLE

--- a/tests/test_slot_mgr_cli.py
+++ b/tests/test_slot_mgr_cli.py
@@ -1,0 +1,150 @@
+"""Unit tests for the ``agora-slot-mgr`` CLI verb dispatch."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+
+from slot_mgr import autoboot as ab
+from slot_mgr import cli
+from slot_mgr.state import STRIKE_LIMIT, load_state
+
+
+AUTOBOOT_DEFAULT = textwrap.dedent("""\
+    # managed by agora-slot-mgr
+    [all]
+    tryboot_a_b=1
+    boot_partition=1
+
+    [tryboot]
+    boot_partition=3
+""")
+
+
+@pytest.fixture
+def slot_env(tmp_path, monkeypatch):
+    """Same idea as test_slot_mgr_core but a slimmer setup."""
+    autoboot = tmp_path / "boot" / "autoboot.txt"
+    mirror = tmp_path / "boot-b" / "autoboot.txt"
+    data = tmp_path / "data"
+    cmdline = tmp_path / "cmdline"
+
+    autoboot.parent.mkdir()
+    mirror.parent.mkdir()
+    data.mkdir()
+    autoboot.write_text(AUTOBOOT_DEFAULT)
+    mirror.write_text(AUTOBOOT_DEFAULT)
+    cmdline.write_text("root=PARTLABEL=root-A rootwait\n")
+
+    monkeypatch.setenv("AGORA_AUTOBOOT_PATH", str(autoboot))
+    monkeypatch.setenv("AGORA_AUTOBOOT_MIRROR_PATH", str(mirror))
+    monkeypatch.setenv("AGORA_SLOT_DATA_DIR", str(data))
+    monkeypatch.setenv("AGORA_PROC_CMDLINE", str(cmdline))
+
+    return {"autoboot": autoboot, "mirror": mirror, "data": data, "cmdline": cmdline}
+
+
+class TestStatus:
+    def test_status_human_output(self, slot_env, capsys):
+        rc = cli.main(["status"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "running slot:" in out
+        assert "default slot:" in out
+        assert "tentative tryboot:" in out
+        assert "strikes:" in out
+
+    def test_status_json_output(self, slot_env, capsys):
+        rc = cli.main(["status", "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["running_slot"] == 1
+        assert payload["default_slot"] == 1
+        assert payload["tentative"] is False
+        assert payload["pinned"] is False
+        assert payload["strikes"] == {"1": 0, "2": 0}
+
+
+class TestTrybootVerb:
+    def test_no_reboot_dispatches_correctly(self, slot_env, capsys, monkeypatch):
+        rebooted = []
+        monkeypatch.setattr(
+            "slot_mgr.core._default_reboot",
+            lambda: rebooted.append(True),
+        )
+        rc = cli.main(["trigger-tryboot", "2", "--no-reboot"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "staged tryboot of slot 2" in out
+        assert "--no-reboot set" in out
+        assert rebooted == []
+        # autoboot rewritten
+        assert ab.read_autoboot(slot_env["autoboot"]).tryboot_partition() == ab.PART_BOOT_B
+
+    def test_letter_slot_accepted(self, slot_env, capsys, monkeypatch):
+        monkeypatch.setattr("slot_mgr.core._default_reboot", lambda: None)
+        rc = cli.main(["trigger-tryboot", "B", "--no-reboot"])
+        assert rc == 0
+
+    def test_invalid_slot_arg_returns_argparse_error(self, slot_env, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["trigger-tryboot", "Z", "--no-reboot"])
+        # argparse exits 2 on argument errors
+        assert exc.value.code == 2
+
+
+class TestPromoteVerb:
+    def test_promote_rewrites_all_section(self, slot_env, capsys):
+        rc = cli.main(["promote", "2"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "promoted slot 2 to default" in out
+        assert ab.read_autoboot(slot_env["autoboot"]).default_partition() == ab.PART_BOOT_B
+
+    def test_promote_writes_sentinel(self, slot_env):
+        cli.main(["promote", "1"])
+        sentinel = slot_env["data"] / "migration-allowed"
+        assert sentinel.exists()
+        assert "slot=1" in sentinel.read_text()
+
+
+class TestRecordStrikeVerb:
+    def test_strike_increments(self, slot_env, capsys):
+        rc = cli.main(["record-strike", "2"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "recorded strike for slot 2" in out
+        assert load_state().get_strikes(2) == 1
+
+    def test_strike_to_pin_then_tryboot_refused(self, slot_env, capsys, monkeypatch):
+        monkeypatch.setattr("slot_mgr.core._default_reboot", lambda: None)
+        for _ in range(STRIKE_LIMIT):
+            cli.main(["record-strike", "2"])
+        assert load_state().pinned is True
+
+        rc = cli.main(["trigger-tryboot", "2", "--no-reboot"])
+        # PinnedError exit code from cli.main
+        assert rc == 3
+
+
+class TestUnpinVerb:
+    def test_unpin_clears_state(self, slot_env, capsys):
+        for _ in range(STRIKE_LIMIT):
+            cli.main(["record-strike", "1"])
+        assert load_state().pinned is True
+
+        rc = cli.main(["unpin"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "unpinned" in out
+        assert load_state().pinned is False
+        assert load_state().strikes == {"1": 0, "2": 0}
+
+
+class TestNoVerb:
+    def test_missing_verb_errors(self, slot_env):
+        with pytest.raises(SystemExit) as exc:
+            cli.main([])
+        assert exc.value.code == 2

--- a/tests/test_slot_mgr_core.py
+++ b/tests/test_slot_mgr_core.py
@@ -1,0 +1,262 @@
+"""Unit tests for ``slot_mgr.core`` - the slot-state derivation, tryboot
+trigger, promote, strike, and unpin logic.
+
+All filesystem interactions point at tmp_path via the ``slot_env`` fixture so
+we never touch /boot/firmware or /data on the dev host.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from slot_mgr import autoboot as ab
+from slot_mgr import core
+from slot_mgr.state import STRIKE_LIMIT, load_state
+
+
+AUTOBOOT_A_DEFAULT = textwrap.dedent("""\
+    # autoboot.txt - managed by agora-slot-mgr
+
+    [all]
+    tryboot_a_b=1
+    boot_partition=1
+
+    [tryboot]
+    boot_partition=3
+""")
+
+AUTOBOOT_B_DEFAULT = textwrap.dedent("""\
+    # autoboot.txt - managed by agora-slot-mgr
+
+    [all]
+    tryboot_a_b=1
+    boot_partition=3
+
+    [tryboot]
+    boot_partition=1
+""")
+
+
+@pytest.fixture
+def slot_env(tmp_path, monkeypatch):
+    """Point every slot_mgr path at tmp_path and return the layout for assertions."""
+    boot_a = tmp_path / "boot-A"
+    boot_b = tmp_path / "boot-B"
+    data = tmp_path / "data"
+    proc = tmp_path / "proc"
+
+    boot_a.mkdir()
+    boot_b.mkdir()
+    data.mkdir()
+    proc.mkdir()
+
+    autoboot_a = boot_a / "autoboot.txt"
+    autoboot_b = boot_b / "autoboot.txt"
+    cmdline = proc / "cmdline"
+
+    autoboot_a.write_text(AUTOBOOT_A_DEFAULT)
+    autoboot_b.write_text(AUTOBOOT_A_DEFAULT)
+    cmdline.write_text(
+        "console=tty1 root=PARTLABEL=root-A rootfstype=ext4 rootwait\n"
+    )
+
+    monkeypatch.setenv("AGORA_AUTOBOOT_PATH", str(autoboot_a))
+    monkeypatch.setenv("AGORA_AUTOBOOT_MIRROR_PATH", str(autoboot_b))
+    monkeypatch.setenv("AGORA_SLOT_DATA_DIR", str(data))
+    monkeypatch.setenv("AGORA_PROC_CMDLINE", str(cmdline))
+
+    return {
+        "autoboot_a": autoboot_a,
+        "autoboot_b": autoboot_b,
+        "cmdline": cmdline,
+        "data": data,
+        "tmp_path": tmp_path,
+    }
+
+
+def _set_cmdline(env, slot_letter: str):
+    env["cmdline"].write_text(
+        f"console=tty1 root=PARTLABEL=root-{slot_letter} rootfstype=ext4 rootwait\n"
+    )
+
+
+def _set_autoboot_default_partition(env, partition: int):
+    parsed = ab.read_autoboot(env["autoboot_a"])
+    parsed.set_default_partition(partition)
+    ab.write_autoboot(parsed, env["autoboot_a"], mirrors=[env["autoboot_b"]])
+
+
+class TestSlotState:
+    def test_steady_state_on_slot_a(self, slot_env):
+        status = core.slot_state()
+        assert status.running_slot == 1
+        assert status.default_slot == 1
+        assert status.tentative is False
+        assert status.pinned is False
+        assert status.strikes == {1: 0, 2: 0}
+
+    def test_tentative_when_running_differs_from_default(self, slot_env):
+        # autoboot.txt still says boot from slot A, but we booted on B (tryboot)
+        _set_cmdline(slot_env, "B")
+        status = core.slot_state()
+        assert status.running_slot == 2
+        assert status.default_slot == 1
+        assert status.tentative is True
+
+    def test_no_tentative_when_cmdline_missing_partlabel(self, slot_env):
+        slot_env["cmdline"].write_text("console=tty1 root=/dev/mmcblk0p3 rootwait\n")
+        status = core.slot_state()
+        assert status.running_slot is None
+        assert status.tentative is False  # cannot derive tentative -> default False
+
+    def test_no_default_when_autoboot_missing(self, slot_env):
+        slot_env["autoboot_a"].unlink()
+        status = core.slot_state()
+        assert status.default_slot is None
+        assert status.tentative is False
+
+
+class TestTriggerTryboot:
+    def test_writes_tryboot_section_and_persists_state(self, slot_env):
+        reboot_called = []
+
+        def fake_reboot():
+            reboot_called.append(True)
+
+        state = core.trigger_tryboot(2, reboot_fn=fake_reboot)
+
+        # autoboot.txt now has [tryboot] boot_partition=3
+        parsed = ab.read_autoboot(slot_env["autoboot_a"])
+        assert parsed.tryboot_partition() == ab.PART_BOOT_B
+        # [all] unchanged - still slot A
+        assert parsed.default_partition() == ab.PART_BOOT_A
+
+        # Mirror updated
+        mirror_parsed = ab.read_autoboot(slot_env["autoboot_b"])
+        assert mirror_parsed.tryboot_partition() == ab.PART_BOOT_B
+
+        # State persisted
+        assert state.last_tryboot_target == 2
+        assert state.last_tryboot_at is not None
+        # Reboot was invoked
+        assert reboot_called == [True]
+
+    def test_no_reboot_kwarg_skips_reboot(self, slot_env):
+        reboot_called = []
+
+        def fake_reboot():
+            reboot_called.append(True)
+
+        core.trigger_tryboot(2, reboot=False, reboot_fn=fake_reboot)
+        assert reboot_called == []
+        # But state and autoboot.txt still updated
+        assert load_state().last_tryboot_target == 2
+
+    def test_refuses_when_pinned(self, slot_env):
+        # Force three strikes on slot 2 to trigger the pin
+        for _ in range(STRIKE_LIMIT):
+            core.record_tryboot_strike(2)
+
+        with pytest.raises(core.PinnedError):
+            core.trigger_tryboot(2, reboot=False)
+
+    def test_invalid_slot_rejected(self, slot_env):
+        with pytest.raises(core.InvalidSlotError):
+            core.trigger_tryboot(0, reboot=False)
+        with pytest.raises(core.InvalidSlotError):
+            core.trigger_tryboot(3, reboot=False)
+
+    def test_mirror_skipped_when_missing(self, slot_env, tmp_path, monkeypatch):
+        # Point mirror at a path whose parent dir doesn't exist
+        monkeypatch.setenv("AGORA_AUTOBOOT_MIRROR_PATH", str(tmp_path / "nope" / "autoboot.txt"))
+        # Should not raise - the mirror is best-effort
+        core.trigger_tryboot(2, reboot=False)
+        parsed = ab.read_autoboot(slot_env["autoboot_a"])
+        assert parsed.tryboot_partition() == ab.PART_BOOT_B
+
+
+class TestPromoteSlot:
+    def test_rewrites_all_section_and_resets_strikes(self, slot_env):
+        # Set up a tentative state: booted on B, strikes accumulated on B
+        _set_cmdline(slot_env, "B")
+        core.record_tryboot_strike(2)
+        core.record_tryboot_strike(2)
+        # Pre-promote: [all] still slot A
+        assert ab.read_autoboot(slot_env["autoboot_a"]).default_partition() == ab.PART_BOOT_A
+
+        state = core.promote_slot(2)
+
+        # [all] flipped to slot B's boot partition
+        parsed = ab.read_autoboot(slot_env["autoboot_a"])
+        assert parsed.default_partition() == ab.PART_BOOT_B
+        # [tryboot] now points at the OTHER slot so a future tryboot is well-formed
+        assert parsed.tryboot_partition() == ab.PART_BOOT_A
+
+        # Mirror updated
+        mirror_parsed = ab.read_autoboot(slot_env["autoboot_b"])
+        assert mirror_parsed.default_partition() == ab.PART_BOOT_B
+        assert mirror_parsed.tryboot_partition() == ab.PART_BOOT_A
+
+        # Strikes for the promoted slot reset; last_success_at set
+        assert state.get_strikes(2) == 0
+        assert state.last_success_at is not None
+        assert state.last_tryboot_target is None
+
+    def test_writes_migration_allowed_sentinel(self, slot_env):
+        core.promote_slot(2)
+        sentinel = slot_env["data"] / "migration-allowed"
+        assert sentinel.exists()
+        content = sentinel.read_text()
+        assert "slot=2" in content
+        assert "promoted_at=" in content
+
+    def test_invalid_slot_rejected(self, slot_env):
+        with pytest.raises(core.InvalidSlotError):
+            core.promote_slot(99)
+
+
+class TestRecordStrike:
+    def test_increments_per_slot(self, slot_env):
+        s1 = core.record_tryboot_strike(2)
+        assert s1.get_strikes(2) == 1
+        s2 = core.record_tryboot_strike(2)
+        assert s2.get_strikes(2) == 2
+        # Slot 1 untouched
+        assert s2.get_strikes(1) == 0
+
+    def test_pins_at_strike_limit(self, slot_env):
+        for _ in range(STRIKE_LIMIT - 1):
+            state = core.record_tryboot_strike(2)
+            assert state.pinned is False
+
+        state = core.record_tryboot_strike(2, reason="frame render hung")
+        assert state.pinned is True
+        assert state.pinned_at is not None
+        assert "frame render hung" in (state.pinned_reason or "")
+        assert state.get_strikes(2) == STRIKE_LIMIT
+
+    def test_invalid_slot_rejected(self, slot_env):
+        with pytest.raises(core.InvalidSlotError):
+            core.record_tryboot_strike(5)
+
+
+class TestUnpin:
+    def test_clears_pin_and_resets_strikes(self, slot_env):
+        for _ in range(STRIKE_LIMIT):
+            core.record_tryboot_strike(2)
+        assert load_state().pinned is True
+
+        state = core.unpin()
+        assert state.pinned is False
+        assert state.pinned_at is None
+        assert state.pinned_reason is None
+        assert state.strikes == {"1": 0, "2": 0}
+        assert state.last_tryboot_target is None
+        assert state.last_tryboot_at is None
+
+    def test_unpin_is_idempotent(self, slot_env):
+        core.unpin()
+        state = core.unpin()  # no-op
+        assert state.pinned is False

--- a/tests/test_slot_mgr_state.py
+++ b/tests/test_slot_mgr_state.py
@@ -1,0 +1,98 @@
+"""Unit tests for ``slot_mgr.state``: SlotState model + persistence."""
+
+from __future__ import annotations
+
+import json
+
+from slot_mgr.state import SCHEMA_VERSION, SlotState, load_state, save_state
+
+
+class TestSlotStateModel:
+    def test_defaults(self):
+        state = SlotState()
+        assert state.schema_version == SCHEMA_VERSION
+        assert state.strikes == {"1": 0, "2": 0}
+        assert state.last_tryboot_target is None
+        assert state.last_tryboot_at is None
+        assert state.last_success_at is None
+        assert state.pinned is False
+        assert state.pinned_reason is None
+
+    def test_get_set_strikes(self):
+        state = SlotState()
+        state.set_strikes(1, 2)
+        assert state.get_strikes(1) == 2
+        assert state.get_strikes(2) == 0
+        state.set_strikes(2, 1)
+        assert state.get_strikes(2) == 1
+
+    def test_extra_keys_ignored_on_load(self):
+        """A future schema-version with extra keys must round-trip through
+        a current-schema reader without raising."""
+        raw = json.dumps(
+            {
+                "schema_version": 1,
+                "strikes": {"1": 0, "2": 0},
+                "future_field": "ignored",
+            }
+        )
+        state = SlotState.model_validate_json(raw)
+        assert state.schema_version == 1
+
+
+class TestLoadSave:
+    def test_load_returns_default_when_file_missing(self, tmp_path):
+        missing = tmp_path / "does-not-exist.json"
+        state = load_state(missing)
+        assert state.strikes == {"1": 0, "2": 0}
+        assert not state.pinned
+
+    def test_load_returns_default_on_corrupt_json(self, tmp_path):
+        path = tmp_path / "slot-state.json"
+        path.write_text("not json")
+        state = load_state(path)
+        assert state.strikes == {"1": 0, "2": 0}
+
+    def test_save_then_load_round_trip(self, tmp_path):
+        path = tmp_path / "slot-state.json"
+        state = SlotState()
+        state.set_strikes(2, 1)
+        state.last_tryboot_target = 2
+        state.last_tryboot_at = "2026-05-13T03:32:00Z"
+        save_state(state, path)
+
+        reloaded = load_state(path)
+        assert reloaded.get_strikes(2) == 1
+        assert reloaded.last_tryboot_target == 2
+        assert reloaded.last_tryboot_at == "2026-05-13T03:32:00Z"
+
+    def test_save_is_atomic_uses_rename(self, tmp_path, monkeypatch):
+        """Verify save_state writes via a tempfile (no partial file on crash)."""
+        path = tmp_path / "slot-state.json"
+        # Pre-populate so we can verify it's not truncated during save.
+        path.write_text('{"schema_version": 1, "strikes": {"1": 5, "2": 5}}')
+
+        original_replace = __import__("os").replace
+        captured = []
+
+        def spying_replace(src, dst):
+            captured.append((str(src), str(dst)))
+            return original_replace(src, dst)
+
+        monkeypatch.setattr("os.replace", spying_replace)
+
+        state = SlotState()
+        state.set_strikes(1, 7)
+        save_state(state, path)
+
+        # The replace was used (atomic rename), and the temp file landed at
+        # the right path
+        assert any(dst == str(path) for _, dst in captured)
+        assert load_state(path).get_strikes(1) == 7
+
+    def test_save_creates_parent_directory(self, tmp_path):
+        """If /data/agora/ doesn't exist yet, save should create it."""
+        path = tmp_path / "new-subdir" / "slot-state.json"
+        state = SlotState()
+        save_state(state, path)
+        assert path.exists()


### PR DESCRIPTION
## What

Lands the first Phase 1 deliverable from the multi-replica OS-update plan: a Python package `slot_mgr` that owns A/B slot mechanics on-device, plus a thin `agora-slot-mgr` CLI wrapper that the rest of the system will drive.

Refs sslivins/agora-cms#544.

## Why

Everything else in Phase 1 (chaos harness, `agora-os-updater`, slot-confirm gate, three-strike pinning) needs a stable surface for the verbs "switch to the other slot", "promote this slot", "where am I and how many strikes do I have left". This PR is that surface.

## What's in the box

- `slot_mgr.autoboot` - parser + writer for `/boot/firmware/autoboot.txt` with mirror-write support so boot-A and boot-B stay byte-identical.
- `slot_mgr.state` - pydantic-v2 `SlotState` model. `SCHEMA_VERSION=1`, `STRIKE_LIMIT=3`. Persisted to `/data/agora/slot-state.json` via atomic write.
- `slot_mgr.core` - the verbs: `slot_state()`, `trigger_tryboot()`, `promote_slot()`, `record_tryboot_strike()`, `unpin()`, plus the ratified error hierarchy (`SlotMgrError` / `PinnedError` / `InvalidSlotError`). `promote_slot()` writes the `/data/agora/migration-allowed` sentinel that Phase 2's migration runner keys on.
- `slot_mgr.paths` - every path is env-var-overridable (`AGORA_AUTOBOOT_PATH`, `AGORA_AUTOBOOT_MIRROR_PATH`, `AGORA_SLOT_DATA_DIR`, `AGORA_PROC_CMDLINE`) so tests can redirect the module into a tmp tree.
- `slot_mgr.cli` - argparse front-end. Exit codes per the plan: 0 ok, 1 generic, 2 invalid-slot/argparse, 3 pinned.
- `packaging/cli-wrappers/agora-slot-mgr` - shell wrapper that execs `python3 -m slot_mgr` with the right `PYTHONPATH`. Deb build now generically installs everything under `packaging/cli-wrappers/` into `/usr/local/sbin/`, so future wrappers get the same treatment for free.

## Tests

53 unit tests across four files (`test_slot_mgr_autoboot.py`, `test_slot_mgr_state.py`, `test_slot_mgr_core.py`, `test_slot_mgr_cli.py`) - all green locally on both Linux and Windows. CI will run them as part of the existing pytest job.

One small platform gotcha worth flagging: `shared.state.atomic_write` opens its tempfile in text mode, so on Windows `\n` round-trips as `\r\n` on disk. The mirror-write test now asserts the real invariant (primary and mirror are byte-identical to each other) plus a parser round-trip, instead of comparing raw bytes against a Linux-LF sample. On the Pi 5 where the library actually runs this is moot.

## Not in this PR (followups in Phase 1)

- Chaos harness (`tools/chaos.sh`) - including the smart-plug subset, which depends on the smart-plug pick `p1-smart-plug-pick`.
- `agora-os-precheck` library.
- `agora-update-tester` package.
- Hardware-watchdog wiring at `/dev/watchdog0` (5s ping / 12s timeout).
- `agora-slot-mgr.service` systemd unit that runs slot-confirm after a tentative boot.

Each is its own `p1-*` todo and will be its own PR.
