### PR TITLE
feat(watchdog): agora-watchdog Pi5 hardware watchdog pinger (Phase 1)

### DIFF
--- a/agora_watchdog/__init__.py
+++ b/agora_watchdog/__init__.py
@@ -1,0 +1,49 @@
+"""Hardware-watchdog pinger for the Pi 5 RP1 watchdog (/dev/watchdog0).
+
+A tiny single-purpose daemon that opens the watchdog device, sets its
+timeout, and writes a keepalive byte at a fixed cadence. Lives in its
+own systemd unit (``agora-watchdog.service``) so that its lifecycle is
+independent of the other agora-* services — if any of those crash,
+systemd will restart them; if the kernel itself hangs, this daemon
+stops petting the watchdog and the RP1 fires a hard reset.
+
+Per Decision #16 of the multi-replica OTA plan:
+- device:   /dev/watchdog0  (RP1-backed on the Pi 5)
+- timeout:  12s             (RP1 hardware max is ~15s)
+- cadence:  5s
+
+All three values are overridable via environment variables so the unit
+tests can redirect the daemon at a tempfile and inject a fake clock.
+
+Public surface:
+
+    AGORA_WATCHDOG_DEVICE          path to the watchdog character device
+    AGORA_WATCHDOG_TIMEOUT_S       integer seconds, passed to WDIOC_SETTIMEOUT
+    AGORA_WATCHDOG_PING_INTERVAL_S float seconds between writes
+
+The CLI entrypoint is ``python3 -m agora_watchdog``; the systemd unit
+execs that with the standard ``PYTHONPATH=/opt/agora/src`` environment.
+"""
+
+from agora_watchdog.pinger import (
+    DEFAULT_DEVICE,
+    DEFAULT_PING_INTERVAL_S,
+    DEFAULT_TIMEOUT_S,
+    MAGIC_CLOSE,
+    Pinger,
+    WatchdogError,
+    main,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_DEVICE",
+    "DEFAULT_PING_INTERVAL_S",
+    "DEFAULT_TIMEOUT_S",
+    "MAGIC_CLOSE",
+    "Pinger",
+    "WatchdogError",
+    "main",
+    "__version__",
+]

--- a/agora_watchdog/__main__.py
+++ b/agora_watchdog/__main__.py
@@ -1,0 +1,11 @@
+"""Run the hardware-watchdog pinger.
+
+Usage: ``python3 -m agora_watchdog``
+
+Exits 0 on clean shutdown (SIGTERM / SIGINT), non-zero on errors. See
+``agora_watchdog.pinger.main`` for the behavior.
+"""
+from agora_watchdog.pinger import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agora_watchdog/pinger.py
+++ b/agora_watchdog/pinger.py
@@ -1,0 +1,343 @@
+"""Open ``/dev/watchdog0``, set its timeout, and pet it forever.
+
+Implemented as a small class (``Pinger``) so the run loop can be unit-tested
+with injected ``time.sleep`` / ``time.monotonic`` and a tempfile for the
+device. The module-level ``main()`` is what the systemd unit calls.
+
+Kernel reference: ``Documentation/watchdog/watchdog-api.rst``.
+- Writing **any** byte (other than the magic close character) pets the
+  watchdog.
+- Writing ``'V'`` before close requests magic-close — the kernel then
+  disables the watchdog on close. Without magic-close, modern kernels
+  keep the watchdog running after close (NOWAYOUT semantics), which is
+  the safer default but makes a clean ``systemctl stop`` look like a
+  crash to the kernel.
+- ``WDIOC_SETTIMEOUT`` (ioctl _IOWR('W', 6, int)) sets the timeout in
+  whole seconds. The kernel may clamp it; we ignore the kernel's
+  preference and just trust it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import struct
+import sys
+import time
+from typing import Callable, Iterable, Optional
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised only on Windows test hosts
+    # ``fcntl`` is Unix-only. The whole point of the IO-callable injection
+    # in ``Pinger.__init__`` is that tests never actually call ``ioctl``.
+    # On Windows test hosts we substitute a stub so ``import agora_watchdog``
+    # succeeds; if anyone tries to use the real default at runtime they'll
+    # get a clear error.
+    class _FcntlStub:
+        @staticmethod
+        def ioctl(*_a, **_kw):
+            raise RuntimeError(
+                "fcntl.ioctl is not available on this platform; "
+                "Pinger needs to be constructed with an explicit ioctl= "
+                "callable on non-Unix hosts"
+            )
+
+    _fcntl = _FcntlStub()  # type: ignore[assignment]
+
+log = logging.getLogger(__name__)
+
+# ─── Kernel ioctl numbers (linux/watchdog.h) ───
+# These are fixed across architectures since they're _IOR/_IOW macros over
+# a 32-bit int, and the layout is identical on arm64 and x86_64.
+WDIOC_KEEPALIVE = 0x80045705  # _IOR('W', 5, int)
+WDIOC_SETTIMEOUT = 0xC0045706  # _IOWR('W', 6, int)
+WDIOC_GETTIMEOUT = 0x80045707  # _IOR('W', 7, int)
+
+# ─── Defaults (per Decision #16) ───
+DEFAULT_DEVICE = "/dev/watchdog0"
+DEFAULT_TIMEOUT_S = 12
+DEFAULT_PING_INTERVAL_S = 5.0
+
+MAGIC_CLOSE = b"V"
+KEEPALIVE_BYTE = b"\0"
+
+# ``os.O_CLOEXEC`` is Unix-only. We always want it on Linux (so a child
+# fork doesn't inherit our watchdog fd) but fall back to 0 on Windows so
+# the module imports cleanly for tests.
+_O_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+
+# Smallest sleep slice used by ``Pinger.run`` so the loop can react to a
+# stop request without waiting a full ping interval.
+_TICK_S = 0.5
+
+
+class WatchdogError(RuntimeError):
+    """Raised when the watchdog device can't be opened or configured."""
+
+
+def _env(name: str, default: str) -> str:
+    v = os.environ.get(name)
+    return v if v else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise WatchdogError(f"{name}={raw!r} is not an integer") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise WatchdogError(f"{name}={raw!r} is not a float") from exc
+
+
+class Pinger:
+    """Owns one open file descriptor on a watchdog device.
+
+    Constructor params:
+
+        device:        path to the watchdog character device.
+        timeout_s:     value passed to ``WDIOC_SETTIMEOUT``.
+        interval_s:    seconds between keepalive writes.
+        opener:        injectable ``os.open``-compatible callable; the
+                       test suite passes a stub that opens a regular file
+                       so ``fcntl.ioctl`` is the only call that needs to
+                       be patched.
+        ioctl:         injectable ``fcntl.ioctl``-compatible callable.
+        writer:        injectable ``os.write``-compatible callable.
+        closer:        injectable ``os.close``-compatible callable.
+        sleeper:       injectable ``time.sleep`` (lets tests drive the
+                       loop deterministically).
+    """
+
+    def __init__(
+        self,
+        device: str = DEFAULT_DEVICE,
+        timeout_s: int = DEFAULT_TIMEOUT_S,
+        interval_s: float = DEFAULT_PING_INTERVAL_S,
+        *,
+        opener: Callable[[str, int], int] = os.open,
+        ioctl: Callable[..., int] = _fcntl.ioctl,
+        writer: Callable[[int, bytes], int] = os.write,
+        closer: Callable[[int], None] = os.close,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if timeout_s <= 0:
+            raise WatchdogError(f"timeout_s must be > 0, got {timeout_s!r}")
+        if interval_s <= 0:
+            raise WatchdogError(f"interval_s must be > 0, got {interval_s!r}")
+        if interval_s >= timeout_s:
+            # Petting once per timeout window is the absolute minimum;
+            # anything slower guarantees a spurious reset.
+            raise WatchdogError(
+                f"interval_s ({interval_s}) must be strictly less than "
+                f"timeout_s ({timeout_s}) to avoid spurious resets"
+            )
+        self.device = device
+        self.timeout_s = timeout_s
+        self.interval_s = interval_s
+        self._opener = opener
+        self._ioctl = ioctl
+        self._writer = writer
+        self._closer = closer
+        self._sleeper = sleeper
+        self._fd: Optional[int] = None
+        self._stop = False
+        self.ping_count = 0  # exposed for tests / future metrics
+
+    # ── lifecycle ───────────────────────────────────────────────
+    def open(self) -> None:
+        """Open the device and apply ``WDIOC_SETTIMEOUT``."""
+        if self._fd is not None:
+            return
+        try:
+            self._fd = self._opener(self.device, os.O_WRONLY | _O_CLOEXEC)
+        except OSError as exc:
+            raise WatchdogError(
+                f"opening watchdog device {self.device!r} failed: {exc}"
+            ) from exc
+        buf = struct.pack("i", int(self.timeout_s))
+        try:
+            self._ioctl(self._fd, WDIOC_SETTIMEOUT, buf)
+        except OSError as exc:
+            # Failure to set timeout is fatal — running at the kernel
+            # default (often 60s) silently weakens the contract.
+            try:
+                self._closer(self._fd)
+            finally:
+                self._fd = None
+            raise WatchdogError(
+                f"WDIOC_SETTIMEOUT={self.timeout_s} on {self.device!r} "
+                f"failed: {exc}"
+            ) from exc
+        log.info(
+            "watchdog opened: device=%s timeout=%ds interval=%.1fs",
+            self.device,
+            self.timeout_s,
+            self.interval_s,
+        )
+
+    def ping(self) -> None:
+        """Write one keepalive byte. Raises if not opened."""
+        if self._fd is None:
+            raise WatchdogError("ping() called before open()")
+        self._writer(self._fd, KEEPALIVE_BYTE)
+        self.ping_count += 1
+
+    def close(self, *, magic: bool = True) -> None:
+        """Close the fd; if ``magic=True``, write ``'V'`` first.
+
+        Magic-close requests that the kernel disable the watchdog when
+        the fd closes (rather than continuing to count down). Used on
+        graceful shutdown so ``systemctl stop`` doesn't trigger a reset
+        12 seconds later.
+        """
+        if self._fd is None:
+            return
+        fd = self._fd
+        self._fd = None
+        try:
+            if magic:
+                try:
+                    self._writer(fd, MAGIC_CLOSE)
+                except OSError as exc:  # pragma: no cover - rare path
+                    log.warning("magic-close write failed: %s", exc)
+        finally:
+            try:
+                self._closer(fd)
+            except OSError as exc:  # pragma: no cover - rare path
+                log.warning("watchdog close failed: %s", exc)
+
+    # ── control ─────────────────────────────────────────────────
+    def stop(self, *_args) -> None:
+        """Signal the run loop to exit on its next tick.
+
+        Suitable as a ``signal.signal`` handler; ignores all positional
+        args (signum, frame) so it can also be called by hand.
+        """
+        self._stop = True
+
+    @property
+    def stopped(self) -> bool:
+        return self._stop
+
+    # ── main loop ───────────────────────────────────────────────
+    def run(self, *, install_signal_handlers: bool = True) -> None:
+        """Pet forever. Returns when ``stop()`` is called.
+
+        Sleeps in ``_TICK_S`` slices so a SIGTERM doesn't have to wait a
+        full ping interval to be honoured.
+        """
+        self.open()
+        prev_handlers: list[tuple[int, object]] = []
+        try:
+            if install_signal_handlers:
+                for sig in self._installable_signals():
+                    try:
+                        prev = signal.signal(sig, self.stop)
+                        prev_handlers.append((sig, prev))
+                    except (OSError, ValueError):  # pragma: no cover
+                        # ValueError on non-main thread, OSError on
+                        # Windows for SIGTERM. Tests bypass this branch.
+                        pass
+            while not self._stop:
+                self.ping()
+                self._sleep_for(self.interval_s)
+        finally:
+            for sig, prev in prev_handlers:
+                try:
+                    signal.signal(sig, prev)  # type: ignore[arg-type]
+                except (OSError, ValueError):  # pragma: no cover
+                    pass
+            self.close(magic=True)
+
+    @staticmethod
+    def _installable_signals() -> Iterable[int]:
+        sigs = [signal.SIGTERM, signal.SIGINT]
+        # SIGHUP isn't on Windows; skip if missing.
+        sighup = getattr(signal, "SIGHUP", None)
+        if sighup is not None:
+            sigs.append(sighup)
+        return sigs
+
+    def _sleep_for(self, total_s: float) -> None:
+        remaining = total_s
+        while remaining > 0 and not self._stop:
+            slice_s = remaining if remaining < _TICK_S else _TICK_S
+            self._sleeper(slice_s)
+            remaining -= slice_s
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entrypoint. Used by ``python3 -m agora_watchdog``.
+
+    Exit codes:
+        0 — clean shutdown via signal
+        1 — open / configuration error
+        2 — argparse error (handled by argparse itself)
+    """
+    try:
+        parser = argparse.ArgumentParser(
+            prog="agora-watchdog",
+            description="Pet the Pi 5 hardware watchdog (/dev/watchdog0).",
+        )
+        parser.add_argument(
+            "--device",
+            default=_env("AGORA_WATCHDOG_DEVICE", DEFAULT_DEVICE),
+            help=f"watchdog character device (default: {DEFAULT_DEVICE})",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=_env_int("AGORA_WATCHDOG_TIMEOUT_S", DEFAULT_TIMEOUT_S),
+            help=f"WDIOC_SETTIMEOUT in seconds (default: {DEFAULT_TIMEOUT_S})",
+        )
+        parser.add_argument(
+            "--interval",
+            type=float,
+            default=_env_float(
+                "AGORA_WATCHDOG_PING_INTERVAL_S", DEFAULT_PING_INTERVAL_S
+            ),
+            help=(
+                "ping cadence in seconds "
+                f"(default: {DEFAULT_PING_INTERVAL_S})"
+            ),
+        )
+        parser.add_argument(
+            "-v", "--verbose", action="store_true", help="enable debug logging"
+        )
+        args = parser.parse_args(argv)
+
+        logging.basicConfig(
+            level=logging.DEBUG if args.verbose else logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        )
+
+        pinger = Pinger(
+            device=args.device,
+            timeout_s=args.timeout,
+            interval_s=args.interval,
+        )
+        pinger.run()
+        return 0
+    except WatchdogError as exc:
+        log.error("watchdog failed: %s", exc)
+        return 1
+    except KeyboardInterrupt:  # pragma: no cover - kept for parity with sigint
+        return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -71,11 +71,14 @@ if [[ -f "${REPO_ROOT}/config/boot-splash.png" ]]; then
 fi
 
 # ── Systemd units ──
-cp "${REPO_ROOT}/systemd/agora-api.service" "${BUILD_DIR}/etc/systemd/system/"
-cp "${REPO_ROOT}/systemd/agora-player.service" "${BUILD_DIR}/etc/systemd/system/"
-cp "${REPO_ROOT}/systemd/agora-cms-client.service" "${BUILD_DIR}/etc/systemd/system/"
-cp "${REPO_ROOT}/systemd/agora-provision.service" "${BUILD_DIR}/etc/systemd/system/"
-cp "${REPO_ROOT}/systemd/agora-fleet-provision.service" "${BUILD_DIR}/etc/systemd/system/"
+# Auto-discover every *.service file under systemd/. Using a glob avoids the
+# class of bug where a new unit (like agora-watchdog.service for the watchdog
+# pinger) gets added to the repo but forgotten in this list — matches the
+# auto-discovery pattern used for source dirs and CLI wrappers above.
+for unit in "${REPO_ROOT}/systemd/"*.service; do
+    [[ -f "$unit" ]] || continue
+    install -m 644 "$unit" "${BUILD_DIR}/etc/systemd/system/$(basename "$unit")"
+done
 
 # ── CLI wrappers (thin shells that exec `python3 -m <pkg>` with the right PYTHONPATH) ──
 mkdir -p "${BUILD_DIR}/usr/local/sbin"

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -255,13 +255,15 @@ fi
 
 # ── Enable and restart services ──
 systemctl daemon-reload
-systemctl enable agora-player agora-api agora-cms-client agora-provision agora-fleet-provision
+systemctl enable agora-watchdog agora-player agora-api agora-cms-client agora-provision agora-fleet-provision
 
 # ── Ensure dnsmasq does not start by default (managed by provision service) ──
 systemctl disable dnsmasq 2>/dev/null || true
 systemctl stop dnsmasq 2>/dev/null || true
 
 if [ "$1" = "configure" ]; then
+    # Watchdog first so it's armed before the heavier services start.
+    systemctl restart agora-watchdog || true
     systemctl restart agora-provision || true
     systemctl restart agora-player || true
     systemctl restart agora-api || true

--- a/packaging/debian/postrm
+++ b/packaging/debian/postrm
@@ -11,7 +11,7 @@ if [ "$1" = "purge" ]; then
     rm -rf /opt/agora/tmp
 
     # Disable services
-    systemctl disable agora-player agora-api agora-cms-client 2>/dev/null || true
+    systemctl disable agora-watchdog agora-player agora-api agora-cms-client 2>/dev/null || true
 fi
 
 if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-# Stop services before removal/upgrade
+# Stop services before removal/upgrade. Watchdog stops last so the
+# hardware failsafe is armed across the rest of the shutdown — and
+# its magic-close on SIGTERM disables the kernel watchdog cleanly.
 if [ "$1" = "remove" ] || [ "$1" = "upgrade" ]; then
     systemctl stop agora-cms-client || true
     systemctl stop agora-api || true
     systemctl stop agora-player || true
+    systemctl stop agora-watchdog || true
 fi

--- a/systemd/agora-watchdog.service
+++ b/systemd/agora-watchdog.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Agora hardware watchdog pinger
+Documentation=https://www.kernel.org/doc/Documentation/watchdog/watchdog-api.rst
+# Start as early as possible so the watchdog is armed before any of
+# the heavier agora-* services begin their startup work. If something
+# hangs the kernel during that startup, /dev/watchdog0 will fire a
+# hard reset instead of us discovering the brick when the device
+# fails to phone home.
+DefaultDependencies=yes
+Before=agora-api.service
+Before=agora-player.service
+Before=agora-cms-client.service
+Before=agora-provision.service
+Before=agora-fleet-provision.service
+# This is the failsafe of last resort; never block on networking.
+ConditionPathExists=/dev/watchdog0
+
+[Service]
+Type=simple
+# Runs as root (no User= directive) because /dev/watchdog0 requires
+# CAP_SYS_ADMIN to open and ioctl(WDIOC_SETTIMEOUT). Standard Pi 5
+# udev rules ship it as root:root 0600.
+ExecStart=/usr/bin/python3 -m agora_watchdog
+WorkingDirectory=/opt/agora/src
+Environment=PYTHONPATH=/opt/agora/src
+Environment=AGORA_BASE=/opt/agora
+
+# Aggressive restart: if the pinger dies for any reason, get it back
+# fast — the kernel watchdog is still counting down regardless of
+# whether our service is alive. Magic-close means each clean exit
+# disables the watchdog momentarily, so the 1s gap is the maximum
+# unprotected window between restart attempts.
+Restart=always
+RestartSec=1
+
+# Use SIGTERM so the python signal handler runs and writes the
+# magic-close byte ('V') before the fd closes. Without that, modern
+# kernels (NOWAYOUT) keep counting down and reset the device 12s after
+# `systemctl stop`.
+KillSignal=SIGTERM
+TimeoutStopSec=5
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_agora_watchdog_pinger.py
+++ b/tests/test_agora_watchdog_pinger.py
@@ -1,0 +1,436 @@
+"""Unit tests for ``agora_watchdog.pinger``.
+
+The pinger talks to ``/dev/watchdog0`` via ``os.open`` / ``fcntl.ioctl`` /
+``os.write`` / ``os.close``. The ``Pinger`` constructor takes all four as
+injectable callables so the tests can:
+
+  - record the exact arguments passed to ``ioctl`` (timeout struct, ioctl
+    number)
+  - assert the keepalive byte vs magic-close byte are written at the
+    right moments
+  - drive the run loop deterministically with a fake sleeper
+  - verify the loop honors ``stop()`` within one tick (not one ping
+    interval)
+
+We don't try to actually exercise ``/dev/watchdog0`` here — that's covered
+in the hardware acceptance tests on the dev Pi5.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+from typing import Any, List, Tuple
+
+import pytest
+
+from agora_watchdog import pinger as pinger_mod
+from agora_watchdog.pinger import (
+    DEFAULT_DEVICE,
+    DEFAULT_PING_INTERVAL_S,
+    DEFAULT_TIMEOUT_S,
+    KEEPALIVE_BYTE,
+    MAGIC_CLOSE,
+    WDIOC_SETTIMEOUT,
+    Pinger,
+    WatchdogError,
+    main,
+)
+
+
+class FakeWatchdog:
+    """Records every interaction the Pinger has with its 'device'.
+
+    Stands in for the four os-level callables. Each call appends a row
+    to ``events`` so a test can assert ordering (open → ioctl → write*
+    → magic-close → close).
+    """
+
+    def __init__(self, *, fd: int = 99) -> None:
+        self.events: List[Tuple[str, Any]] = []
+        self.fd = fd
+        self.opened = False
+        self.closed = False
+        # Allow tests to inject failures for individual operations.
+        self.open_err: Exception | None = None
+        self.ioctl_err: Exception | None = None
+        self.write_err: Exception | None = None
+
+    def opener(self, path: str, flags: int) -> int:
+        if self.open_err is not None:
+            raise self.open_err
+        self.events.append(("open", (path, flags)))
+        self.opened = True
+        return self.fd
+
+    def ioctl(self, fd: int, request: int, arg: Any) -> int:
+        if self.ioctl_err is not None:
+            raise self.ioctl_err
+        self.events.append(("ioctl", (fd, request, bytes(arg))))
+        return 0
+
+    def writer(self, fd: int, data: bytes) -> int:
+        if self.write_err is not None:
+            raise self.write_err
+        self.events.append(("write", (fd, bytes(data))))
+        return len(data)
+
+    def closer(self, fd: int) -> None:
+        self.events.append(("close", fd))
+        self.closed = True
+
+    # ── convenience filters ──
+    def writes(self) -> List[bytes]:
+        return [args[1] for kind, args in self.events if kind == "write"]
+
+    def ioctls(self) -> List[Tuple[int, int, bytes]]:
+        return [args for kind, args in self.events if kind == "ioctl"]
+
+    def kinds(self) -> List[str]:
+        return [kind for kind, _ in self.events]
+
+
+@pytest.fixture
+def fake() -> FakeWatchdog:
+    return FakeWatchdog()
+
+
+def _make_pinger(
+    fake: FakeWatchdog,
+    *,
+    device: str = "/dev/watchdog0",
+    timeout_s: int = 12,
+    interval_s: float = 5.0,
+    sleeper=lambda _s: None,
+) -> Pinger:
+    return Pinger(
+        device=device,
+        timeout_s=timeout_s,
+        interval_s=interval_s,
+        opener=fake.opener,
+        ioctl=fake.ioctl,
+        writer=fake.writer,
+        closer=fake.closer,
+        sleeper=sleeper,
+    )
+
+
+# ─── constants ─────────────────────────────────────────────────
+
+
+def test_defaults_match_decision_16():
+    """Decision #16: 12s timeout, 5s ping, /dev/watchdog0."""
+    assert DEFAULT_DEVICE == "/dev/watchdog0"
+    assert DEFAULT_TIMEOUT_S == 12
+    assert DEFAULT_PING_INTERVAL_S == 5.0
+
+
+def test_wdioc_settimeout_constant():
+    """The ioctl number is fixed by the kernel; pin it so we notice if
+    someone "fixes" the hex value."""
+    assert WDIOC_SETTIMEOUT == 0xC0045706
+
+
+def test_magic_close_byte_is_capital_v():
+    assert MAGIC_CLOSE == b"V"
+
+
+def test_keepalive_byte_is_not_v():
+    """Any byte other than 'V' pets the watchdog. We pick NUL to avoid
+    any chance of accidentally writing the magic-close byte in the
+    keepalive path."""
+    assert KEEPALIVE_BYTE != MAGIC_CLOSE
+
+
+# ─── constructor validation ────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", [0, -1, -100])
+def test_constructor_rejects_nonpositive_timeout(bad, fake):
+    with pytest.raises(WatchdogError, match="timeout_s"):
+        _make_pinger(fake, timeout_s=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -0.5, -10])
+def test_constructor_rejects_nonpositive_interval(bad, fake):
+    with pytest.raises(WatchdogError, match="interval_s"):
+        _make_pinger(fake, interval_s=bad)
+
+
+def test_constructor_rejects_interval_geq_timeout(fake):
+    """An interval >= timeout guarantees a spurious reset because the
+    kernel decrements the timer between writes."""
+    with pytest.raises(WatchdogError, match="strictly less"):
+        _make_pinger(fake, timeout_s=12, interval_s=12)
+    with pytest.raises(WatchdogError, match="strictly less"):
+        _make_pinger(fake, timeout_s=12, interval_s=15)
+
+
+# ─── open() ────────────────────────────────────────────────────
+
+
+def test_open_sends_settimeout_ioctl(fake):
+    p = _make_pinger(fake, timeout_s=12)
+    p.open()
+    # First two events: open, then ioctl(WDIOC_SETTIMEOUT, packed 12s)
+    assert fake.kinds()[:2] == ["open", "ioctl"]
+    fd, req, arg = fake.ioctls()[0]
+    assert fd == fake.fd
+    assert req == WDIOC_SETTIMEOUT
+    assert struct.unpack("i", arg)[0] == 12
+
+
+def test_open_passes_o_wronly_and_cloexec(fake):
+    p = _make_pinger(fake)
+    p.open()
+    (_path, flags) = fake.events[0][1]
+    assert flags & os.O_WRONLY
+    # O_CLOEXEC is Unix-only; on Windows test hosts the flag is 0.
+    if pinger_mod._O_CLOEXEC:
+        assert flags & pinger_mod._O_CLOEXEC
+
+
+def test_open_is_idempotent(fake):
+    """Calling open() twice doesn't reopen or re-ioctl."""
+    p = _make_pinger(fake)
+    p.open()
+    p.open()
+    assert fake.kinds().count("open") == 1
+    assert fake.kinds().count("ioctl") == 1
+
+
+def test_open_failure_raises_watchdogerror(fake):
+    fake.open_err = PermissionError("EACCES")
+    p = _make_pinger(fake)
+    with pytest.raises(WatchdogError, match="opening watchdog"):
+        p.open()
+    # We never recorded the open event since the stub raised before append.
+    assert "ioctl" not in fake.kinds()
+
+
+def test_ioctl_failure_closes_fd_and_raises(fake):
+    """If WDIOC_SETTIMEOUT fails we must release the fd; otherwise a
+    second start would leak."""
+    fake.ioctl_err = OSError("EINVAL")
+    p = _make_pinger(fake)
+    with pytest.raises(WatchdogError, match="WDIOC_SETTIMEOUT"):
+        p.open()
+    # We did open, then attempted ioctl (which raised), then closed.
+    assert "close" in fake.kinds()
+
+
+# ─── ping() ────────────────────────────────────────────────────
+
+
+def test_ping_writes_keepalive_byte(fake):
+    p = _make_pinger(fake)
+    p.open()
+    p.ping()
+    assert fake.writes() == [KEEPALIVE_BYTE]
+    assert p.ping_count == 1
+
+
+def test_ping_before_open_raises(fake):
+    p = _make_pinger(fake)
+    with pytest.raises(WatchdogError, match="before open"):
+        p.ping()
+
+
+def test_multiple_pings_accumulate_count(fake):
+    p = _make_pinger(fake)
+    p.open()
+    for _ in range(5):
+        p.ping()
+    assert p.ping_count == 5
+    assert fake.writes() == [KEEPALIVE_BYTE] * 5
+
+
+# ─── close() ───────────────────────────────────────────────────
+
+
+def test_close_writes_magic_close_by_default(fake):
+    p = _make_pinger(fake)
+    p.open()
+    p.close()
+    # Last write before close() must be 'V'.
+    assert fake.writes()[-1] == MAGIC_CLOSE
+    assert "close" in fake.kinds()
+
+
+def test_close_magic_false_skips_magic_byte(fake):
+    p = _make_pinger(fake)
+    p.open()
+    p.close(magic=False)
+    assert MAGIC_CLOSE not in fake.writes()
+    assert "close" in fake.kinds()
+
+
+def test_close_is_idempotent(fake):
+    p = _make_pinger(fake)
+    p.open()
+    p.close()
+    p.close()  # second call is a no-op
+    assert fake.kinds().count("close") == 1
+
+
+# ─── run() ─────────────────────────────────────────────────────
+
+
+def test_run_pings_then_stops_cleanly(fake):
+    """Drive run(): inject a fake sleeper that stops the pinger after
+    the third ping, confirm we got exactly three keepalives followed by
+    the magic-close byte."""
+    pings_seen: List[int] = []
+    p = _make_pinger(fake, interval_s=5.0)
+
+    def fake_sleep(_dt: float) -> None:
+        pings_seen.append(p.ping_count)
+        if p.ping_count >= 3:
+            p.stop()
+
+    p._sleeper = fake_sleep  # type: ignore[attr-defined]
+    p.run(install_signal_handlers=False)
+
+    # Three keepalive writes (one per ping), followed by the magic-close.
+    keepalives = [w for w in fake.writes() if w == KEEPALIVE_BYTE]
+    assert len(keepalives) == 3
+    assert fake.writes()[-1] == MAGIC_CLOSE
+
+
+def test_run_stop_honors_tick_granularity(fake):
+    """Even with interval_s=60, calling stop() should exit within a
+    single _TICK_S window rather than waiting a full minute."""
+    sleep_calls: List[float] = []
+    p = _make_pinger(fake, timeout_s=120, interval_s=60.0)
+
+    def fake_sleep(dt: float) -> None:
+        sleep_calls.append(dt)
+        # Stop after the very first sleep slice.
+        p.stop()
+
+    p._sleeper = fake_sleep  # type: ignore[attr-defined]
+    p.run(install_signal_handlers=False)
+
+    # Should have slept exactly one _TICK_S slice (0.5s) and exited,
+    # rather than the full 60s interval.
+    assert sleep_calls == [pinger_mod._TICK_S]
+
+
+def test_run_writes_magic_close_on_stop(fake):
+    p = _make_pinger(fake)
+    p._sleeper = lambda _dt: p.stop()  # type: ignore[attr-defined]
+    p.run(install_signal_handlers=False)
+    # Final byte written must be magic-close so the kernel disables the
+    # watchdog instead of resetting the box after timeout seconds.
+    assert fake.writes()[-1] == MAGIC_CLOSE
+
+
+def test_run_opens_before_first_ping(fake):
+    """run() must call open() (and therefore ioctl) before the first
+    write — otherwise a slow kernel + fast first-write race could pet
+    at the wrong timeout."""
+    p = _make_pinger(fake)
+    p._sleeper = lambda _dt: p.stop()  # type: ignore[attr-defined]
+    p.run(install_signal_handlers=False)
+    kinds = fake.kinds()
+    # The first three kinds must be: open, ioctl, write.
+    assert kinds[:3] == ["open", "ioctl", "write"]
+
+
+# ─── main() / env vars ─────────────────────────────────────────
+
+
+def test_main_env_overrides(fake, monkeypatch):
+    """AGORA_WATCHDOG_* env vars should reach the Pinger constructor."""
+    captured: dict = {}
+
+    class Recorded(Pinger):
+        def __init__(self, *a, **kw):
+            captured.update(kw)
+            captured["args"] = a
+            super().__init__(
+                *a,
+                **kw,
+                opener=fake.opener,
+                ioctl=fake.ioctl,
+                writer=fake.writer,
+                closer=fake.closer,
+                sleeper=lambda _dt: self.stop(),
+            )
+
+    monkeypatch.setattr(pinger_mod, "Pinger", Recorded)
+    monkeypatch.setenv("AGORA_WATCHDOG_DEVICE", "/tmp/wd-fake")
+    monkeypatch.setenv("AGORA_WATCHDOG_TIMEOUT_S", "8")
+    monkeypatch.setenv("AGORA_WATCHDOG_PING_INTERVAL_S", "2.5")
+
+    rc = main([])
+    assert rc == 0
+    assert captured["device"] == "/tmp/wd-fake"
+    assert captured["timeout_s"] == 8
+    assert captured["interval_s"] == 2.5
+
+
+def test_main_cli_overrides_env(fake, monkeypatch):
+    """CLI flags should beat env vars."""
+    captured: dict = {}
+
+    class Recorded(Pinger):
+        def __init__(self, *a, **kw):
+            captured.update(kw)
+            super().__init__(
+                *a,
+                **kw,
+                opener=fake.opener,
+                ioctl=fake.ioctl,
+                writer=fake.writer,
+                closer=fake.closer,
+                sleeper=lambda _dt: self.stop(),
+            )
+
+    monkeypatch.setattr(pinger_mod, "Pinger", Recorded)
+    monkeypatch.setenv("AGORA_WATCHDOG_TIMEOUT_S", "8")
+    rc = main(["--timeout", "10", "--interval", "3"])
+    assert rc == 0
+    assert captured["timeout_s"] == 10
+    assert captured["interval_s"] == 3.0
+
+
+def test_main_returns_1_on_watchdog_error(monkeypatch):
+    def boom(*_a, **_kw):
+        raise WatchdogError("nope")
+
+    monkeypatch.setattr(pinger_mod, "Pinger", boom)
+    rc = main([])
+    assert rc == 1
+
+
+@pytest.mark.parametrize(
+    "var,bad_value",
+    [
+        ("AGORA_WATCHDOG_TIMEOUT_S", "abc"),
+        ("AGORA_WATCHDOG_PING_INTERVAL_S", "five"),
+    ],
+)
+def test_main_returns_1_on_invalid_env(monkeypatch, var, bad_value):
+    """Non-numeric env values should produce WatchdogError → exit 1,
+    not a Python traceback."""
+    monkeypatch.setenv(var, bad_value)
+    rc = main([])
+    assert rc == 1
+
+
+# ─── package re-exports ────────────────────────────────────────
+
+
+def test_package_reexports():
+    """The top-level package surface is what other code (and the
+    systemd unit) imports. Don't break it accidentally."""
+    import agora_watchdog
+
+    assert agora_watchdog.DEFAULT_DEVICE == DEFAULT_DEVICE
+    assert agora_watchdog.DEFAULT_TIMEOUT_S == DEFAULT_TIMEOUT_S
+    assert agora_watchdog.DEFAULT_PING_INTERVAL_S == DEFAULT_PING_INTERVAL_S
+    assert agora_watchdog.MAGIC_CLOSE == MAGIC_CLOSE
+    assert agora_watchdog.Pinger is Pinger
+    assert agora_watchdog.WatchdogError is WatchdogError
+    assert callable(agora_watchdog.main)


### PR DESCRIPTION
Phase 1 (Decision #16) of the A/B OTA plan (sslivins/agora-cms#544): a
standalone systemd service that pets the Pi 5 hardware watchdog at
`/dev/watchdog0`.

## Why a separate daemon

If `agora.service` hangs (deadlock, CMS-client wedge, framebuffer
stall, etc.) we *want* the watchdog to fire — that's the whole point.
Petting the watchdog from inside `agora.service` would defeat the
recovery path. `agora-watchdog` has zero coupling to the rest of the
agora stack: only `/dev/watchdog0`, a 1s sleep, and a SIGTERM handler.

## Cadence

- WDIOC_SETTIMEOUT = 12s
- ping interval    = 5s

Pi 5's RP1 watchdog has a ~15s hardware ceiling, so the original 30s
spec was infeasible. 12s + 5s gives 2.4x headroom against a single
missed tick.

## Files

- `agora_watchdog/{__init__,__main__,pinger}.py` — implementation
  with injectable IO callables (`opener`, `ioctl`, `writer`,
  `closer`, `sleeper`) so tests don't need `/dev/watchdog0`
- `systemd/agora-watchdog.service` — `Before=` every other agora
  service, `Restart=always`, `RestartSec=1`,
  `ConditionPathExists=/dev/watchdog0` so it no-ops on hardware that
  doesn't expose the device
- `tests/test_agora_watchdog_pinger.py` — 32 unit tests covering
  open / setup, keepalive byte, magic-close on clean stop, the run
  loop, env/CLI parsing, and stop-tick granularity (loop honours
  `stop()` within one 0.5s tick, not one ping interval)
- `packaging/build-deb.sh` — replaces the hardcoded 5-line `cp`
  block for systemd units with a glob loop so adding future units
  is one line
- `packaging/debian/{postinst,prerm,postrm}` — enables watchdog
  first, restarts it before other services on upgrade, stops it last
  on uninstall, disables on purge

## Testing

Local Windows: `python -m pytest tests/test_agora_watchdog_pinger.py`
→ 32 passed. Full test sweep (with the two pre-existing-Windows-broken
test files ignored): 804 passed, 30 skipped, 0 failed.

Hardware acceptance (writing the keepalive byte, `vcgencmd`
verification, simulated agora hang triggering watchdog reset) happens
in Phase 1 acceptance on the dev Pi5 once all five Phase 1 todos are
on `main`.