### PR TITLE
feat(precheck): pre-flight checks library (Phase 1)

### DIFF
--- a/precheck/__init__.py
+++ b/precheck/__init__.py
@@ -1,0 +1,67 @@
+"""Pre-flight checks library used by slot-mgr, os-updater, and chaos tests.
+
+This is a *library* — there is no CLI and no systemd unit. Callers compose
+the individual ``check_*`` functions and (optionally) aggregate with
+:func:`run_checks` to decide whether it is safe to begin a slot transition
+or an OS update.
+
+The Phase 1 spec (plan.md §"Phase 1 — Bootloader integration") lists four
+checks; this module ships one function per check, plus an aggregator:
+
+* :func:`check_data_free_space` — refuse if /data has less than the
+  caller's threshold of free bytes
+* :func:`check_ntp_fresh` — refuse if the system clock is not
+  ``timedatectl``-NTP-synchronized
+* :func:`check_inactive_slot_clean` — refuse if ``fsck -n`` on the
+  inactive slot's rootfs reports any filesystem error
+* :func:`check_watchdog_responsive` — refuse if ``/dev/watchdog0`` is
+  missing OR ``agora-watchdog.service`` is not active
+* :func:`run_checks` — execute a sequence of checks and report
+  ``(all_ok, [CheckResult])``
+
+Every check accepts injection seams (``runner``, ``statvfs_fn``, etc.)
+so the whole module is exercised by unit tests on a developer laptop
+without a Pi, without ``/proc``, without ``/dev/watchdog0``, and without
+``timedatectl``. The defaults talk to the real syscalls / commands on a
+production Pi.
+
+A check NEVER raises on a failed check — it returns
+``CheckResult(ok=False, ...)``. The only exception class
+(:class:`PrecheckError`) is reserved for *programmer* errors (invalid
+arguments) so a buggy caller is loud, while a routine "free space is
+low" outcome stays a normal return value the caller can format / log.
+"""
+
+from precheck.core import (
+    CheckResult,
+    DEFAULT_DATA_FREE_BYTES,
+    DEFAULT_DATA_PATH,
+    DEFAULT_NTP_MAX_SKEW_SECONDS,
+    DEFAULT_PARTLABEL_BASE,
+    DEFAULT_WATCHDOG_DEVICE,
+    DEFAULT_WATCHDOG_SERVICE,
+    PrecheckError,
+    check_data_free_space,
+    check_inactive_slot_clean,
+    check_ntp_fresh,
+    check_watchdog_responsive,
+    run_checks,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "CheckResult",
+    "DEFAULT_DATA_FREE_BYTES",
+    "DEFAULT_DATA_PATH",
+    "DEFAULT_NTP_MAX_SKEW_SECONDS",
+    "DEFAULT_PARTLABEL_BASE",
+    "DEFAULT_WATCHDOG_DEVICE",
+    "DEFAULT_WATCHDOG_SERVICE",
+    "PrecheckError",
+    "check_data_free_space",
+    "check_inactive_slot_clean",
+    "check_ntp_fresh",
+    "check_watchdog_responsive",
+    "run_checks",
+]

--- a/precheck/core.py
+++ b/precheck/core.py
@@ -1,0 +1,650 @@
+"""Implementation of the pre-flight checks library.
+
+Every check is a small function with the same shape::
+
+    def check_X(*, ...defaults..., runner=subprocess.run, ...) -> CheckResult
+
+The injectable seams (``runner``, ``statvfs_fn``, ``stat_fn``,
+``slot_state_fn``) default to real-system implementations and are
+overridden in tests with fakes. This is the same pattern used by
+:mod:`agora_watchdog.pinger` and :mod:`slot_mgr.core`.
+
+Failure semantics
+-----------------
+
+A check never raises ``PrecheckError`` for a routine failure. If
+``/data`` is short on space, ``check_data_free_space`` returns
+``CheckResult(ok=False, detail="…")`` — not an exception. This makes it
+easy to compose several checks with :func:`run_checks` and surface a
+combined report.
+
+``PrecheckError`` is reserved for *programmer* errors: invalid argument
+types, a slot identifier outside ``{1, 2}``, etc. — bugs the caller
+needs to fix in code, not at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+#: Where the persistent data partition is mounted on a Pi running agora-os.
+DEFAULT_DATA_PATH: str = "/data"
+
+#: Phase 1 free-space floor (plan.md §"Phase 1"). Phase 2 may pass a
+#: smaller value (2 GiB hard floor) — the library is threshold-agnostic;
+#: callers pass ``min_bytes`` explicitly.
+DEFAULT_DATA_FREE_BYTES: int = 4 * 1024 * 1024 * 1024
+
+#: Maximum acceptable NTP skew when the caller opts in to ``chronyc``
+#: skew checking. Phase 2 spec: "NTP not fresh (skew > 5 min)".
+DEFAULT_NTP_MAX_SKEW_SECONDS: int = 5 * 60
+
+#: Pi 5 hardware-watchdog device. Same constant used by
+#: :mod:`agora_watchdog.pinger`.
+DEFAULT_WATCHDOG_DEVICE: str = "/dev/watchdog0"
+
+#: Systemd unit that pets the hardware watchdog. Created by Phase 1
+#: PR #167 (``feat: agora-watchdog Pi5 hardware watchdog pinger``).
+DEFAULT_WATCHDOG_SERVICE: str = "agora-watchdog.service"
+
+#: Directory where the kernel exposes per-partition symlinks-by-label.
+#: ``root-A`` / ``root-B`` live here on a Phase-0-imaged Pi.
+DEFAULT_PARTLABEL_BASE: str = "/dev/disk/by-partlabel"
+
+
+# ── Types ───────────────────────────────────────────────────────────────────
+
+
+class PrecheckError(RuntimeError):
+    """Programmer error in calling a precheck function.
+
+    Reserved for invalid arguments / impossible inputs. Routine
+    "the check failed" outcomes are returned as
+    ``CheckResult(ok=False, …)`` instead.
+    """
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of one pre-flight check.
+
+    Attributes
+    ----------
+    name
+        Short identifier for the check (``"data_free_space"``,
+        ``"ntp_fresh"``, etc.). Stable across versions so log
+        consumers can pattern-match.
+    ok
+        ``True`` iff the check passed.
+    detail
+        Human-readable one-line summary suitable for journald.
+    measurement
+        Numeric / structured side data for whoever consumes the
+        result programmatically (a Prometheus exporter, an
+        operator's status command, etc.). Always present, possibly
+        empty.
+    """
+
+    name: str
+    ok: bool
+    detail: str
+    measurement: Mapping[str, Any] = field(default_factory=dict)
+
+
+# ── Runner alias ────────────────────────────────────────────────────────────
+
+#: Callable type matching :func:`subprocess.run`. Tests pass a fake that
+#: returns a canned :class:`subprocess.CompletedProcess`.
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+def _default_runner(
+    args: Sequence[str],
+    *,
+    check: bool = False,
+    capture_output: bool = True,
+    text: bool = True,
+    timeout: Optional[float] = None,
+) -> "subprocess.CompletedProcess[str]":
+    """Thin wrapper around ``subprocess.run`` with our defaults applied."""
+    return subprocess.run(
+        list(args),
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+    )
+
+
+# ── 1. /data free space ─────────────────────────────────────────────────────
+
+
+def check_data_free_space(
+    *,
+    path: str | os.PathLike[str] = DEFAULT_DATA_PATH,
+    min_bytes: int = DEFAULT_DATA_FREE_BYTES,
+    statvfs_fn: Callable[[str], os.statvfs_result] | None = None,
+) -> CheckResult:
+    """Verify ``path`` (default ``/data``) has at least ``min_bytes`` free.
+
+    Uses ``os.statvfs`` for unprivileged, syscall-cheap measurement.
+    The available-blocks figure (``f_bavail * f_frsize``) reflects
+    space usable by an unprivileged user — same number ``df`` reports
+    in the "Available" column.
+
+    Parameters
+    ----------
+    path
+        Mountpoint or any file/dir under the volume to inspect.
+    min_bytes
+        Refuse to pass if free bytes < this. Defaults to 4 GiB
+        (Phase 1 threshold). Callers (os-updater, chaos tests)
+        override.
+    statvfs_fn
+        Injection seam for tests. Defaults to :func:`os.statvfs`.
+
+    Returns
+    -------
+    CheckResult
+        ``ok=True`` iff free bytes ≥ ``min_bytes``. On a missing
+        path (``FileNotFoundError``) or an unrelated ``OSError``,
+        ``ok=False`` with the errno in ``measurement``.
+    """
+    if min_bytes < 0:
+        raise PrecheckError(f"min_bytes must be non-negative, got {min_bytes!r}")
+
+    statvfs_fn = statvfs_fn or getattr(os, "statvfs", None)
+    if statvfs_fn is None:
+        raise PrecheckError(
+            "os.statvfs is unavailable on this platform; "
+            "pass statvfs_fn= explicitly"
+        )
+    path_str = os.fspath(path)
+
+    try:
+        st = statvfs_fn(path_str)
+    except FileNotFoundError as exc:
+        return CheckResult(
+            name="data_free_space",
+            ok=False,
+            detail=f"path not found: {path_str}",
+            measurement={"path": path_str, "errno": exc.errno},
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="data_free_space",
+            ok=False,
+            detail=f"statvfs({path_str}) failed: {exc.strerror or exc}",
+            measurement={"path": path_str, "errno": exc.errno},
+        )
+
+    free_bytes = int(st.f_bavail) * int(st.f_frsize)
+    total_bytes = int(st.f_blocks) * int(st.f_frsize)
+    ok = free_bytes >= min_bytes
+
+    if ok:
+        detail = (
+            f"{_humanize_bytes(free_bytes)} free on {path_str} "
+            f"(>= {_humanize_bytes(min_bytes)} required)"
+        )
+    else:
+        detail = (
+            f"only {_humanize_bytes(free_bytes)} free on {path_str} "
+            f"(need {_humanize_bytes(min_bytes)})"
+        )
+
+    return CheckResult(
+        name="data_free_space",
+        ok=ok,
+        detail=detail,
+        measurement={
+            "path": path_str,
+            "free_bytes": free_bytes,
+            "total_bytes": total_bytes,
+            "min_bytes": int(min_bytes),
+        },
+    )
+
+
+def _humanize_bytes(n: int) -> str:
+    """Render ``n`` bytes as e.g. ``"4.0 GiB"`` (always 1 decimal place)."""
+    f = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(f) < 1024.0:
+            return f"{f:.1f} {unit}"
+        f /= 1024.0
+    return f"{f:.1f} PiB"
+
+
+# ── 2. NTP fresh ────────────────────────────────────────────────────────────
+
+
+def check_ntp_fresh(
+    *,
+    runner: Runner | None = None,
+    timeout_s: float = 5.0,
+) -> CheckResult:
+    """Verify the system clock is NTP-synchronized.
+
+    Runs ``timedatectl show -p NTPSynchronized --value`` (the
+    systemd-timesyncd canonical answer) and accepts only literal
+    ``yes``. Everything else (``no``, missing command, non-zero exit,
+    timeout) maps to ``ok=False``.
+
+    Phase 1 spec wants "NTP fresh"; Phase 2 spec wants "skew > 5 min ->
+    fail". The synchronized-flag is sufficient for Phase 1 — when
+    systemd-timesyncd has not yet drifted away from a successful sync,
+    it leaves the flag set. A future enhancement can layer a skew check
+    on top by parsing ``chronyc tracking`` when chrony is installed.
+
+    Parameters
+    ----------
+    runner
+        Injection seam for tests. Defaults to :func:`subprocess.run`
+        with our standard kwargs.
+    timeout_s
+        Soft timeout applied to the ``timedatectl`` call.
+
+    Returns
+    -------
+    CheckResult
+        ``ok=True`` iff timedatectl reports ``NTPSynchronized=yes``.
+    """
+    runner = runner or _default_runner
+
+    try:
+        result = runner(
+            ["timedatectl", "show", "-p", "NTPSynchronized", "--value"],
+            timeout=timeout_s,
+        )
+    except FileNotFoundError:
+        return CheckResult(
+            name="ntp_fresh",
+            ok=False,
+            detail="timedatectl not installed",
+            measurement={"reason": "missing_command"},
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            name="ntp_fresh",
+            ok=False,
+            detail=f"timedatectl timed out after {timeout_s}s",
+            measurement={"reason": "timeout", "timeout_s": timeout_s},
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="ntp_fresh",
+            ok=False,
+            detail=f"timedatectl failed to launch: {exc.strerror or exc}",
+            measurement={"reason": "oserror", "errno": exc.errno},
+        )
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return CheckResult(
+            name="ntp_fresh",
+            ok=False,
+            detail=(
+                f"timedatectl exited {result.returncode}: {stderr}"
+                if stderr
+                else f"timedatectl exited {result.returncode}"
+            ),
+            measurement={"reason": "nonzero_exit", "returncode": result.returncode},
+        )
+
+    raw = (result.stdout or "").strip()
+    synchronized = raw.lower() == "yes"
+    return CheckResult(
+        name="ntp_fresh",
+        ok=synchronized,
+        detail=(
+            "NTP-synchronized (timedatectl)"
+            if synchronized
+            else f"NTP not synchronized (timedatectl reported {raw!r})"
+        ),
+        measurement={"ntp_synchronized": raw},
+    )
+
+
+# ── 3. Inactive slot clean ──────────────────────────────────────────────────
+
+
+_PARTLABEL_FOR_SLOT = {1: "root-A", 2: "root-B"}
+
+
+def check_inactive_slot_clean(
+    *,
+    partlabel_base: str | os.PathLike[str] = DEFAULT_PARTLABEL_BASE,
+    slot_state_fn: Callable[[], Any] | None = None,
+    runner: Runner | None = None,
+    timeout_s: float = 120.0,
+) -> CheckResult:
+    """Verify the inactive slot's rootfs is clean (``fsck -n`` is happy).
+
+    "Inactive" means: the slot we are *not* currently running on. The
+    library asks :func:`slot_mgr.slot_state` for the running slot,
+    flips it (1<->2), looks up the matching ``/dev/disk/by-partlabel/root-{A,B}``
+    symlink, and runs ``fsck -n <device>`` — a read-only filesystem
+    check that NEVER modifies the partition.
+
+    A return code of ``0`` means clean. ``1`` means errors were
+    corrected (impossible with ``-n``, so we treat it as failure for
+    safety). ``>=4`` means uncorrectable errors. Everything non-zero
+    counts as "not clean."
+
+    Parameters
+    ----------
+    partlabel_base
+        Directory containing per-label device symlinks. Defaults to
+        ``/dev/disk/by-partlabel``.
+    slot_state_fn
+        Callable returning an object with ``.running_slot`` attribute
+        (int in ``{1, 2}`` or ``None``). Defaults to importing and
+        calling :func:`slot_mgr.slot_state`. Tests inject a fake.
+    runner
+        Injection seam for the ``fsck`` invocation.
+    timeout_s
+        Soft timeout applied to ``fsck``. Default 2 min — plenty for
+        a couple-of-GiB rootfs on a Pi 5's SD card.
+
+    Returns
+    -------
+    CheckResult
+        ``ok=True`` iff ``fsck -n`` exits ``0`` on the inactive
+        partition. Edge cases (running_slot unknown, partlabel
+        symlink missing, fsck not installed, timeout) all map to
+        ``ok=False`` with a descriptive ``detail``.
+    """
+    runner = runner or _default_runner
+    slot_state_fn = slot_state_fn or _default_slot_state
+
+    try:
+        status = slot_state_fn()
+    except Exception as exc:  # noqa: BLE001 — any failure ⇒ inconclusive
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail=f"slot_state() raised {type(exc).__name__}: {exc}",
+            measurement={"reason": "slot_state_error"},
+        )
+
+    running = getattr(status, "running_slot", None)
+    if running not in (1, 2):
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail=f"running slot unknown (slot_state.running_slot={running!r})",
+            measurement={"reason": "running_slot_unknown", "running_slot": running},
+        )
+
+    inactive = 2 if running == 1 else 1
+    label = _PARTLABEL_FOR_SLOT[inactive]
+    device = Path(os.fspath(partlabel_base)) / label
+
+    if not device.exists():
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail=f"inactive-slot device missing: {device}",
+            measurement={
+                "reason": "device_missing",
+                "device": str(device),
+                "inactive_slot": inactive,
+                "running_slot": running,
+            },
+        )
+
+    try:
+        result = runner(
+            ["fsck", "-n", str(device)],
+            timeout=timeout_s,
+        )
+    except FileNotFoundError:
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail="fsck not installed",
+            measurement={"reason": "missing_command", "device": str(device)},
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail=f"fsck -n {device} timed out after {timeout_s}s",
+            measurement={
+                "reason": "timeout",
+                "device": str(device),
+                "timeout_s": timeout_s,
+            },
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="inactive_slot_clean",
+            ok=False,
+            detail=f"fsck failed to launch: {exc.strerror or exc}",
+            measurement={
+                "reason": "oserror",
+                "device": str(device),
+                "errno": exc.errno,
+            },
+        )
+
+    ok = result.returncode == 0
+    out_tail = _last_nonblank_line((result.stdout or "") + (result.stderr or ""))
+    return CheckResult(
+        name="inactive_slot_clean",
+        ok=ok,
+        detail=(
+            f"inactive slot {label} clean (fsck -n returned 0)"
+            if ok
+            else (
+                f"inactive slot {label} not clean (fsck -n returned "
+                f"{result.returncode}): {out_tail}"
+            )
+        ),
+        measurement={
+            "device": str(device),
+            "inactive_slot": inactive,
+            "running_slot": running,
+            "returncode": result.returncode,
+        },
+    )
+
+
+def _default_slot_state() -> Any:
+    """Lazy-import :func:`slot_mgr.slot_state` so the precheck library
+    can be imported on a developer laptop without slot_mgr's runtime
+    deps (autoboot.txt, /proc/cmdline) being satisfied.
+
+    A bare ``from slot_mgr import slot_state`` at module top works fine
+    — slot_mgr has no import-time side effects — but doing it lazily
+    here keeps the dependency edge visible in code review and lets
+    tests stub the function via ``slot_state_fn=`` without monkey-
+    patching :mod:`slot_mgr`.
+    """
+    from slot_mgr import slot_state  # local import is intentional
+
+    return slot_state()
+
+
+def _last_nonblank_line(text: str) -> str:
+    """Return the last non-blank line of ``text``, trimmed; ``""`` if none."""
+    for line in reversed(text.splitlines()):
+        s = line.strip()
+        if s:
+            return s
+    return ""
+
+
+# ── 4. Watchdog responsive ──────────────────────────────────────────────────
+
+
+def check_watchdog_responsive(
+    *,
+    device: str | os.PathLike[str] = DEFAULT_WATCHDOG_DEVICE,
+    service: str = DEFAULT_WATCHDOG_SERVICE,
+    stat_fn: Callable[[str], os.stat_result] | None = None,
+    runner: Runner | None = None,
+    timeout_s: float = 5.0,
+) -> CheckResult:
+    """Verify the hardware watchdog is being pet.
+
+    Two conditions, both required:
+
+    1. ``device`` (default ``/dev/watchdog0``) exists.
+    2. ``systemctl is-active <service>`` returns ``"active"`` (exit 0).
+
+    We deliberately do NOT open ``/dev/watchdog0`` ourselves: on Linux
+    that device is single-open. Opening here would either (a) fail with
+    EBUSY because :mod:`agora_watchdog.pinger` already holds it (which
+    is exactly the healthy state we are trying to verify), or (b)
+    succeed because the pinger is dead — at which point we would have
+    to remember to magic-close it ourselves before exiting or the
+    watchdog would fire on us. Both outcomes are worse than asking
+    systemd whether the daemon is active.
+
+    Parameters
+    ----------
+    device
+        Watchdog character device path.
+    service
+        Systemd unit name (without ``.service`` is fine too; pass the
+        full name for clarity).
+    stat_fn
+        Injection seam, defaults to :func:`os.stat`.
+    runner
+        Injection seam, defaults to :func:`subprocess.run`.
+    timeout_s
+        Soft timeout for the ``systemctl`` call.
+
+    Returns
+    -------
+    CheckResult
+        ``ok=True`` iff both conditions hold.
+    """
+    runner = runner or _default_runner
+    stat_fn = stat_fn or os.stat
+    device_str = os.fspath(device)
+
+    # (1) device present
+    try:
+        stat_fn(device_str)
+    except FileNotFoundError:
+        return CheckResult(
+            name="watchdog_responsive",
+            ok=False,
+            detail=f"watchdog device missing: {device_str}",
+            measurement={
+                "reason": "device_missing",
+                "device": device_str,
+                "service": service,
+            },
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="watchdog_responsive",
+            ok=False,
+            detail=f"stat({device_str}) failed: {exc.strerror or exc}",
+            measurement={
+                "reason": "device_stat_error",
+                "device": device_str,
+                "errno": exc.errno,
+            },
+        )
+
+    # (2) service active
+    try:
+        result = runner(
+            ["systemctl", "is-active", service],
+            timeout=timeout_s,
+        )
+    except FileNotFoundError:
+        return CheckResult(
+            name="watchdog_responsive",
+            ok=False,
+            detail="systemctl not installed",
+            measurement={"reason": "missing_command"},
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            name="watchdog_responsive",
+            ok=False,
+            detail=f"systemctl is-active {service} timed out after {timeout_s}s",
+            measurement={
+                "reason": "timeout",
+                "service": service,
+                "timeout_s": timeout_s,
+            },
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="watchdog_responsive",
+            ok=False,
+            detail=f"systemctl failed to launch: {exc.strerror or exc}",
+            measurement={"reason": "oserror", "errno": exc.errno},
+        )
+
+    state = (result.stdout or "").strip()
+    ok = result.returncode == 0 and state == "active"
+    if ok:
+        detail = f"watchdog active (device={device_str}, {service}=active)"
+    else:
+        detail = (
+            f"agora-watchdog not active "
+            f"(state={state!r}, returncode={result.returncode})"
+        )
+    return CheckResult(
+        name="watchdog_responsive",
+        ok=ok,
+        detail=detail,
+        measurement={
+            "device": device_str,
+            "service": service,
+            "service_state": state,
+            "returncode": result.returncode,
+        },
+    )
+
+
+# ── Aggregator ──────────────────────────────────────────────────────────────
+
+
+def run_checks(
+    checks: Sequence[Callable[[], CheckResult]],
+) -> tuple[bool, list[CheckResult]]:
+    """Execute ``checks`` in order, return ``(all_ok, results)``.
+
+    Every callable in ``checks`` is invoked with no arguments — wrap
+    your specific check with :func:`functools.partial` or a lambda
+    when you need to bind a particular threshold::
+
+        from functools import partial
+        ok, results = run_checks([
+            partial(check_data_free_space, min_bytes=2 * 1024**3),
+            check_ntp_fresh,
+            check_inactive_slot_clean,
+            check_watchdog_responsive,
+        ])
+
+    Aggregation is "all-or-nothing": ``all_ok`` is ``True`` iff every
+    :class:`CheckResult` has ``ok=True``. If a check callable itself
+    raises (a bug), the exception is *not* suppressed — that's a
+    :class:`PrecheckError`-class condition we want to be noisy about.
+    """
+    results: list[CheckResult] = []
+    for check in checks:
+        result = check()
+        if not isinstance(result, CheckResult):
+            raise PrecheckError(
+                f"check {check!r} returned {type(result).__name__}, "
+                f"expected CheckResult"
+            )
+        results.append(result)
+    return (all(r.ok for r in results), results)

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -1,0 +1,751 @@
+"""Unit tests for :mod:`precheck`.
+
+The pre-flight check library is built around four injectable seams
+(``statvfs_fn``, ``stat_fn``, ``runner``, ``slot_state_fn``) so every
+test runs on a developer laptop without ``/dev/watchdog0``, ``/proc``,
+``timedatectl``, or a slot-mgr-compatible environment. The tests below
+exercise the happy path, every documented failure path, and the
+aggregator's contract.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import subprocess
+from collections import namedtuple
+from typing import Any, List, Sequence
+from unittest.mock import patch
+
+import pytest
+
+from precheck import (
+    CheckResult,
+    DEFAULT_DATA_FREE_BYTES,
+    DEFAULT_DATA_PATH,
+    DEFAULT_WATCHDOG_DEVICE,
+    DEFAULT_WATCHDOG_SERVICE,
+    PrecheckError,
+    check_data_free_space,
+    check_inactive_slot_clean,
+    check_ntp_fresh,
+    check_watchdog_responsive,
+    run_checks,
+)
+from precheck import core as precheck_core
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+# A minimal statvfs_result-style namedtuple — the real ``os.statvfs_result``
+# only takes positional ints from the kernel and we just need .f_bavail,
+# .f_frsize, .f_blocks for our caller. A namedtuple matches the access
+# pattern exactly.
+FakeStatvfs = namedtuple("FakeStatvfs", ["f_bavail", "f_frsize", "f_blocks"])
+
+
+def _statvfs_yielding(result: FakeStatvfs):
+    """Build a fake ``statvfs_fn`` that returns ``result`` and records calls."""
+    calls: List[str] = []
+
+    def fn(path: str) -> FakeStatvfs:
+        calls.append(path)
+        return result
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+def _statvfs_raising(exc: Exception):
+    """Build a fake ``statvfs_fn`` that always raises ``exc``."""
+    calls: List[str] = []
+
+    def fn(path: str) -> FakeStatvfs:
+        calls.append(path)
+        raise exc
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+def _stat_present(path: str) -> os.stat_result:
+    """Stand-in ``stat_fn`` for a device that exists."""
+    # We never look at fields; only the absence of an exception matters.
+    return os.stat_result((0o020666, 1, 1, 1, 0, 0, 0, 0, 0, 0))
+
+
+def _stat_missing(path: str) -> os.stat_result:
+    raise FileNotFoundError(errno.ENOENT, "No such file", path)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class FakeRunner:
+    """Recording stand-in for :func:`subprocess.run`.
+
+    Optionally returns a queued result or raises a queued exception
+    on each call. Lets a test assert exact arg vectors without
+    monkeypatching the real ``subprocess`` module.
+    """
+
+    def __init__(self, *, results: Sequence[Any] = (), raises: Sequence[Any] = ()):
+        self._results = list(results)
+        self._raises = list(raises)
+        self.calls: List[dict[str, Any]] = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append({"args": list(args), **kwargs})
+        if self._raises:
+            exc = self._raises.pop(0)
+            if exc is not None:
+                raise exc
+        if self._results:
+            return self._results.pop(0)
+        return _completed()
+
+
+# ── check_data_free_space ───────────────────────────────────────────────────
+
+
+class TestCheckDataFreeSpace:
+    def test_pass_when_free_meets_threshold(self):
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=5_000, f_frsize=1024 * 1024, f_blocks=10_000)
+        )  # 5 GiB free of 10 GiB total
+
+        result = check_data_free_space(
+            path="/data",
+            min_bytes=4 * 1024 * 1024 * 1024,
+            statvfs_fn=statvfs_fn,
+        )
+
+        assert result.ok is True
+        assert result.name == "data_free_space"
+        assert result.measurement["path"] == "/data"
+        assert result.measurement["free_bytes"] == 5_000 * 1024 * 1024
+        assert result.measurement["total_bytes"] == 10_000 * 1024 * 1024
+        assert result.measurement["min_bytes"] == 4 * 1024 * 1024 * 1024
+        assert statvfs_fn.calls == ["/data"]  # type: ignore[attr-defined]
+
+    def test_pass_exactly_at_threshold(self):
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=1024, f_frsize=1024 * 1024, f_blocks=2048)
+        )  # exactly 1 GiB free
+
+        result = check_data_free_space(
+            min_bytes=1024 * 1024 * 1024, statvfs_fn=statvfs_fn
+        )
+
+        assert result.ok is True
+
+    def test_fail_when_below_threshold(self):
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=1024, f_frsize=1024 * 1024, f_blocks=10_000)
+        )  # 1 GiB free; need 4 GiB
+
+        result = check_data_free_space(
+            min_bytes=4 * 1024 * 1024 * 1024, statvfs_fn=statvfs_fn
+        )
+
+        assert result.ok is False
+        assert "only" in result.detail.lower()
+        assert "1.0 gib" in result.detail.lower()
+        assert "4.0 gib" in result.detail.lower()
+
+    def test_path_not_found(self):
+        statvfs_fn = _statvfs_raising(
+            FileNotFoundError(errno.ENOENT, "No such file", "/data")
+        )
+
+        result = check_data_free_space(path="/data", statvfs_fn=statvfs_fn)
+
+        assert result.ok is False
+        assert "not found" in result.detail
+        assert result.measurement["errno"] == errno.ENOENT
+
+    def test_oserror_propagates_as_failure(self):
+        statvfs_fn = _statvfs_raising(OSError(errno.EIO, "I/O error", "/data"))
+
+        result = check_data_free_space(path="/data", statvfs_fn=statvfs_fn)
+
+        assert result.ok is False
+        assert "i/o error" in result.detail.lower()
+        assert result.measurement["errno"] == errno.EIO
+
+    def test_negative_min_bytes_raises(self):
+        with pytest.raises(PrecheckError, match="non-negative"):
+            check_data_free_space(min_bytes=-1)
+
+    def test_zero_min_bytes_passes(self):
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=0, f_frsize=4096, f_blocks=0)
+        )
+
+        result = check_data_free_space(min_bytes=0, statvfs_fn=statvfs_fn)
+
+        assert result.ok is True
+
+    def test_default_path_is_data(self):
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=10**9, f_frsize=4096, f_blocks=10**9)
+        )
+
+        check_data_free_space(statvfs_fn=statvfs_fn, min_bytes=0)
+
+        assert statvfs_fn.calls == [DEFAULT_DATA_PATH]  # type: ignore[attr-defined]
+        assert DEFAULT_DATA_PATH == "/data"
+
+    def test_path_can_be_pathlike(self):
+        from pathlib import PurePosixPath
+
+        statvfs_fn = _statvfs_yielding(
+            FakeStatvfs(f_bavail=10**6, f_frsize=4096, f_blocks=10**6)
+        )
+
+        result = check_data_free_space(
+            path=PurePosixPath("/var/data"),
+            min_bytes=0,
+            statvfs_fn=statvfs_fn,
+        )
+
+        assert result.ok is True
+        assert statvfs_fn.calls == ["/var/data"]  # type: ignore[attr-defined]
+
+
+# ── check_ntp_fresh ─────────────────────────────────────────────────────────
+
+
+class TestCheckNtpFresh:
+    def test_yes_means_ok(self):
+        runner = FakeRunner(results=[_completed(stdout="yes\n")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is True
+        assert result.name == "ntp_fresh"
+        assert result.measurement["ntp_synchronized"] == "yes"
+        # Confirm we called the canonical command, not something else.
+        assert runner.calls[0]["args"] == [
+            "timedatectl",
+            "show",
+            "-p",
+            "NTPSynchronized",
+            "--value",
+        ]
+
+    def test_yes_case_insensitive(self):
+        runner = FakeRunner(results=[_completed(stdout="YES\n")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is True
+
+    def test_no_means_fail(self):
+        runner = FakeRunner(results=[_completed(stdout="no\n")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "'no'" in result.detail
+        assert result.measurement["ntp_synchronized"] == "no"
+
+    def test_unexpected_output_means_fail(self):
+        runner = FakeRunner(results=[_completed(stdout="maybe\n")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "'maybe'" in result.detail
+
+    def test_missing_command(self):
+        runner = FakeRunner(raises=[FileNotFoundError("no timedatectl")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "not installed" in result.detail
+        assert result.measurement["reason"] == "missing_command"
+
+    def test_timeout(self):
+        runner = FakeRunner(
+            raises=[subprocess.TimeoutExpired(cmd="timedatectl", timeout=5.0)]
+        )
+
+        result = check_ntp_fresh(runner=runner, timeout_s=5.0)
+
+        assert result.ok is False
+        assert "timed out" in result.detail
+        assert result.measurement["reason"] == "timeout"
+        assert result.measurement["timeout_s"] == 5.0
+
+    def test_nonzero_exit(self):
+        runner = FakeRunner(
+            results=[_completed(returncode=1, stderr="Failed to connect\n")]
+        )
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "exited 1" in result.detail
+        assert "Failed to connect" in result.detail
+        assert result.measurement["reason"] == "nonzero_exit"
+        assert result.measurement["returncode"] == 1
+
+    def test_nonzero_exit_no_stderr(self):
+        runner = FakeRunner(results=[_completed(returncode=2, stderr="")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "exited 2" in result.detail
+
+    def test_oserror(self):
+        runner = FakeRunner(raises=[OSError(errno.EACCES, "Permission denied")])
+
+        result = check_ntp_fresh(runner=runner)
+
+        assert result.ok is False
+        assert "permission denied" in result.detail.lower()
+        assert result.measurement["reason"] == "oserror"
+        assert result.measurement["errno"] == errno.EACCES
+
+
+# ── check_inactive_slot_clean ───────────────────────────────────────────────
+
+
+class FakeSlotStatus:
+    """Stands in for :class:`slot_mgr.SlotStatus`. Only ``running_slot``
+    is read by the precheck library."""
+
+    def __init__(self, running_slot):
+        self.running_slot = running_slot
+
+
+class TestCheckInactiveSlotClean:
+    def test_running_slot_1_checks_root_b(self, tmp_path):
+        # Pre-create both partlabel symlinks so the device-exists guard
+        # passes; we want to verify the inactive selection logic.
+        (tmp_path / "root-A").write_text("")
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(results=[_completed(returncode=0)])
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+        )
+
+        assert result.ok is True
+        assert result.name == "inactive_slot_clean"
+        assert result.measurement["inactive_slot"] == 2
+        assert result.measurement["running_slot"] == 1
+        assert str(tmp_path / "root-B") in runner.calls[0]["args"]
+        # Confirm read-only flag is set so the test inadvertently can't
+        # write to /dev.
+        assert runner.calls[0]["args"][:2] == ["fsck", "-n"]
+
+    def test_running_slot_2_checks_root_a(self, tmp_path):
+        (tmp_path / "root-A").write_text("")
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(results=[_completed(returncode=0)])
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(2),
+            runner=runner,
+        )
+
+        assert result.ok is True
+        assert result.measurement["inactive_slot"] == 1
+        assert str(tmp_path / "root-A") in runner.calls[0]["args"]
+
+    def test_running_slot_none_fails(self, tmp_path):
+        runner = FakeRunner()
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(None),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "running slot unknown" in result.detail
+        assert result.measurement["reason"] == "running_slot_unknown"
+        assert runner.calls == []  # never tried fsck
+
+    def test_running_slot_invalid_int_fails(self, tmp_path):
+        runner = FakeRunner()
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(7),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert result.measurement["running_slot"] == 7
+        assert runner.calls == []
+
+    def test_partlabel_missing(self, tmp_path):
+        # Don't create root-B
+        runner = FakeRunner()
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "device missing" in result.detail
+        assert result.measurement["reason"] == "device_missing"
+        assert runner.calls == []
+
+    def test_fsck_missing_command(self, tmp_path):
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(raises=[FileNotFoundError("no fsck")])
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "fsck not installed" in result.detail
+        assert result.measurement["reason"] == "missing_command"
+
+    def test_fsck_timeout(self, tmp_path):
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(
+            raises=[subprocess.TimeoutExpired(cmd="fsck", timeout=120.0)]
+        )
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+            timeout_s=120.0,
+        )
+
+        assert result.ok is False
+        assert "timed out" in result.detail
+        assert result.measurement["reason"] == "timeout"
+        assert result.measurement["timeout_s"] == 120.0
+
+    def test_fsck_oserror(self, tmp_path):
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(raises=[OSError(errno.EACCES, "Permission denied")])
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "permission denied" in result.detail.lower()
+        assert result.measurement["reason"] == "oserror"
+
+    def test_fsck_nonzero_exit_is_failure(self, tmp_path):
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(
+            results=[
+                _completed(returncode=4, stdout="root-B: UNEXPECTED INCONSISTENCY\n")
+            ]
+        )
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=lambda: FakeSlotStatus(1),
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "returned 4" in result.detail
+        assert "UNEXPECTED INCONSISTENCY" in result.detail
+        assert result.measurement["returncode"] == 4
+
+    def test_slot_state_raises(self, tmp_path):
+        def bad():
+            raise RuntimeError("can't read /proc/cmdline")
+
+        result = check_inactive_slot_clean(
+            partlabel_base=tmp_path,
+            slot_state_fn=bad,
+            runner=FakeRunner(),
+        )
+
+        assert result.ok is False
+        assert "slot_state() raised RuntimeError" in result.detail
+        assert "can't read" in result.detail
+        assert result.measurement["reason"] == "slot_state_error"
+
+    def test_default_slot_state_lazy_import(self, tmp_path):
+        # Verify the default slot_state_fn actually imports slot_mgr and
+        # calls slot_state(). We don't want a real read of /proc/cmdline
+        # in the test, so we patch slot_mgr.slot_state to a no-op.
+        (tmp_path / "root-B").write_text("")
+        runner = FakeRunner(results=[_completed(returncode=0)])
+
+        with patch("slot_mgr.slot_state", return_value=FakeSlotStatus(1)) as m:
+            result = check_inactive_slot_clean(
+                partlabel_base=tmp_path,
+                runner=runner,
+                # slot_state_fn omitted on purpose — exercise default
+            )
+
+        assert m.called
+        assert result.ok is True
+
+
+# ── check_watchdog_responsive ───────────────────────────────────────────────
+
+
+class TestCheckWatchdogResponsive:
+    def test_device_and_service_active(self):
+        runner = FakeRunner(results=[_completed(returncode=0, stdout="active\n")])
+
+        result = check_watchdog_responsive(
+            device="/dev/watchdog0",
+            service="agora-watchdog.service",
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is True
+        assert result.name == "watchdog_responsive"
+        assert result.measurement["service_state"] == "active"
+        assert result.measurement["returncode"] == 0
+        assert runner.calls[0]["args"] == [
+            "systemctl",
+            "is-active",
+            "agora-watchdog.service",
+        ]
+
+    def test_device_missing(self):
+        runner = FakeRunner()
+
+        result = check_watchdog_responsive(
+            device="/dev/watchdog0",
+            stat_fn=_stat_missing,
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "watchdog device missing" in result.detail
+        assert result.measurement["reason"] == "device_missing"
+        assert runner.calls == []  # short-circuited before systemctl
+
+    def test_device_stat_other_oserror(self):
+        def stat_eio(path):
+            raise OSError(errno.EIO, "I/O error", path)
+
+        runner = FakeRunner()
+
+        result = check_watchdog_responsive(
+            device="/dev/watchdog0",
+            stat_fn=stat_eio,
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "i/o error" in result.detail.lower()
+        assert result.measurement["reason"] == "device_stat_error"
+        assert runner.calls == []
+
+    def test_service_inactive(self):
+        runner = FakeRunner(
+            results=[_completed(returncode=3, stdout="inactive\n")]
+        )
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "'inactive'" in result.detail
+        assert "returncode=3" in result.detail
+        assert result.measurement["service_state"] == "inactive"
+
+    def test_service_active_but_systemctl_nonzero(self):
+        # systemctl is-active normally returns 0 for "active" and 3 for
+        # "inactive" / "failed". A 0 with stdout "active" is the only
+        # combination we accept.
+        runner = FakeRunner(
+            results=[_completed(returncode=3, stdout="active\n")]
+        )
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is False
+
+    def test_systemctl_missing(self):
+        runner = FakeRunner(raises=[FileNotFoundError("no systemctl")])
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "systemctl not installed" in result.detail
+        assert result.measurement["reason"] == "missing_command"
+
+    def test_systemctl_timeout(self):
+        runner = FakeRunner(
+            raises=[subprocess.TimeoutExpired(cmd="systemctl", timeout=5.0)]
+        )
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+            timeout_s=5.0,
+        )
+
+        assert result.ok is False
+        assert "timed out" in result.detail
+        assert result.measurement["reason"] == "timeout"
+        assert result.measurement["timeout_s"] == 5.0
+
+    def test_systemctl_oserror(self):
+        runner = FakeRunner(raises=[OSError(errno.EACCES, "Permission denied")])
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is False
+        assert "permission denied" in result.detail.lower()
+        assert result.measurement["reason"] == "oserror"
+
+    def test_default_device_and_service(self):
+        runner = FakeRunner(results=[_completed(returncode=0, stdout="active\n")])
+
+        result = check_watchdog_responsive(
+            stat_fn=_stat_present,
+            runner=runner,
+        )
+
+        assert result.ok is True
+        assert result.measurement["device"] == DEFAULT_WATCHDOG_DEVICE
+        assert result.measurement["service"] == DEFAULT_WATCHDOG_SERVICE
+        assert DEFAULT_WATCHDOG_DEVICE == "/dev/watchdog0"
+        assert DEFAULT_WATCHDOG_SERVICE == "agora-watchdog.service"
+
+
+# ── run_checks aggregator ───────────────────────────────────────────────────
+
+
+def _ok(name="x") -> CheckResult:
+    return CheckResult(name=name, ok=True, detail="fine")
+
+
+def _bad(name="x") -> CheckResult:
+    return CheckResult(name=name, ok=False, detail="broken")
+
+
+class TestRunChecks:
+    def test_empty_returns_all_ok(self):
+        all_ok, results = run_checks([])
+        assert all_ok is True
+        assert results == []
+
+    def test_all_pass(self):
+        all_ok, results = run_checks(
+            [lambda: _ok("a"), lambda: _ok("b"), lambda: _ok("c")]
+        )
+        assert all_ok is True
+        assert [r.name for r in results] == ["a", "b", "c"]
+
+    def test_one_failure_flips_all_ok_false(self):
+        all_ok, results = run_checks(
+            [lambda: _ok("a"), lambda: _bad("b"), lambda: _ok("c")]
+        )
+        assert all_ok is False
+        # All results are collected even when one fails — no short-circuit.
+        assert [r.name for r in results] == ["a", "b", "c"]
+        assert results[1].ok is False
+
+    def test_checks_run_in_order(self):
+        order: List[str] = []
+
+        def mk(name):
+            def fn():
+                order.append(name)
+                return _ok(name)
+
+            return fn
+
+        run_checks([mk("first"), mk("second"), mk("third")])
+        assert order == ["first", "second", "third"]
+
+    def test_non_check_result_raises_programmer_error(self):
+        with pytest.raises(PrecheckError, match="expected CheckResult"):
+            run_checks([lambda: "not a result"])  # type: ignore[list-item]
+
+    def test_callable_raising_propagates(self):
+        # A check raising an unexpected exception is a bug; we don't
+        # swallow it into ok=False.
+        def boom():
+            raise ValueError("oops")
+
+        with pytest.raises(ValueError, match="oops"):
+            run_checks([lambda: _ok(), boom, lambda: _ok()])
+
+
+# ── Misc invariants ─────────────────────────────────────────────────────────
+
+
+class TestModuleSurface:
+    def test_check_result_is_frozen(self):
+        r = _ok()
+        with pytest.raises(Exception):
+            r.ok = False  # type: ignore[misc]
+
+    def test_check_result_measurement_defaults_to_empty(self):
+        r = CheckResult(name="x", ok=True, detail="")
+        assert r.measurement == {}
+
+    def test_precheck_error_is_runtimeerror(self):
+        assert issubclass(PrecheckError, RuntimeError)
+
+    def test_defaults_exported_at_package_level(self):
+        # If we forget to re-export a default in __init__.py, callers
+        # break silently. Lock the public surface.
+        import precheck
+
+        assert precheck.DEFAULT_DATA_PATH == "/data"
+        assert precheck.DEFAULT_DATA_FREE_BYTES == 4 * 1024**3
+        assert precheck.DEFAULT_WATCHDOG_DEVICE == "/dev/watchdog0"
+        assert precheck.DEFAULT_WATCHDOG_SERVICE == "agora-watchdog.service"
+        assert precheck.DEFAULT_PARTLABEL_BASE == "/dev/disk/by-partlabel"
+
+    def test_humanize_bytes_units(self):
+        from precheck.core import _humanize_bytes
+
+        assert _humanize_bytes(0) == "0.0 B"
+        assert _humanize_bytes(1023) == "1023.0 B"
+        assert _humanize_bytes(1024) == "1.0 KiB"
+        assert _humanize_bytes(1024 * 1024) == "1.0 MiB"
+        assert _humanize_bytes(4 * 1024**3) == "4.0 GiB"
+        assert _humanize_bytes(2 * 1024**4) == "2.0 TiB"
+
+    def test_last_nonblank_line(self):
+        from precheck.core import _last_nonblank_line
+
+        assert _last_nonblank_line("") == ""
+        assert _last_nonblank_line("\n\n") == ""
+        assert _last_nonblank_line("only one") == "only one"
+        assert _last_nonblank_line("first\nsecond\n\n") == "second"
+        assert _last_nonblank_line("a  \n  b  \n") == "b"


### PR DESCRIPTION
Implements the `agora-os-precheck` library called out in Phase 1 of the agora-os update plan. Library only — no CLI, no service, no deb wiring (build-deb.sh auto-discovers `*/__init__.py`).

## What

Four pre-flight checks, all consumable from `slot-mgr` today and from `os-updater` in Phase 2:

* `check_data_free_space` — statvfs on /data, configurable min_bytes floor.
* `check_ntp_fresh` — `timedatectl show -p NTPSynchronized`. Only literal `yes` is OK. The skew > 5 min check the plan calls for is deferred to Phase 2 (parking it until the dispatcher actually consumes it).
* `check_inactive_slot_clean` — read-only `fsck -n` against `/dev/disk/by-partlabel/root-{A,B}`. Uses a lazy `slot_mgr.slot_state` import so this package stays installable / testable without `slot_mgr` in the way.
* `check_watchdog_responsive` — stats /dev/watchdog0 and asks `systemctl is-active agora-watchdog.service`. We intentionally do **not** `open()` the device — Linux watchdogs are single-open, so opening would either fail EBUSY (daemon healthy → wrong signal) or succeed and we'd have to magic-close to keep from resetting the box.

Aggregator: `run_checks(checks) -> (all_ok, results)`. Runs every check (no short-circuit) so the caller sees the full picture, not just the first failure.

## Design notes

* `CheckResult` is a frozen dataclass with `measurement: Mapping[str, Any]` — gives callers structured data for the UI and telemetry without having to re-parse `detail`.
* `PrecheckError(RuntimeError)` is reserved for *programmer* errors — negative thresholds, non-CheckResult returns from custom checks. Operational failures (no NTP, fsck dirty, disk full) come back as `CheckResult(ok=False)`, not exceptions. The aggregator does not catch `PrecheckError`.
* Every check accepts injection seams (`runner`, `statvfs_fn`, `stat_fn`, `slot_state_fn`). The test suite never has to monkeypatch `os` or `subprocess`.
* Defaults match Phase 1 plan: 4 GiB free on /data, watchdog at /dev/watchdog0, watchdog service `agora-watchdog.service`, partlabel base `/dev/disk/by-partlabel`.

## Tests

50 unit tests across 7 test classes. Same `FakeRunner` event-recording pattern as `test_agora_watchdog_pinger.py`. Coverage:

* Per-check happy path, edge thresholds, missing binaries, non-zero exit codes, exception paths.
* slot_mgr lazy-import shape (verified with `patch("slot_mgr.slot_state", ...)`).
* Aggregator: empty input, ordering preserved, one-fail-fails-all, `PrecheckError` propagation.
* Module surface: `__all__` correctness, `__version__` present, re-exports resolvable.

Full sweep on `main` + this branch: `854 passed, 30 skipped` in 91s.

## Plan refs

Phase 1 spec, section "Pre-flight checks library: `agora-os-precheck`" — this PR.