### PR TITLE
feat(migration_fence): forward-migration fence reader + CLI (Phase 1)

### DIFF
--- a/migration_fence/__init__.py
+++ b/migration_fence/__init__.py
@@ -1,0 +1,71 @@
+"""Forward-migration fence reader.
+
+The companion to :func:`slot_mgr.promote_slot`. When ``promote_slot()`` makes
+a tentative slot the permanent default it writes a ``slot=N`` sentinel at
+``/data/agora/migration-allowed``. This package is the consumer side: every
+piece of agora code that wants to forward-migrate persistent state on
+``/data`` (schema bumps, on-disk format changes, anything that's hard to
+undo) must call :func:`is_migration_allowed` first and refuse if the
+sentinel is absent or names a different slot than the one we're running on.
+
+Why a fence at all
+------------------
+
+Phase 1 boots are always two-stage: tryboot -> slot-confirm -> promote.
+Between tryboot and promote, the new agora.service is running but the
+device could revert to the previous slot on the next normal reboot (the
+bootloader's [all] section still points at the old slot). If the new
+service migrated /data forward during that window, a tryboot-revert would
+land the *old* kernel on a *newer* /data and either crash on schema
+mismatch or - worse - silently corrupt data.
+
+The fence makes "migrate forward on /data" idempotent with promotion:
+
+* Sentinel missing                  -> tentative, do not migrate
+* Sentinel present, slot mismatch   -> sentinel is from a previous slot,
+                                       do not migrate
+* Sentinel present, slot matches    -> we own this slot now, migrating
+                                       is safe
+
+CLI
+---
+
+``python -m migration_fence`` prints the current fence status as JSON and
+exits 0 when migration is allowed, 1 when it is not. Use this from
+``agora.service``'s pre-migration step::
+
+    ExecStartPre=/usr/bin/python3 -m migration_fence --check
+
+Surface
+-------
+
+Public API is intentionally small:
+
+* :func:`is_migration_allowed` - one-liner boolean for service code
+* :func:`check_migration_fence` - full structured status for diagnostics
+* :class:`FenceStatus` - dataclass returned by check_migration_fence
+* :exc:`MigrationFenceError` - reserved for *programmer* errors (e.g.
+  passing a negative slot to a helper). Operational failures are reported
+  as ``FenceStatus(allowed=False, reason=...)``, not exceptions.
+"""
+
+from migration_fence.core import (
+    DEFAULT_SENTINEL_PATH,
+    FenceStatus,
+    MigrationFenceError,
+    check_migration_fence,
+    is_migration_allowed,
+    parse_sentinel,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_SENTINEL_PATH",
+    "FenceStatus",
+    "MigrationFenceError",
+    "__version__",
+    "check_migration_fence",
+    "is_migration_allowed",
+    "parse_sentinel",
+]

--- a/migration_fence/__main__.py
+++ b/migration_fence/__main__.py
@@ -1,0 +1,59 @@
+"""``python -m migration_fence`` - status / gate for service ExecStartPre.
+
+Prints the current :class:`FenceStatus` as JSON on stdout and exits:
+
+* 0 if migration is allowed (sentinel present, slot matches running)
+* 1 if migration is denied for any operational reason
+
+Wire from a systemd unit's pre-migration step::
+
+    ExecStartPre=/usr/bin/python3 -m migration_fence --check
+
+For human inspection on the device::
+
+    python3 -m migration_fence
+
+(no ``--check`` always exits 0 - useful when you just want the JSON).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from typing import Sequence
+
+from migration_fence.core import check_migration_fence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m migration_fence",
+        description=(
+            "Print the forward-migration fence status as JSON. "
+            "With --check, exit non-zero when migration is not allowed."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when migration is not allowed (for use in ExecStartPre).",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    status = check_migration_fence()
+    payload = dataclasses.asdict(status)
+    payload["measurement"] = dict(payload.get("measurement") or {})
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    if args.check and not status.allowed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by integration paths
+    raise SystemExit(main())

--- a/migration_fence/core.py
+++ b/migration_fence/core.py
@@ -1,0 +1,309 @@
+"""Forward-migration fence reader - implementation.
+
+See :mod:`migration_fence` for the high-level rationale. This module is
+the no-magic implementation: read the sentinel, parse it, compare against
+the running slot, return a structured result.
+
+Every IO seam is injectable so the test suite can drive every branch
+without touching ``/data``, ``slot_mgr``, or ``os``.
+
+Sentinel format
+---------------
+
+The sentinel is the file written by :func:`slot_mgr.promote_slot`. It is
+plain UTF-8 text with one ``key=value`` per line::
+
+    slot=2
+    promoted_at=2026-04-22T18:30:00+00:00
+
+Only ``slot`` is required. Any additional lines are tolerated and exposed
+verbatim in :attr:`FenceStatus.measurement`. Lines without ``=`` or whose
+key/value is empty after stripping are skipped silently - we'd rather let
+``promote_slot()`` add fields than have the reader reject sentinels from
+slightly-newer firmware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+
+#: Default location of the sentinel file. Matches
+#: ``slot_mgr.paths.migration_allowed_sentinel_path()`` on the device.
+#: Re-declared here as a string so this package does not have a hard
+#: import dependency on slot_mgr - tests and dev hosts can use this
+#: library without slot_mgr being installed.
+DEFAULT_SENTINEL_PATH = "/data/agora/migration-allowed"
+
+
+class MigrationFenceError(RuntimeError):
+    """Programmer-error class (bad arguments, broken plumbing).
+
+    The fence reader *never* raises this for operational situations
+    (sentinel missing, slot mismatch, malformed file): those are reported
+    via :class:`FenceStatus` so service code can keep going without a
+    try/except wrapper.
+    """
+
+
+@dataclass(frozen=True)
+class FenceStatus:
+    """Snapshot of the forward-migration fence.
+
+    ``allowed``
+        ``True`` iff the caller is permitted to run forward-migrations on
+        ``/data``. ``False`` for every other case (sentinel missing,
+        slot mismatch, IO error reading the sentinel, indeterminate
+        running slot).
+
+    ``reason``
+        Human-readable explanation of the decision. Stable enough to be
+        useful in logs but not part of the public contract for
+        programmatic use - branch on the booleans / slot fields, not on
+        the string.
+
+    ``allowed_slot``
+        Slot number named by the sentinel's ``slot=N`` line, or ``None``
+        if the sentinel was missing or unparseable.
+
+    ``running_slot``
+        Slot the device is currently running, sourced from
+        :func:`slot_mgr.slot_state` (or the injected ``slot_state_fn``).
+        ``None`` if the cmdline did not name a slot - which on a real Pi
+        only happens during the very first boot off a freshly-flashed
+        card.
+
+    ``sentinel_present``
+        ``True`` if the file at the sentinel path was readable. False
+        when the file is missing *or* unreadable (the distinction lives
+        in :attr:`reason`).
+
+    ``measurement``
+        Verbatim parsed key/value pairs from the sentinel. ``slot`` is
+        always a string here even though :attr:`allowed_slot` is an int -
+        this dict is for telemetry; the typed field is for logic.
+    """
+
+    allowed: bool
+    reason: str
+    allowed_slot: Optional[int]
+    running_slot: Optional[int]
+    sentinel_present: bool
+    measurement: Mapping[str, Any] = field(default_factory=dict)
+
+
+def parse_sentinel(text: str) -> Mapping[str, str]:
+    """Parse a sentinel body into a dict of string key/values.
+
+    Forgiving on purpose. Lines without ``=`` are skipped; surrounding
+    whitespace is stripped from both key and value. Returns an empty dict
+    for the empty string.
+
+    Used by :func:`check_migration_fence` but exposed publicly so callers
+    can inspect a sentinel file without re-implementing the format.
+    """
+    out: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        out[key] = value
+    return out
+
+
+def _default_sentinel_reader(path: Path) -> Optional[str]:
+    """Read the sentinel file. Returns ``None`` when it doesn't exist."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def _default_slot_state():
+    """Lazy import of :func:`slot_mgr.slot_state`.
+
+    Kept as a function (not a module-level import) so this package stays
+    installable in environments that don't have ``slot_mgr`` - tests, dev
+    laptops, and the os-image build pipeline before slot_mgr is installed
+    can all import :mod:`migration_fence` without failing.
+    """
+    from slot_mgr import slot_state  # imported lazily on first call
+
+    return slot_state()
+
+
+def is_migration_allowed(
+    *,
+    sentinel_path: Optional[Path] = None,
+    sentinel_reader: Optional[Callable[[Path], Optional[str]]] = None,
+    slot_state_fn: Optional[Callable[[], Any]] = None,
+) -> bool:
+    """Convenience wrapper around :func:`check_migration_fence`.
+
+    Returns just the boolean. Equivalent to::
+
+        check_migration_fence(...).allowed
+
+    Service code that already routes through structured logging should
+    prefer :func:`check_migration_fence` so the :attr:`FenceStatus.reason`
+    string ends up in the log line.
+    """
+    return check_migration_fence(
+        sentinel_path=sentinel_path,
+        sentinel_reader=sentinel_reader,
+        slot_state_fn=slot_state_fn,
+    ).allowed
+
+
+def check_migration_fence(
+    *,
+    sentinel_path: Optional[Path] = None,
+    sentinel_reader: Optional[Callable[[Path], Optional[str]]] = None,
+    slot_state_fn: Optional[Callable[[], Any]] = None,
+) -> FenceStatus:
+    """Read the sentinel + running slot and decide whether to migrate.
+
+    Algorithm:
+
+    1. Locate sentinel file (``sentinel_path`` or ``DEFAULT_SENTINEL_PATH``).
+    2. Read it (``sentinel_reader`` or ``Path.read_text``).
+       Missing file -> ``allowed=False, reason="sentinel absent"``.
+    3. Parse with :func:`parse_sentinel`.
+       No ``slot`` key, or non-integer value -> ``allowed=False, reason="malformed"``.
+    4. Resolve the running slot (``slot_state_fn`` or
+       :func:`slot_mgr.slot_state`).
+       ``None`` -> ``allowed=False, reason="running slot unknown"``.
+    5. Compare. Equal -> ``allowed=True``. Otherwise -> ``allowed=False,
+       reason="sentinel for slot X, running on Y"``.
+
+    Any exception raised by the reader or ``slot_state_fn`` is caught and
+    reported as ``allowed=False`` - never propagated. This keeps callers
+    from having to wrap the fence check in a try/except: an unreadable
+    sentinel is operationally identical to a missing one.
+    """
+    path = Path(sentinel_path) if sentinel_path is not None else Path(DEFAULT_SENTINEL_PATH)
+    reader = sentinel_reader or _default_sentinel_reader
+    state_fn = slot_state_fn or _default_slot_state
+
+    try:
+        text = reader(path)
+    except Exception as exc:  # pragma: no cover - covered by injected reader tests
+        return FenceStatus(
+            allowed=False,
+            reason=f"sentinel unreadable: {exc.__class__.__name__}: {exc}",
+            allowed_slot=None,
+            running_slot=_safe_running_slot(state_fn),
+            sentinel_present=False,
+            measurement={},
+        )
+
+    if text is None:
+        return FenceStatus(
+            allowed=False,
+            reason=f"sentinel absent at {path}",
+            allowed_slot=None,
+            running_slot=_safe_running_slot(state_fn),
+            sentinel_present=False,
+            measurement={},
+        )
+
+    measurement = dict(parse_sentinel(text))
+    slot_str = measurement.get("slot")
+    if slot_str is None or slot_str == "":
+        return FenceStatus(
+            allowed=False,
+            reason="sentinel malformed: missing 'slot' key",
+            allowed_slot=None,
+            running_slot=_safe_running_slot(state_fn),
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    try:
+        allowed_slot = int(slot_str)
+    except ValueError:
+        return FenceStatus(
+            allowed=False,
+            reason=f"sentinel malformed: slot={slot_str!r} is not an integer",
+            allowed_slot=None,
+            running_slot=_safe_running_slot(state_fn),
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    if allowed_slot not in (1, 2):
+        return FenceStatus(
+            allowed=False,
+            reason=f"sentinel slot={allowed_slot} is not a valid A/B slot",
+            allowed_slot=allowed_slot,
+            running_slot=_safe_running_slot(state_fn),
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    try:
+        status = state_fn()
+        running_slot = getattr(status, "running_slot", None)
+    except Exception as exc:
+        return FenceStatus(
+            allowed=False,
+            reason=f"slot_state unavailable: {exc.__class__.__name__}: {exc}",
+            allowed_slot=allowed_slot,
+            running_slot=None,
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    if running_slot is None:
+        return FenceStatus(
+            allowed=False,
+            reason="running slot unknown (no PARTLABEL in /proc/cmdline)",
+            allowed_slot=allowed_slot,
+            running_slot=None,
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    if running_slot != allowed_slot:
+        return FenceStatus(
+            allowed=False,
+            reason=(
+                f"sentinel names slot {allowed_slot} but device is running "
+                f"slot {running_slot} (tryboot-revert window)"
+            ),
+            allowed_slot=allowed_slot,
+            running_slot=running_slot,
+            sentinel_present=True,
+            measurement=measurement,
+        )
+
+    return FenceStatus(
+        allowed=True,
+        reason=f"sentinel matches running slot {running_slot}",
+        allowed_slot=allowed_slot,
+        running_slot=running_slot,
+        sentinel_present=True,
+        measurement=measurement,
+    )
+
+
+def _safe_running_slot(state_fn: Callable[[], Any]) -> Optional[int]:
+    """Best-effort running-slot lookup that never raises.
+
+    Used by the early-exit paths in :func:`check_migration_fence` so that
+    even when we already know we're going to deny, the returned
+    ``FenceStatus`` still has the running_slot filled in when possible
+    (it's useful for log lines and the CLI).
+    """
+    try:
+        status = state_fn()
+        return getattr(status, "running_slot", None)
+    except Exception:
+        return None

--- a/tests/test_migration_fence.py
+++ b/tests/test_migration_fence.py
@@ -1,0 +1,695 @@
+"""Unit tests for :mod:`migration_fence`.
+
+The fence reader is built around three injectable seams
+(``sentinel_path``, ``sentinel_reader``, ``slot_state_fn``) so every test
+runs on a developer laptop without ``/data``, ``slot_mgr``, or
+``/proc/cmdline``. We exercise the happy path, every documented deny
+path, and the convenience wrapper + CLI.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from collections import namedtuple
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from migration_fence import (
+    DEFAULT_SENTINEL_PATH,
+    FenceStatus,
+    MigrationFenceError,
+    check_migration_fence,
+    is_migration_allowed,
+    parse_sentinel,
+)
+from migration_fence import core as fence_core
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+# Mirrors the ``running_slot`` attribute of ``slot_mgr.SlotStatus`` without
+# importing slot_mgr - the fence only reads that one field.
+FakeSlotStatus = namedtuple("FakeSlotStatus", ["running_slot"])
+
+
+def _reader_returning(payload: Optional[str]):
+    """Build a fake ``sentinel_reader`` that returns ``payload``."""
+    calls: list[Path] = []
+
+    def fn(path: Path) -> Optional[str]:
+        calls.append(path)
+        return payload
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+def _reader_raising(exc: Exception):
+    """Build a fake ``sentinel_reader`` that always raises ``exc``."""
+    calls: list[Path] = []
+
+    def fn(path: Path) -> Optional[str]:
+        calls.append(path)
+        raise exc
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+def _slot(running: Optional[int]):
+    """Build a fake ``slot_state_fn`` that yields the given running slot."""
+    calls: list[int] = []
+
+    def fn() -> FakeSlotStatus:
+        calls.append(len(calls))
+        return FakeSlotStatus(running_slot=running)
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+def _slot_raising(exc: Exception):
+    """Build a fake ``slot_state_fn`` that always raises ``exc``."""
+    def fn() -> FakeSlotStatus:
+        raise exc
+
+    return fn
+
+
+# ── parse_sentinel ──────────────────────────────────────────────────────────
+
+
+class TestParseSentinel:
+    def test_empty_string_returns_empty_dict(self):
+        assert parse_sentinel("") == {}
+
+    def test_whitespace_only_returns_empty_dict(self):
+        assert parse_sentinel("   \n\n  \t\n") == {}
+
+    def test_single_key_value(self):
+        assert parse_sentinel("slot=2\n") == {"slot": "2"}
+
+    def test_multiple_keys(self):
+        text = "slot=1\npromoted_at=2026-04-22T18:30:00+00:00\n"
+        result = parse_sentinel(text)
+        assert result == {
+            "slot": "1",
+            "promoted_at": "2026-04-22T18:30:00+00:00",
+        }
+
+    def test_strips_surrounding_whitespace_on_key_and_value(self):
+        assert parse_sentinel("  slot  =  2  \n") == {"slot": "2"}
+
+    def test_lines_without_equals_are_skipped(self):
+        text = "slot=1\nthis is a comment\npromoted_at=now\n"
+        assert parse_sentinel(text) == {"slot": "1", "promoted_at": "now"}
+
+    def test_blank_lines_are_skipped(self):
+        text = "\nslot=1\n\n\npromoted_at=now\n\n"
+        assert parse_sentinel(text) == {"slot": "1", "promoted_at": "now"}
+
+    def test_empty_key_is_skipped(self):
+        # "=value" has an empty key after strip; we tolerate it silently.
+        assert parse_sentinel("=value\nslot=2\n") == {"slot": "2"}
+
+    def test_value_can_be_empty_string(self):
+        # Empty value is preserved - the caller decides if it's meaningful.
+        assert parse_sentinel("slot=\n") == {"slot": ""}
+
+    def test_duplicate_keys_last_wins(self):
+        assert parse_sentinel("slot=1\nslot=2\n") == {"slot": "2"}
+
+    def test_value_containing_equals_sign_is_kept_intact(self):
+        # ``partition`` splits on the first ``=`` only; later ``='s land
+        # in the value verbatim. Lets us forward future structured fields
+        # without re-engineering the parser.
+        assert parse_sentinel("note=a=b=c\n") == {"note": "a=b=c"}
+
+    def test_no_trailing_newline(self):
+        # Last line missing \n must still parse.
+        assert parse_sentinel("slot=2") == {"slot": "2"}
+
+    def test_crlf_line_endings(self):
+        # ``str.splitlines`` handles \r\n natively.
+        assert parse_sentinel("slot=1\r\npromoted_at=x\r\n") == {
+            "slot": "1",
+            "promoted_at": "x",
+        }
+
+
+# ── check_migration_fence: sentinel absent / unreadable ─────────────────────
+
+
+class TestCheckMigrationFenceSentinelAbsent:
+    def test_missing_file_denies(self):
+        reader = _reader_returning(None)
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is False
+        assert "absent" in result.reason
+        assert result.allowed_slot is None
+        # running_slot is still populated as a courtesy
+        assert result.running_slot == 1
+        assert result.measurement == {}
+
+    def test_missing_file_still_reports_running_slot_when_state_raises(self):
+        # Both the sentinel is missing and slot_state explodes - reason
+        # is still the absent-sentinel path; running_slot is None.
+        reader = _reader_returning(None)
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot_raising(RuntimeError("no cmdline")),
+        )
+        assert result.allowed is False
+        assert "absent" in result.reason
+        assert result.running_slot is None
+
+    def test_reader_raises_permission_error_denies(self):
+        reader = _reader_raising(PermissionError("denied"))
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is False
+        assert "unreadable" in result.reason
+        assert "PermissionError" in result.reason
+        assert result.running_slot == 1
+
+    def test_reader_raises_os_error_denies(self):
+        reader = _reader_raising(OSError(5, "I/O error"))
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(2),
+        )
+        assert result.allowed is False
+        assert "unreadable" in result.reason
+        assert "OSError" in result.reason
+
+    def test_reader_called_with_default_path(self):
+        reader = _reader_returning(None)
+        check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert reader.calls == [Path(DEFAULT_SENTINEL_PATH)]
+
+    def test_reader_called_with_custom_path(self, tmp_path):
+        custom = tmp_path / "elsewhere"
+        reader = _reader_returning(None)
+        check_migration_fence(
+            sentinel_path=custom,
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert reader.calls == [custom]
+
+
+# ── check_migration_fence: malformed sentinel ───────────────────────────────
+
+
+class TestCheckMigrationFenceMalformedSentinel:
+    def test_missing_slot_key_denies(self):
+        reader = _reader_returning("promoted_at=2026-04-22\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is True
+        assert "missing 'slot' key" in result.reason
+        assert result.allowed_slot is None
+        # measurement still surfaces what we did parse
+        assert result.measurement == {"promoted_at": "2026-04-22"}
+
+    def test_empty_slot_value_denies(self):
+        reader = _reader_returning("slot=\npromoted_at=now\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert "missing 'slot' key" in result.reason
+        assert result.allowed_slot is None
+
+    def test_non_integer_slot_value_denies(self):
+        reader = _reader_returning("slot=abc\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is True
+        assert "not an integer" in result.reason
+        assert result.allowed_slot is None
+        assert result.measurement == {"slot": "abc"}
+
+    def test_slot_zero_denies(self):
+        reader = _reader_returning("slot=0\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert "not a valid A/B slot" in result.reason
+        assert result.allowed_slot == 0  # int parsed, but rejected by range check
+
+    def test_slot_three_denies(self):
+        reader = _reader_returning("slot=3\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert "not a valid A/B slot" in result.reason
+        assert result.allowed_slot == 3
+
+    def test_negative_slot_denies(self):
+        reader = _reader_returning("slot=-1\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert "not a valid A/B slot" in result.reason
+
+
+# ── check_migration_fence: running-slot indeterminate ───────────────────────
+
+
+class TestCheckMigrationFenceRunningSlotIndeterminate:
+    def test_running_slot_none_denies(self):
+        reader = _reader_returning("slot=1\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(None),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is True
+        assert "running slot unknown" in result.reason
+        assert result.allowed_slot == 1
+        assert result.running_slot is None
+
+    def test_slot_state_raises_denies(self):
+        reader = _reader_returning("slot=1\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot_raising(RuntimeError("cmdline parse failed")),
+        )
+        assert result.allowed is False
+        assert "slot_state unavailable" in result.reason
+        assert "RuntimeError" in result.reason
+        assert result.allowed_slot == 1
+        assert result.running_slot is None
+
+    def test_slot_state_returns_object_without_running_slot_attr_denies(self):
+        # If someone wires us a stand-in that doesn't expose
+        # ``running_slot``, ``getattr`` returns ``None`` and we treat it
+        # exactly like a real None.
+        reader = _reader_returning("slot=1\n")
+
+        class WeirdStatus:
+            pass
+
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=lambda: WeirdStatus(),
+        )
+        assert result.allowed is False
+        assert "running slot unknown" in result.reason
+
+
+# ── check_migration_fence: slot mismatch ────────────────────────────────────
+
+
+class TestCheckMigrationFenceSlotMismatch:
+    def test_sentinel_slot_2_running_slot_1_denies(self):
+        reader = _reader_returning("slot=2\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is False
+        assert result.sentinel_present is True
+        assert "slot 2" in result.reason
+        assert "slot 1" in result.reason
+        assert "tryboot-revert" in result.reason
+        assert result.allowed_slot == 2
+        assert result.running_slot == 1
+
+    def test_sentinel_slot_1_running_slot_2_denies(self):
+        reader = _reader_returning("slot=1\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(2),
+        )
+        assert result.allowed is False
+        assert result.allowed_slot == 1
+        assert result.running_slot == 2
+
+
+# ── check_migration_fence: happy path ───────────────────────────────────────
+
+
+class TestCheckMigrationFenceSlotMatch:
+    def test_slot_1_match_allows(self):
+        reader = _reader_returning("slot=1\npromoted_at=2026-04-22T18:00:00+00:00\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is True
+        assert result.sentinel_present is True
+        assert result.allowed_slot == 1
+        assert result.running_slot == 1
+        assert "matches running slot 1" in result.reason
+        assert result.measurement == {
+            "slot": "1",
+            "promoted_at": "2026-04-22T18:00:00+00:00",
+        }
+
+    def test_slot_2_match_allows(self):
+        reader = _reader_returning("slot=2\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(2),
+        )
+        assert result.allowed is True
+        assert result.allowed_slot == 2
+        assert result.running_slot == 2
+
+    def test_extra_keys_tolerated(self):
+        # Future slot_mgr versions can add fields without breaking the
+        # consumer. ``measurement`` carries them through for telemetry.
+        reader = _reader_returning(
+            "slot=1\npromoted_at=now\nfuture_field=hello\n"
+        )
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is True
+        assert result.measurement["future_field"] == "hello"
+
+    def test_whitespace_around_slot_value_tolerated(self):
+        reader = _reader_returning("slot =  2  \n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(2),
+        )
+        assert result.allowed is True
+        assert result.allowed_slot == 2
+
+    def test_measurement_is_a_plain_dict(self):
+        # measurement is materialized into a dict so callers can json.dumps it
+        # without surprises.
+        reader = _reader_returning("slot=1\n")
+        result = check_migration_fence(
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert isinstance(result.measurement, dict)
+        # And the dataclass itself is JSON-friendly via dataclasses.asdict
+        # (used by the CLI).
+        import dataclasses
+        json.dumps(dataclasses.asdict(result))
+
+
+# ── is_migration_allowed convenience wrapper ────────────────────────────────
+
+
+class TestIsMigrationAllowed:
+    def test_returns_true_on_match(self):
+        reader = _reader_returning("slot=1\n")
+        assert (
+            is_migration_allowed(
+                sentinel_reader=reader,
+                slot_state_fn=_slot(1),
+            )
+            is True
+        )
+
+    def test_returns_false_on_mismatch(self):
+        reader = _reader_returning("slot=1\n")
+        assert (
+            is_migration_allowed(
+                sentinel_reader=reader,
+                slot_state_fn=_slot(2),
+            )
+            is False
+        )
+
+    def test_returns_false_on_missing_sentinel(self):
+        assert (
+            is_migration_allowed(
+                sentinel_reader=_reader_returning(None),
+                slot_state_fn=_slot(1),
+            )
+            is False
+        )
+
+    def test_returns_false_on_reader_exception(self):
+        assert (
+            is_migration_allowed(
+                sentinel_reader=_reader_raising(OSError("io")),
+                slot_state_fn=_slot(1),
+            )
+            is False
+        )
+
+    def test_passes_through_custom_path(self, tmp_path):
+        custom = tmp_path / "x"
+        reader = _reader_returning(None)
+        is_migration_allowed(
+            sentinel_path=custom,
+            sentinel_reader=reader,
+            slot_state_fn=_slot(1),
+        )
+        assert reader.calls == [custom]
+
+
+# ── Default reader (touches the filesystem) ─────────────────────────────────
+
+
+class TestDefaultSentinelReader:
+    def test_returns_text_when_file_exists(self, tmp_path):
+        p = tmp_path / "sentinel"
+        p.write_text("slot=2\npromoted_at=now\n", encoding="utf-8")
+        assert fence_core._default_sentinel_reader(p) == "slot=2\npromoted_at=now\n"
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        p = tmp_path / "nope"
+        assert fence_core._default_sentinel_reader(p) is None
+
+    def test_end_to_end_with_real_file(self, tmp_path):
+        # Drive the public API with the real reader + a fake slot state.
+        sentinel = tmp_path / "migration-allowed"
+        sentinel.write_text("slot=1\npromoted_at=now\n", encoding="utf-8")
+        result = check_migration_fence(
+            sentinel_path=sentinel,
+            slot_state_fn=_slot(1),
+        )
+        assert result.allowed is True
+        assert result.allowed_slot == 1
+
+
+# ── Default slot_state: lazy import contract ────────────────────────────────
+
+
+class TestDefaultSlotStateLazyImport:
+    def test_default_slot_state_imports_and_calls_slot_mgr(self, monkeypatch):
+        # The body of _default_slot_state does ``from slot_mgr import
+        # slot_state`` lazily. If a future refactor turns it back into a
+        # module-level import, the test environment without slot_mgr
+        # installed would import-fail before this test even runs - so the
+        # presence of this test together with a passing CI is the proof
+        # that the import really is lazy.
+        called = {"hit": False}
+
+        def fake_slot_state():
+            called["hit"] = True
+            return FakeSlotStatus(running_slot=1)
+
+        # Patch the symbol on the slot_mgr module that the lazy import
+        # would resolve. Provide a fake module if slot_mgr isn't
+        # installed - safer than touching the real one.
+        import types
+
+        fake_mod = types.ModuleType("slot_mgr")
+        fake_mod.slot_state = fake_slot_state  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "slot_mgr", fake_mod)
+
+        status = fence_core._default_slot_state()
+        assert called["hit"] is True
+        assert status.running_slot == 1
+
+    def test_check_migration_fence_uses_default_slot_state_when_unset(
+        self, monkeypatch
+    ):
+        # End-to-end: drive the public function with no slot_state_fn
+        # override and verify it routes through _default_slot_state ->
+        # slot_mgr.slot_state.
+        import types
+
+        fake_mod = types.ModuleType("slot_mgr")
+        fake_mod.slot_state = lambda: FakeSlotStatus(running_slot=1)  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "slot_mgr", fake_mod)
+
+        reader = _reader_returning("slot=1\n")
+        result = check_migration_fence(sentinel_reader=reader)
+        assert result.allowed is True
+        assert result.running_slot == 1
+
+
+# ── Module surface ──────────────────────────────────────────────────────────
+
+
+class TestModuleSurface:
+    def test_fence_status_is_frozen(self):
+        s = FenceStatus(
+            allowed=True,
+            reason="x",
+            allowed_slot=1,
+            running_slot=1,
+            sentinel_present=True,
+        )
+        with pytest.raises(Exception):
+            s.allowed = False  # type: ignore[misc]
+
+    def test_fence_status_measurement_defaults_to_empty(self):
+        s = FenceStatus(
+            allowed=False,
+            reason="r",
+            allowed_slot=None,
+            running_slot=None,
+            sentinel_present=False,
+        )
+        assert s.measurement == {}
+
+    def test_migration_fence_error_is_runtimeerror(self):
+        assert issubclass(MigrationFenceError, RuntimeError)
+
+    def test_default_sentinel_path_is_under_data_agora(self):
+        # Must agree with slot_mgr.paths.migration_allowed_sentinel_path()
+        # on the device. Hard-coding here means a refactor on either side
+        # will fail this test instead of silently disagreeing.
+        assert DEFAULT_SENTINEL_PATH == "/data/agora/migration-allowed"
+
+    def test_public_api_exported_at_package_level(self):
+        import migration_fence
+
+        # Everything in __all__ must actually resolve as an attribute.
+        for name in migration_fence.__all__:
+            assert hasattr(migration_fence, name), name
+
+    def test_version_present(self):
+        import migration_fence
+
+        assert isinstance(migration_fence.__version__, str)
+        # Loose sanity check - not enforcing semver shape, just non-empty.
+        assert migration_fence.__version__
+
+    def test_all_list_shape(self):
+        import migration_fence
+
+        # Bundles the obviously-public names. Tightens the contract so a
+        # refactor can't silently drop or rename a symbol.
+        assert set(migration_fence.__all__) == {
+            "DEFAULT_SENTINEL_PATH",
+            "FenceStatus",
+            "MigrationFenceError",
+            "__version__",
+            "check_migration_fence",
+            "is_migration_allowed",
+            "parse_sentinel",
+        }
+
+
+# ── CLI (python -m migration_fence) ─────────────────────────────────────────
+
+
+class TestCLI:
+    def _run(self, argv, *, fence_result):
+        """Invoke ``__main__.main`` with the given argv + patched fence.
+
+        Returns ``(exit_code, parsed_json_stdout)``.
+        """
+        from migration_fence import __main__ as cli
+
+        out = io.StringIO()
+        with patch.object(cli, "check_migration_fence", return_value=fence_result):
+            with patch.object(sys, "stdout", out):
+                rc = cli.main(argv)
+        return rc, json.loads(out.getvalue())
+
+    def _allowed(self):
+        return FenceStatus(
+            allowed=True,
+            reason="sentinel matches running slot 1",
+            allowed_slot=1,
+            running_slot=1,
+            sentinel_present=True,
+            measurement={"slot": "1"},
+        )
+
+    def _denied(self, reason="sentinel absent"):
+        return FenceStatus(
+            allowed=False,
+            reason=reason,
+            allowed_slot=None,
+            running_slot=None,
+            sentinel_present=False,
+            measurement={},
+        )
+
+    def test_no_check_flag_returns_zero_even_when_denied(self):
+        # Plain ``python -m migration_fence`` is meant for human
+        # inspection - it should always exit 0 and just print status.
+        rc, payload = self._run([], fence_result=self._denied())
+        assert rc == 0
+        assert payload["allowed"] is False
+        assert payload["reason"] == "sentinel absent"
+
+    def test_check_flag_zero_when_allowed(self):
+        rc, payload = self._run(["--check"], fence_result=self._allowed())
+        assert rc == 0
+        assert payload["allowed"] is True
+        assert payload["allowed_slot"] == 1
+        assert payload["running_slot"] == 1
+        assert payload["measurement"] == {"slot": "1"}
+
+    def test_check_flag_one_when_denied(self):
+        rc, payload = self._run(
+            ["--check"], fence_result=self._denied("sentinel absent at /x")
+        )
+        assert rc == 1
+        assert payload["allowed"] is False
+        assert payload["reason"] == "sentinel absent at /x"
+
+    def test_output_is_valid_json(self):
+        # Both --check and no-args paths must emit parseable JSON. We've
+        # already proven it parses in _run; here we just check structure.
+        rc, payload = self._run([], fence_result=self._allowed())
+        assert rc == 0
+        for key in (
+            "allowed",
+            "reason",
+            "allowed_slot",
+            "running_slot",
+            "sentinel_present",
+            "measurement",
+        ):
+            assert key in payload
+
+    def test_measurement_is_a_dict_even_when_empty(self):
+        rc, payload = self._run([], fence_result=self._denied())
+        assert isinstance(payload["measurement"], dict)


### PR DESCRIPTION
# Forward-migration fence (Phase 1)

Implements the **read side** of the forward-migration fence — the producer side already lives in `slot_mgr/core.py::_write_migration_sentinel()` (Phase 1 `p1-slot-mgr`, PR #166).

## Why

From the OS-update plan (Phase 1 §145):

> The new app on a tentative slot must read `/data` but must NOT run schema migrations until promote completes. … `agora.service` startup migration step refuses to run if the sentinel is missing or its slot tag doesn't match the running slot. Prevents tryboot-revert from landing an old kernel on a forward-migrated `/data`.

Producer:
- `slot_mgr.promote_slot(N)` writes `/data/agora/migration-allowed` with `slot=N\npromoted_at=<utc iso>\n`.

Consumer (this PR):
- `migration_fence.check_migration_fence()` reads the sentinel, parses it, compares `slot=N` against `slot_mgr.slot_state().running_slot`, and returns a `FenceStatus` saying whether forward-migration is allowed.

Future wire-up (Phase 1 `p1-slot-confirm` / agora.service migration step) calls either the library or the CLI before running any `/data` schema migration.

## Deny conditions

`FenceStatus.allowed = False` is returned in four cases:

1. **Sentinel absent** — the file isn't there, or the reader raised `PermissionError` / `OSError`. Reason starts with `sentinel absent` or `sentinel unreadable`.
2. **Sentinel malformed** — `slot` key missing, empty, non-integer, or not in `{1, 2}`. Reason names the specific problem.
3. **Running slot indeterminate** — `slot_mgr.slot_state()` raises, returns an object without `running_slot`, or returns `running_slot=None` (dev hosts). Reason starts with `running slot unknown` or `slot_state unavailable`.
4. **Slot mismatch** — sentinel `slot=N` ≠ running `slot=M`. This is the post-tryboot-revert case the fence exists to catch.

The success path (`allowed=True`) requires that `sentinel.slot == running_slot` and both are in `{1, 2}`.

## API

```python
from migration_fence import check_migration_fence, is_migration_allowed

status = check_migration_fence()      # default sentinel path, default slot_state
if status.allowed:
    run_data_migrations()
else:
    log.warning("migration blocked: %s", status.reason)

# Or the convenience boolean form:
if is_migration_allowed():
    run_data_migrations()
```

Injectable seams for tests / non-prod hosts:

```python
check_migration_fence(
    sentinel_path=...,   # path-like, overrides DEFAULT_SENTINEL_PATH
    sentinel_reader=...,  # callable(Path) -> str | None
    slot_state_fn=...,    # callable() -> object with .running_slot
)
```

`FenceStatus` is a frozen dataclass with fields:
`allowed: bool, reason: str, allowed_slot: int | None, running_slot: int | None, sentinel_present: bool, measurement: dict`.
`measurement` carries every parsed sentinel key so calling code can log / forward provenance (e.g. `promoted_at`).

## CLI

```bash
$ python -m migration_fence
{
  "allowed": true,
  "allowed_slot": 1,
  "measurement": { "slot": "1", "promoted_at": "2026-04-21T18:34:11+00:00" },
  "reason": "matches running slot",
  "running_slot": 1,
  "sentinel_present": true
}

$ python -m migration_fence --check
# exit 0 on allowed, exit 1 on denied — for ExecStartPre= wiring on agora.service.
```

## Tests

`tests/test_migration_fence.py` — 57 tests across 11 classes:

- `TestParseSentinel` (13) — full grammar coverage of the sentinel format.
- `TestCheckMigrationFenceSentinelAbsent` (6) — file missing / unreadable; running_slot still populated when possible.
- `TestCheckMigrationFenceMalformedSentinel` (6) — missing key, empty, non-integer, slot 0/3/-1.
- `TestCheckMigrationFenceRunningSlotIndeterminate` (3) — None, raises, getattr fallback.
- `TestCheckMigrationFenceSlotMismatch` (2) — 2 vs 1, 1 vs 2.
- `TestCheckMigrationFenceSlotMatch` (5) — 1↔1, 2↔2, extra keys tolerated, whitespace tolerated, measurement shape.
- `TestIsMigrationAllowed` (5) — convenience boolean wrapper.
- `TestDefaultSentinelReader` (3) — real-file integration.
- `TestDefaultSlotStateLazyImport` (2) — `sys.modules` stub validates that production code lazily imports `slot_mgr.slot_state` only when needed.
- `TestModuleSurface` (7) — frozen dataclass, `__version__`, `__all__` shape, `MigrationFenceError ⊆ RuntimeError`.
- `TestCLI` (5) — exit-code matrix, JSON shape, dict-typed `measurement`.

Local run: `911 passed, 30 skipped, 1387 warnings in 74.75s` against the full agora suite (with the two pre-existing Windows-broken modules ignored).

## Out of scope

- Wiring this into `agora.service` startup — that's `p1-slot-confirm`.
- Schema-migration runner itself — that's Phase 2 (`agora-os-updater`'s post-promote migration step).
- Recovery flow when the fence repeatedly denies — Phase 5 runbook `recover-pinned-device.md`.
