### PR TITLE
feat(slot-confirm): post-tryboot 4-check gate + systemd unit (Phase 1)

### DIFF
--- a/slot_confirm/__init__.py
+++ b/slot_confirm/__init__.py
@@ -1,0 +1,78 @@
+"""Slot-confirm gate for the Pi 5 A/B tryboot update path.
+
+Runs immediately after a tentative boot to decide whether the new slot
+is healthy enough to promote (write the new ``[all]`` boot_partition)
+or whether the device should revert by recording a strike against the
+tryboot target.
+
+The 4-check gate (per Phase 1 plan §137-141):
+
+1. ``agora-*.service`` units have been active for ≥5 min
+2. The framebuffer is writable (a test frame can be submitted)
+3. ``/data`` is mounted r/w (a probe file can be created and removed)
+4. The WPS receiver process reports connected (``cms_status.json``
+   state field == ``"connected"``)
+
+Note: CMS *reachability* is deliberately **not** in the gate. The
+device only needs to know its own WPS receiver is alive — being
+asked to slot-confirm a boot where the upstream CMS is briefly
+unreachable would falsely fail the gate.
+
+Public API:
+
+    slot_confirm() -> ConfirmStatus
+        Aggregated result. Looks up running_slot + tentative via
+        :func:`slot_mgr.slot_state`, runs the 4 checks, and indicates
+        the recommended ``next_action`` (``"promote"``, ``"strike"``,
+        or ``"skipped"`` when not on a tentative boot).
+
+    check_agora_services_active() -> CheckResult
+    check_framebuffer() -> CheckResult
+    check_data_writable() -> CheckResult
+    check_wps_connected() -> CheckResult
+        Individual checks; useful for tests, status commands, and
+        ad-hoc CLI invocations.
+
+    CheckResult / ConfirmStatus
+        Frozen dataclasses; the result types.
+
+CLI:
+
+    python -m slot_confirm                # run checks, print JSON, always exit 0
+    python -m slot_confirm --check        # exit 1 if any check failed
+    python -m slot_confirm --auto         # run checks, then promote / strike via slot_mgr
+"""
+
+from slot_confirm.core import (
+    DEFAULT_AGORA_SERVICES,
+    DEFAULT_CMS_STATUS_PATH,
+    DEFAULT_DATA_PROBE_DIR,
+    DEFAULT_FRAMEBUFFER_DEVICE,
+    DEFAULT_MIN_ACTIVE_SECONDS,
+    CheckResult,
+    ConfirmStatus,
+    SlotConfirmError,
+    check_agora_services_active,
+    check_data_writable,
+    check_framebuffer,
+    check_wps_connected,
+    slot_confirm,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    "DEFAULT_AGORA_SERVICES",
+    "DEFAULT_CMS_STATUS_PATH",
+    "DEFAULT_DATA_PROBE_DIR",
+    "DEFAULT_FRAMEBUFFER_DEVICE",
+    "DEFAULT_MIN_ACTIVE_SECONDS",
+    "CheckResult",
+    "ConfirmStatus",
+    "SlotConfirmError",
+    "__version__",
+    "check_agora_services_active",
+    "check_data_writable",
+    "check_framebuffer",
+    "check_wps_connected",
+    "slot_confirm",
+]

--- a/slot_confirm/__main__.py
+++ b/slot_confirm/__main__.py
@@ -1,0 +1,167 @@
+"""CLI entrypoint: ``python -m slot_confirm``.
+
+Modes (these may be combined):
+
+* (no flags)       — run the 4-check gate, print JSON to stdout, exit 0.
+* ``--check``       — exit 1 if any check failed; useful for
+                       systemd ``ExecStartPost=`` style invocations
+                       that want to react to gate failure without
+                       performing an action.
+* ``--auto``        — after running the gate, *act on* the recommended
+                       ``next_action`` by invoking the corresponding
+                       :mod:`slot_mgr` verb:
+
+                         next_action="promote" → slot_mgr.promote_slot(running_slot)
+                         next_action="strike"  → slot_mgr.record_tryboot_strike(running_slot)
+                         next_action="skipped" → no-op
+                         next_action="error"   → no action, exit 2
+
+                       The emitted JSON adds ``action_taken`` and any
+                       ``action_error``.
+
+JSON shape (without ``--auto``)::
+
+    {
+      "ok": true,
+      "next_action": "promote",
+      "running_slot": 2,
+      "tentative": true,
+      "error": "",
+      "checks": [
+        {"name": "agora_services_active", "ok": true, "detail": "…", "measurement": {…}},
+        ...
+      ]
+    }
+
+Exit codes:
+
+* 0 — checks ran (default), or checks ran + acted (--auto), or
+      ``--check`` and ``ok=True``.
+* 1 — ``--check`` and ``ok=False``.
+* 2 — couldn't even run the gate (slot_mgr import failed, or
+      ``next_action=="error"`` under ``--auto``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from typing import Any, Sequence
+
+from slot_confirm import __version__
+from slot_confirm.core import ConfirmStatus, slot_confirm
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m slot_confirm",
+        description=(
+            "Run the slot-confirm 4-check gate against the current boot."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"slot_confirm {__version__}",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any check failed",
+    )
+    parser.add_argument(
+        "--auto",
+        action="store_true",
+        help=(
+            "act on the recommended next_action: promote / strike / skip. "
+            "Uses slot_mgr.promote_slot or slot_mgr.record_tryboot_strike."
+        ),
+    )
+    return parser
+
+
+def _act(status: ConfirmStatus) -> tuple[str, str]:
+    """Carry out ``status.next_action`` via slot_mgr.
+
+    Returns a ``(action_taken, action_error)`` tuple. ``action_taken``
+    is one of ``"promote"``, ``"strike"``, ``"skipped"``, or
+    ``"none"`` (when ``next_action == "error"``). ``action_error`` is
+    a free-form message on failure, ``""`` otherwise.
+    """
+    if status.next_action == "skipped":
+        return "skipped", ""
+
+    if status.next_action == "error":
+        return "none", status.error or "slot_state() failed"
+
+    if status.running_slot is None:
+        return "none", "running_slot is unknown; cannot act"
+
+    try:
+        from slot_mgr import promote_slot, record_tryboot_strike
+    except ImportError as exc:
+        return "none", f"slot_mgr import failed: {exc}"
+
+    try:
+        if status.next_action == "promote":
+            promote_slot(status.running_slot)
+            return "promote", ""
+        if status.next_action == "strike":
+            record_tryboot_strike(
+                status.running_slot,
+                reason="slot-confirm checks failed",
+            )
+            return "strike", ""
+    except Exception as exc:  # noqa: BLE001
+        return "none", f"{status.next_action} action raised: {exc}"
+
+    return "none", f"unrecognised next_action {status.next_action!r}"
+
+
+def _to_payload(status: ConfirmStatus) -> dict[str, Any]:
+    """Convert :class:`ConfirmStatus` to a JSON-friendly dict."""
+    payload = asdict(status)
+    # asdict turns the checks tuple into a list of dicts; re-wrap
+    # each measurement so JSON serialises cleanly even if it was a
+    # custom Mapping.
+    checks = []
+    for c in payload.get("checks", []):
+        measurement = c.get("measurement") or {}
+        checks.append(
+            {
+                "name": c["name"],
+                "ok": c["ok"],
+                "detail": c["detail"],
+                "measurement": dict(measurement),
+            }
+        )
+    payload["checks"] = checks
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    status = slot_confirm()
+    payload = _to_payload(status)
+
+    if args.auto:
+        action_taken, action_error = _act(status)
+        payload["action_taken"] = action_taken
+        payload["action_error"] = action_error
+
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+    if args.auto and status.next_action == "error":
+        return 2
+    if args.check and not status.ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slot_confirm/core.py
+++ b/slot_confirm/core.py
@@ -1,0 +1,679 @@
+"""Implementation of the slot-confirm 4-check gate.
+
+Design mirrors :mod:`precheck.core` and :mod:`migration_fence.core`:
+
+* Each check is a top-level function returning :class:`CheckResult`.
+* Every check has an injection seam (``runner``, ``opener``, ``writer``,
+  ``reader``) so tests can stub the underlying syscall without
+  monkey-patching ``subprocess``/``builtins.open``.
+* :func:`slot_confirm` is the aggregator: it looks up the boot state
+  via :mod:`slot_mgr`, runs the 4 checks, and labels the recommended
+  ``next_action``.
+
+Routine failures (service inactive, framebuffer missing, ``/data`` read-only)
+return ``CheckResult(ok=False, …)`` — never raise. :class:`SlotConfirmError`
+is reserved for programmer errors (negative thresholds, missing
+``slot_mgr`` module).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+#: The agora-* systemd units that must be active for the gate to pass.
+#: Order is informational — every entry is checked independently.
+DEFAULT_AGORA_SERVICES: tuple[str, ...] = (
+    "agora-api.service",
+    "agora-cms-client.service",
+    "agora-player.service",
+    "agora-watchdog.service",
+)
+
+#: Minimum seconds a service must have been Active for the check to pass.
+#: Plan §137: "agora.service active for ≥5 min".
+DEFAULT_MIN_ACTIVE_SECONDS: int = 5 * 60
+
+#: Default framebuffer device on Pi 5 (HDMI0).
+DEFAULT_FRAMEBUFFER_DEVICE: str = "/dev/fb0"
+
+#: Directory under which the data-writable check creates its probe file.
+#: ``slot_mgr`` already creates and uses this directory for slot-state.json.
+DEFAULT_DATA_PROBE_DIR: str = "/data/agora"
+
+#: WPS receiver status file. Written by ``cms_client/service.py``.
+#: Schema (subset used here): ``{"state": "connected" | "connecting" |
+#: "disconnected" | "error", ...}``.
+DEFAULT_CMS_STATUS_PATH: str = "/opt/agora/state/cms_status.json"
+
+
+# ── Types ───────────────────────────────────────────────────────────────────
+
+
+class SlotConfirmError(RuntimeError):
+    """Programmer error in calling a slot-confirm function.
+
+    Routine "the check failed" outcomes return
+    :class:`CheckResult` (``ok=False``); this exception is reserved
+    for bugs (invalid threshold, missing required module, etc.).
+    """
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of one slot-confirm check."""
+
+    name: str
+    ok: bool
+    detail: str
+    measurement: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConfirmStatus:
+    """Aggregated outcome of running the slot-confirm 4-check gate.
+
+    Attributes
+    ----------
+    ok
+        ``True`` iff all 4 checks passed *and* the device was on a
+        tentative boot. ``True`` is also returned when the boot was
+        **not** tentative (already on the default slot) — there's
+        nothing to confirm.
+    next_action
+        One of ``"promote"`` (tentative + all checks passed),
+        ``"strike"`` (tentative + ≥1 check failed), or ``"skipped"``
+        (not tentative). The CLI's ``--auto`` mode uses this to
+        decide which :mod:`slot_mgr` verb to invoke.
+    checks
+        Tuple of all :class:`CheckResult` instances, in the order they
+        were run. Empty when ``next_action == "skipped"``.
+    running_slot
+        The slot the device booted into (1 or 2). ``None`` if the
+        running slot could not be determined (e.g. ``slot_mgr`` raised).
+    tentative
+        ``True`` if the device booted via ``[tryboot]`` (default slot
+        differs from running slot). ``None`` if the state could not
+        be determined.
+    error
+        Free-form detail when ``next_action == "error"`` or the boot
+        state was indeterminate. Empty otherwise.
+    """
+
+    ok: bool
+    next_action: str
+    checks: tuple[CheckResult, ...] = ()
+    running_slot: Optional[int] = None
+    tentative: Optional[bool] = None
+    error: str = ""
+
+
+# ── Runner / opener / reader aliases ───────────────────────────────────────
+
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+NowFn = Callable[[], datetime]
+FrameOpener = Callable[[str], Any]
+ProbeWriter = Callable[[str, bytes], None]
+StatusReader = Callable[[str], str]
+SlotStateFn = Callable[[], Any]
+
+
+def _default_runner(
+    args: Sequence[str],
+    *,
+    check: bool = False,
+    capture_output: bool = True,
+    text: bool = True,
+    timeout: Optional[float] = None,
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        list(args),
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+    )
+
+
+def _default_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+# ── 1. agora services active for ≥5 min ────────────────────────────────────
+
+
+def _parse_systemd_timestamp(raw: str) -> Optional[datetime]:
+    """Parse a systemd ``ActiveEnterTimestamp`` (or similar) value.
+
+    systemd emits timestamps as ``"<DOW> YYYY-MM-DD HH:MM:SS UTC"`` (e.g.
+    ``"Mon 2026-04-22 19:30:11 UTC"``) when ``LANG=C`` is in effect, which
+    is the case under systemd unit execution. Returns ``None`` for the
+    sentinel empty value emitted before the service has ever activated.
+    """
+    raw = (raw or "").strip()
+    if not raw or raw == "0" or raw.startswith("n/a"):
+        return None
+    # Strip the leading day-of-week if present ("Mon ").
+    parts = raw.split(maxsplit=1)
+    payload = parts[1] if len(parts) == 2 and parts[0].isalpha() else raw
+    # Try "YYYY-MM-DD HH:MM:SS TZ"
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S %Z",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            dt = datetime.strptime(payload, fmt)
+            if dt.tzinfo is None:
+                # systemd's "UTC" suffix is dropped by %Z on many platforms;
+                # the timestamp itself is wall-clock UTC.
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    return None
+
+
+def check_agora_services_active(
+    *,
+    services: Sequence[str] = DEFAULT_AGORA_SERVICES,
+    min_active_seconds: int = DEFAULT_MIN_ACTIVE_SECONDS,
+    runner: Optional[Runner] = None,
+    now_fn: Optional[NowFn] = None,
+) -> CheckResult:
+    """Verify every ``services`` entry is Active and has been so for ≥ ``min_active_seconds``.
+
+    Returns ``ok=False`` on the first service that is not active or has
+    been active for less than the threshold. The reason and offending
+    service are recorded in ``detail`` and ``measurement``.
+    """
+    if min_active_seconds < 0:
+        raise SlotConfirmError(
+            f"min_active_seconds must be non-negative, got {min_active_seconds!r}"
+        )
+    if not services:
+        raise SlotConfirmError("services must contain at least one entry")
+
+    run = runner or _default_runner
+    now = (now_fn or _default_now)()
+
+    per_service: dict[str, dict[str, Any]] = {}
+    for unit in services:
+        try:
+            cp = run(
+                [
+                    "systemctl",
+                    "show",
+                    unit,
+                    "--property=ActiveState",
+                    "--property=ActiveEnterTimestamp",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except FileNotFoundError as exc:
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=f"systemctl not available: {exc}",
+                measurement={"service": unit, "errno": getattr(exc, "errno", None)},
+            )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=f"systemctl timed out for {unit}",
+                measurement={"service": unit},
+            )
+
+        active_state: Optional[str] = None
+        enter_raw: str = ""
+        for line in (cp.stdout or "").splitlines():
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key == "ActiveState":
+                active_state = value.strip()
+            elif key == "ActiveEnterTimestamp":
+                enter_raw = value.strip()
+
+        if active_state != "active":
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=f"{unit} is {active_state!r}, expected 'active'",
+                measurement={
+                    "service": unit,
+                    "active_state": active_state,
+                    "stderr": (cp.stderr or "").strip(),
+                },
+            )
+
+        entered = _parse_systemd_timestamp(enter_raw)
+        if entered is None:
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=f"{unit} has no ActiveEnterTimestamp",
+                measurement={
+                    "service": unit,
+                    "active_enter_raw": enter_raw,
+                },
+            )
+
+        age = (now - entered).total_seconds()
+        per_service[unit] = {
+            "active_for_seconds": age,
+            "entered_at": entered.isoformat(),
+        }
+        if age < min_active_seconds:
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=(
+                    f"{unit} has been active for {age:.0f}s, "
+                    f"need ≥{min_active_seconds}s"
+                ),
+                measurement={
+                    "service": unit,
+                    "active_for_seconds": age,
+                    "min_active_seconds": min_active_seconds,
+                    "entered_at": entered.isoformat(),
+                },
+            )
+
+    return CheckResult(
+        name="agora_services_active",
+        ok=True,
+        detail=(
+            f"all {len(services)} agora services active for "
+            f"≥{min_active_seconds}s"
+        ),
+        measurement={
+            "services": list(services),
+            "min_active_seconds": min_active_seconds,
+            "per_service": per_service,
+        },
+    )
+
+
+# ── 2. framebuffer writable ────────────────────────────────────────────────
+
+
+def check_framebuffer(
+    *,
+    device: str = DEFAULT_FRAMEBUFFER_DEVICE,
+    opener: Optional[FrameOpener] = None,
+) -> CheckResult:
+    """Verify a test frame can be submitted to the framebuffer.
+
+    The default implementation opens ``device`` for writing and writes
+    a single zero-byte block, then closes. Any ``OSError`` (no device,
+    EACCES, EIO) returns ``ok=False`` with the errno in the measurement.
+
+    Tests pass an ``opener`` stub that mimics the ``open(path, mode)``
+    signature; the function then calls ``write`` and ``close`` on the
+    returned file object.
+    """
+    open_fn: FrameOpener = opener or (lambda path: open(path, "wb"))
+    try:
+        fh = open_fn(device)
+    except FileNotFoundError as exc:
+        return CheckResult(
+            name="framebuffer",
+            ok=False,
+            detail=f"framebuffer device not found: {device}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+        )
+    except PermissionError as exc:
+        return CheckResult(
+            name="framebuffer",
+            ok=False,
+            detail=f"framebuffer device not writable: {device}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+        )
+    except OSError as exc:
+        return CheckResult(
+            name="framebuffer",
+            ok=False,
+            detail=f"framebuffer open failed: {exc}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+        )
+
+    try:
+        try:
+            fh.write(b"\x00")
+        except OSError as exc:
+            return CheckResult(
+                name="framebuffer",
+                ok=False,
+                detail=f"framebuffer write failed: {exc}",
+                measurement={"device": device, "errno": getattr(exc, "errno", None)},
+            )
+    finally:
+        close = getattr(fh, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+
+    return CheckResult(
+        name="framebuffer",
+        ok=True,
+        detail=f"test frame written to {device}",
+        measurement={"device": device, "bytes_written": 1},
+    )
+
+
+# ── 3. /data is mounted r/w ────────────────────────────────────────────────
+
+
+def check_data_writable(
+    *,
+    probe_dir: str = DEFAULT_DATA_PROBE_DIR,
+    writer: Optional[ProbeWriter] = None,
+) -> CheckResult:
+    """Verify ``probe_dir`` is writable by writing + removing a probe file.
+
+    The default implementation:
+
+    1. Creates a unique probe path under ``probe_dir``.
+    2. Writes a small payload to it via ``open(path, "wb")``.
+    3. Removes the probe file.
+
+    Any failure (read-only mount, missing dir, ENOSPC) returns
+    ``ok=False`` with the errno in the measurement.
+
+    Tests pass a ``writer`` stub: ``writer(path, payload)`` that mimics
+    the write step. Cleanup is the default's responsibility — tests
+    don't need to remove anything.
+    """
+    probe_name = f".slot-confirm-probe-{uuid.uuid4().hex}"
+    probe_path = os.path.join(probe_dir, probe_name)
+
+    if writer is not None:
+        try:
+            writer(probe_path, b"slot-confirm probe\n")
+        except FileNotFoundError as exc:
+            return CheckResult(
+                name="data_writable",
+                ok=False,
+                detail=f"probe directory not found: {probe_dir}",
+                measurement={
+                    "probe_path": probe_path,
+                    "errno": getattr(exc, "errno", None),
+                },
+            )
+        except (PermissionError, OSError) as exc:
+            return CheckResult(
+                name="data_writable",
+                ok=False,
+                detail=f"probe write failed: {exc}",
+                measurement={
+                    "probe_path": probe_path,
+                    "errno": getattr(exc, "errno", None),
+                },
+            )
+        return CheckResult(
+            name="data_writable",
+            ok=True,
+            detail=f"probe write succeeded under {probe_dir}",
+            measurement={"probe_path": probe_path},
+        )
+
+    try:
+        with open(probe_path, "wb") as fh:
+            fh.write(b"slot-confirm probe\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+    except FileNotFoundError as exc:
+        return CheckResult(
+            name="data_writable",
+            ok=False,
+            detail=f"probe directory not found: {probe_dir}",
+            measurement={"probe_path": probe_path, "errno": getattr(exc, "errno", None)},
+        )
+    except (PermissionError, OSError) as exc:
+        return CheckResult(
+            name="data_writable",
+            ok=False,
+            detail=f"probe write failed: {exc}",
+            measurement={"probe_path": probe_path, "errno": getattr(exc, "errno", None)},
+        )
+
+    try:
+        os.unlink(probe_path)
+    except OSError:
+        # Leaving a stale probe file is not a failure of the r/w check —
+        # the write itself succeeded, which is what we're testing.
+        pass
+
+    return CheckResult(
+        name="data_writable",
+        ok=True,
+        detail=f"probe write+remove succeeded under {probe_dir}",
+        measurement={"probe_path": probe_path},
+    )
+
+
+# ── 4. WPS receiver reports connected ──────────────────────────────────────
+
+
+def check_wps_connected(
+    *,
+    status_path: str = DEFAULT_CMS_STATUS_PATH,
+    reader: Optional[StatusReader] = None,
+) -> CheckResult:
+    """Verify the WPS receiver has written ``state: "connected"`` to its status file.
+
+    Reads ``status_path`` (default ``/opt/agora/state/cms_status.json``)
+    written by :mod:`cms_client.service`. ``state`` must equal
+    ``"connected"``; any other value (``connecting``, ``disconnected``,
+    ``error``) is a fail.
+
+    Note: this does **not** verify CMS *reachability* — only that the
+    WPS receiver process is up and reports a live connection. If the
+    CMS itself is briefly unreachable, the receiver will write
+    ``"disconnected"`` and this check will (correctly) fail.
+
+    Tests pass a ``reader`` stub returning the raw JSON text.
+    """
+    if reader is not None:
+        try:
+            raw = reader(status_path)
+        except FileNotFoundError as exc:
+            return CheckResult(
+                name="wps_connected",
+                ok=False,
+                detail=f"status file not found: {status_path}",
+                measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            )
+        except (PermissionError, OSError) as exc:
+            return CheckResult(
+                name="wps_connected",
+                ok=False,
+                detail=f"status file unreadable: {exc}",
+                measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            )
+    else:
+        try:
+            raw = Path(status_path).read_text()
+        except FileNotFoundError as exc:
+            return CheckResult(
+                name="wps_connected",
+                ok=False,
+                detail=f"status file not found: {status_path}",
+                measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            )
+        except (PermissionError, OSError) as exc:
+            return CheckResult(
+                name="wps_connected",
+                ok=False,
+                detail=f"status file unreadable: {exc}",
+                measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            )
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        return CheckResult(
+            name="wps_connected",
+            ok=False,
+            detail=f"status file not valid JSON: {exc}",
+            measurement={"status_path": status_path},
+        )
+
+    if not isinstance(payload, dict):
+        return CheckResult(
+            name="wps_connected",
+            ok=False,
+            detail="status file payload is not a JSON object",
+            measurement={"status_path": status_path, "payload_type": type(payload).__name__},
+        )
+
+    state = payload.get("state")
+    registration = payload.get("registration", "")
+    if state == "connected":
+        return CheckResult(
+            name="wps_connected",
+            ok=True,
+            detail=(
+                f"WPS receiver reports connected (registration={registration!r})"
+                if registration
+                else "WPS receiver reports connected"
+            ),
+            measurement={
+                "status_path": status_path,
+                "state": state,
+                "registration": registration,
+            },
+        )
+
+    return CheckResult(
+        name="wps_connected",
+        ok=False,
+        detail=f"WPS receiver state is {state!r}, expected 'connected'",
+        measurement={
+            "status_path": status_path,
+            "state": state,
+            "registration": registration,
+        },
+    )
+
+
+# ── Aggregator ─────────────────────────────────────────────────────────────
+
+
+def _default_slot_state() -> Any:
+    """Lazily import :mod:`slot_mgr` so tests can stub it.
+
+    Tests inject a fake by ``monkeypatch.setitem(sys.modules, "slot_mgr", fake)``
+    or by passing ``slot_state_fn=`` to :func:`slot_confirm` directly.
+    """
+    from slot_mgr import slot_state  # noqa: WPS433 (intentional lazy import)
+
+    return slot_state()
+
+
+def _safe_slot_info(slot_state_fn: SlotStateFn) -> tuple[Optional[int], Optional[bool], str]:
+    """Return ``(running_slot, tentative, error_detail)`` without raising."""
+    try:
+        status = slot_state_fn()
+    except Exception as exc:  # noqa: BLE001
+        return None, None, f"slot_state() raised: {exc}"
+
+    running = getattr(status, "running_slot", None)
+    tentative = getattr(status, "tentative", None)
+    return running, tentative, ""
+
+
+def slot_confirm(
+    *,
+    slot_state_fn: Optional[SlotStateFn] = None,
+    agora_service_fn: Optional[Callable[[], CheckResult]] = None,
+    framebuffer_fn: Optional[Callable[[], CheckResult]] = None,
+    data_writable_fn: Optional[Callable[[], CheckResult]] = None,
+    wps_connected_fn: Optional[Callable[[], CheckResult]] = None,
+) -> ConfirmStatus:
+    """Run the slot-confirm 4-check gate against the current boot.
+
+    Steps:
+
+    1. Look up running_slot + tentative via :mod:`slot_mgr`.
+       * If lookup fails → return ``next_action="error"``.
+       * If not tentative → return ``next_action="skipped"`` (nothing to
+         confirm; the device is already on the default slot).
+    2. Tentative → run all 4 checks and aggregate.
+       * Every check passed → ``next_action="promote"``.
+       * Any check failed → ``next_action="strike"``.
+
+    Each ``*_fn`` parameter overrides the corresponding check; useful
+    for tests and for callers that want to short-circuit one of the
+    pillars (e.g. a headless test rig with no framebuffer).
+    """
+    slot_state_fn = slot_state_fn or _default_slot_state
+    running, tentative, err = _safe_slot_info(slot_state_fn)
+
+    if err:
+        return ConfirmStatus(
+            ok=False,
+            next_action="error",
+            checks=(),
+            running_slot=running,
+            tentative=tentative,
+            error=err,
+        )
+
+    if tentative is False:
+        return ConfirmStatus(
+            ok=True,
+            next_action="skipped",
+            checks=(),
+            running_slot=running,
+            tentative=False,
+            error="",
+        )
+
+    # Tentative (True) or unknown (None) — run the gate either way.
+    # Unknown is unusual but we still want signal; the caller decides
+    # what to do with ok=True/next_action="promote" when tentative is None.
+    fns = (
+        agora_service_fn or check_agora_services_active,
+        framebuffer_fn or check_framebuffer,
+        data_writable_fn or check_data_writable,
+        wps_connected_fn or check_wps_connected,
+    )
+
+    results: list[CheckResult] = []
+    all_ok = True
+    for fn in fns:
+        result = fn()
+        results.append(result)
+        if not result.ok:
+            all_ok = False
+
+    if all_ok:
+        next_action = "promote"
+        ok = True
+    else:
+        next_action = "strike"
+        ok = False
+
+    return ConfirmStatus(
+        ok=ok,
+        next_action=next_action,
+        checks=tuple(results),
+        running_slot=running,
+        tentative=tentative,
+        error="",
+    )

--- a/systemd/agora-slot-mgr.service
+++ b/systemd/agora-slot-mgr.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=Agora slot-confirm gate (post-tryboot promote/strike decision)
+Documentation=https://github.com/sslivins/agora/blob/main/slot_confirm/README.md
+# Run after the agora-* services have had time to come up, since the
+# gate verifies they have been Active for ≥5 min.  We do not block on
+# any of them via `After=` — the gate's own logic returns
+# `next_action="strike"` if they haven't come up yet, which is what we
+# want (the strike counter is what eventually pins a broken slot).
+After=agora-api.service
+After=agora-cms-client.service
+After=agora-player.service
+After=agora-watchdog.service
+DefaultDependencies=yes
+
+[Service]
+# `oneshot` so the unit runs once after boot and exits; the gate's job
+# is a single decision, not a long-running daemon. Combined with
+# `Restart=on-failure` below, this gives us a bounded retry budget when
+# `slot_state()` or one of the checks raises transiently.
+Type=oneshot
+ExecStart=/usr/bin/python3 -m slot_confirm --auto
+WorkingDirectory=/opt/agora/src
+Environment=PYTHONPATH=/opt/agora/src
+Environment=AGORA_BASE=/opt/agora
+
+# Retry transient failures (e.g. systemctl-show RPC timeout, status
+# file briefly missing) up to ~5 minutes total. `next_action="error"`
+# from --auto exits 2 which counts as failure; `strike` exits 0, so
+# the unit stops on its own as soon as a non-error decision has been
+# recorded.
+Restart=on-failure
+RestartSec=30
+StartLimitBurst=10
+StartLimitIntervalSec=600
+
+# Both `--auto` exit codes that mean "ran to completion" are 0 or 1,
+# and we already filter exit 1 via `--auto` (which always exits 0 or 2).
+# Keep SuccessExitStatus minimal; let the retry budget handle failures.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_slot_confirm.py
+++ b/tests/test_slot_confirm.py
@@ -1,0 +1,774 @@
+"""Tests for the :mod:`slot_confirm` package.
+
+The 4 checks each have their own ``Test*`` class; the aggregator
+:func:`slot_confirm.slot_confirm` has its own class; the CLI has
+its own class. Every test runs without root, without /data, without
+/dev/fb0, and without a real systemctl — every external surface is
+injected via the documented seams (``runner``, ``opener``,
+``writer``, ``reader``, ``slot_state_fn``).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any, Sequence
+from unittest.mock import patch
+
+import pytest
+
+from slot_confirm import (
+    DEFAULT_AGORA_SERVICES,
+    CheckResult,
+    ConfirmStatus,
+    SlotConfirmError,
+    __version__,
+    check_agora_services_active,
+    check_data_writable,
+    check_framebuffer,
+    check_wps_connected,
+    slot_confirm,
+)
+from slot_confirm import __main__ as cli
+from slot_confirm import core as scc
+
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────────
+
+
+FakeStatus = namedtuple("FakeStatus", ["running_slot", "default_slot", "tentative"])
+
+
+def _fixed_now(seconds_ago: int = 0) -> datetime:
+    base = datetime(2026, 4, 22, 19, 30, 0, tzinfo=timezone.utc)
+    return base + timedelta(seconds=seconds_ago)
+
+
+def _show_output(active_state: str, entered_at: str = "") -> str:
+    return f"ActiveState={active_state}\nActiveEnterTimestamp={entered_at}\n"
+
+
+def _systemctl_runner(per_service: dict[str, tuple[str, str]]) -> scc.Runner:
+    """Build a runner that returns canned ``systemctl show`` output per service.
+
+    ``per_service`` is ``{unit: (active_state, entered_raw)}``.
+    """
+
+    def runner(
+        args: Sequence[str],
+        *,
+        check: bool = False,
+        capture_output: bool = True,
+        text: bool = True,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        unit = args[2]
+        active, entered = per_service.get(unit, ("inactive", ""))
+        return subprocess.CompletedProcess(
+            args=list(args),
+            returncode=0,
+            stdout=_show_output(active, entered),
+            stderr="",
+        )
+
+    return runner
+
+
+# ── _parse_systemd_timestamp ───────────────────────────────────────────────
+
+
+class TestParseSystemdTimestamp:
+    def test_dow_prefix_with_utc(self) -> None:
+        ts = scc._parse_systemd_timestamp("Mon 2026-04-22 19:30:11 UTC")
+        assert ts == datetime(2026, 4, 22, 19, 30, 11, tzinfo=timezone.utc)
+
+    def test_no_dow_prefix_with_utc(self) -> None:
+        ts = scc._parse_systemd_timestamp("2026-04-22 19:30:11 UTC")
+        assert ts == datetime(2026, 4, 22, 19, 30, 11, tzinfo=timezone.utc)
+
+    def test_no_timezone_suffix_treated_as_utc(self) -> None:
+        ts = scc._parse_systemd_timestamp("2026-04-22 19:30:11")
+        assert ts is not None
+        assert ts.tzinfo is timezone.utc
+
+    def test_empty_returns_none(self) -> None:
+        assert scc._parse_systemd_timestamp("") is None
+
+    def test_zero_returns_none(self) -> None:
+        assert scc._parse_systemd_timestamp("0") is None
+
+    def test_na_returns_none(self) -> None:
+        assert scc._parse_systemd_timestamp("n/a") is None
+
+    def test_malformed_returns_none(self) -> None:
+        assert scc._parse_systemd_timestamp("not a date") is None
+
+
+# ── check_agora_services_active ────────────────────────────────────────────
+
+
+class TestCheckAgoraServicesActive:
+    def test_happy_path(self) -> None:
+        now = _fixed_now(0)
+        entered = (now - timedelta(seconds=600)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        runner = _systemctl_runner(
+            {svc: ("active", entered) for svc in DEFAULT_AGORA_SERVICES}
+        )
+        result = check_agora_services_active(runner=runner, now_fn=lambda: now)
+        assert result.ok is True
+        assert result.name == "agora_services_active"
+        assert len(result.measurement["per_service"]) == len(DEFAULT_AGORA_SERVICES)
+
+    def test_inactive_service_fails(self) -> None:
+        now = _fixed_now(0)
+        entered = (now - timedelta(seconds=600)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        # First service inactive, others fine.
+        per = {svc: ("active", entered) for svc in DEFAULT_AGORA_SERVICES}
+        per[DEFAULT_AGORA_SERVICES[0]] = ("inactive", entered)
+        runner = _systemctl_runner(per)
+        result = check_agora_services_active(runner=runner, now_fn=lambda: now)
+        assert result.ok is False
+        assert "inactive" in result.detail
+        assert result.measurement["service"] == DEFAULT_AGORA_SERVICES[0]
+
+    def test_too_young_fails(self) -> None:
+        now = _fixed_now(0)
+        entered = (now - timedelta(seconds=60)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        runner = _systemctl_runner(
+            {svc: ("active", entered) for svc in DEFAULT_AGORA_SERVICES}
+        )
+        result = check_agora_services_active(
+            runner=runner, now_fn=lambda: now, min_active_seconds=300
+        )
+        assert result.ok is False
+        assert "60s" in result.detail
+        assert result.measurement["active_for_seconds"] == pytest.approx(60.0)
+
+    def test_missing_timestamp_fails(self) -> None:
+        now = _fixed_now(0)
+        runner = _systemctl_runner(
+            {svc: ("active", "") for svc in DEFAULT_AGORA_SERVICES}
+        )
+        result = check_agora_services_active(runner=runner, now_fn=lambda: now)
+        assert result.ok is False
+        assert "no ActiveEnterTimestamp" in result.detail
+
+    def test_custom_service_list(self) -> None:
+        now = _fixed_now(0)
+        entered = (now - timedelta(seconds=600)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        runner = _systemctl_runner({"agora-api.service": ("active", entered)})
+        result = check_agora_services_active(
+            services=("agora-api.service",),
+            runner=runner,
+            now_fn=lambda: now,
+        )
+        assert result.ok is True
+        assert result.measurement["services"] == ["agora-api.service"]
+
+    def test_systemctl_missing(self) -> None:
+        def runner(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            raise FileNotFoundError(2, "No such file or directory", "systemctl")
+
+        result = check_agora_services_active(runner=runner, now_fn=_fixed_now)
+        assert result.ok is False
+        assert "systemctl not available" in result.detail
+
+    def test_systemctl_timeout(self) -> None:
+        def runner(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="systemctl", timeout=10)
+
+        result = check_agora_services_active(runner=runner, now_fn=_fixed_now)
+        assert result.ok is False
+        assert "timed out" in result.detail
+
+    def test_negative_threshold_raises(self) -> None:
+        with pytest.raises(SlotConfirmError, match="non-negative"):
+            check_agora_services_active(min_active_seconds=-1, runner=lambda *a, **k: None)
+
+    def test_empty_services_raises(self) -> None:
+        with pytest.raises(SlotConfirmError, match="at least one"):
+            check_agora_services_active(services=(), runner=lambda *a, **k: None)
+
+    def test_default_runner_is_real_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["args"] = args
+            return subprocess.CompletedProcess(
+                args=list(args[0]),
+                returncode=0,
+                stdout=_show_output("inactive"),
+                stderr="",
+            )
+
+        monkeypatch.setattr(scc.subprocess, "run", fake_run)
+        result = check_agora_services_active(
+            services=("agora-api.service",), now_fn=_fixed_now
+        )
+        assert result.ok is False  # because we returned "inactive"
+        assert captured["args"][0][0] == "systemctl"
+
+
+# ── check_framebuffer ──────────────────────────────────────────────────────
+
+
+class _FakeFile:
+    def __init__(self, *, write_raises: BaseException | None = None) -> None:
+        self.write_raises = write_raises
+        self.written: list[bytes] = []
+        self.closed = False
+
+    def write(self, data: bytes) -> int:
+        if self.write_raises is not None:
+            raise self.write_raises
+        self.written.append(data)
+        return len(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestCheckFramebuffer:
+    def test_happy_path(self) -> None:
+        fake = _FakeFile()
+        result = check_framebuffer(opener=lambda path: fake)
+        assert result.ok is True
+        assert fake.written == [b"\x00"]
+        assert fake.closed is True
+
+    def test_device_not_found(self) -> None:
+        def opener(path: str) -> Any:
+            raise FileNotFoundError(2, "No such file or directory", path)
+
+        result = check_framebuffer(opener=opener)
+        assert result.ok is False
+        assert "not found" in result.detail
+        assert result.measurement["errno"] == 2
+
+    def test_permission_denied(self) -> None:
+        def opener(path: str) -> Any:
+            raise PermissionError(13, "Permission denied", path)
+
+        result = check_framebuffer(opener=opener)
+        assert result.ok is False
+        assert "not writable" in result.detail
+        assert result.measurement["errno"] == 13
+
+    def test_open_oserror(self) -> None:
+        def opener(path: str) -> Any:
+            raise OSError(5, "Input/output error", path)
+
+        result = check_framebuffer(opener=opener)
+        assert result.ok is False
+        assert "open failed" in result.detail
+
+    def test_write_oserror_still_closes(self) -> None:
+        fake = _FakeFile(write_raises=OSError(5, "I/O"))
+        result = check_framebuffer(opener=lambda path: fake)
+        assert result.ok is False
+        assert "write failed" in result.detail
+        assert fake.closed is True
+
+    def test_custom_device(self) -> None:
+        fake = _FakeFile()
+        captured: dict[str, str] = {}
+
+        def opener(path: str) -> Any:
+            captured["path"] = path
+            return fake
+
+        result = check_framebuffer(device="/dev/fb1", opener=opener)
+        assert captured["path"] == "/dev/fb1"
+        assert result.measurement["device"] == "/dev/fb1"
+        assert result.ok is True
+
+
+# ── check_data_writable ────────────────────────────────────────────────────
+
+
+class TestCheckDataWritable:
+    def test_happy_path_with_writer_stub(self) -> None:
+        captured: list[tuple[str, bytes]] = []
+
+        def writer(path: str, payload: bytes) -> None:
+            captured.append((path, payload))
+
+        result = check_data_writable(writer=writer)
+        assert result.ok is True
+        assert len(captured) == 1
+        # os.path.join uses backslashes on Windows, so just match the leaf.
+        assert ".slot-confirm-probe-" in captured[0][0]
+        assert b"slot-confirm" in captured[0][1]
+
+    def test_dir_not_found(self) -> None:
+        def writer(path: str, payload: bytes) -> None:
+            raise FileNotFoundError(2, "No such file or directory", path)
+
+        result = check_data_writable(writer=writer)
+        assert result.ok is False
+        assert "not found" in result.detail
+
+    def test_permission_denied(self) -> None:
+        def writer(path: str, payload: bytes) -> None:
+            raise PermissionError(13, "Permission denied", path)
+
+        result = check_data_writable(writer=writer)
+        assert result.ok is False
+        assert "write failed" in result.detail
+        assert result.measurement["errno"] == 13
+
+    def test_readonly_oserror(self) -> None:
+        def writer(path: str, payload: bytes) -> None:
+            raise OSError(30, "Read-only file system", path)
+
+        result = check_data_writable(writer=writer)
+        assert result.ok is False
+        assert result.measurement["errno"] == 30
+
+    def test_default_writer_real_file_roundtrip(self, tmp_path: Any) -> None:
+        result = check_data_writable(probe_dir=str(tmp_path))
+        assert result.ok is True
+        # Probe file should have been cleaned up.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_default_writer_cleanup_failure_still_ok(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If unlink raises, the check should still return ok=True — the
+        # write succeeded, which is what we're testing.
+        def _fail_unlink(path: Any) -> None:
+            raise OSError(1, "cannot remove")
+
+        monkeypatch.setattr(scc.os, "unlink", _fail_unlink)
+        result = check_data_writable(probe_dir=str(tmp_path))
+        assert result.ok is True
+        # And the file is still there because unlink "failed".
+        assert len(list(tmp_path.iterdir())) == 1
+
+
+# ── check_wps_connected ────────────────────────────────────────────────────
+
+
+def _reader_returning(content: str):
+    def reader(path: str) -> str:
+        return content
+
+    return reader
+
+
+def _reader_raising(exc: BaseException):
+    def reader(path: str) -> str:
+        raise exc
+
+    return reader
+
+
+class TestCheckWpsConnected:
+    def test_happy_path(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_returning(
+                json.dumps({"state": "connected", "registration": "registered"})
+            )
+        )
+        assert result.ok is True
+        assert "registered" in result.detail
+        assert result.measurement["state"] == "connected"
+
+    def test_disconnected_fails(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_returning(json.dumps({"state": "disconnected"}))
+        )
+        assert result.ok is False
+        assert "'disconnected'" in result.detail
+
+    def test_connecting_fails(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_returning(json.dumps({"state": "connecting"}))
+        )
+        assert result.ok is False
+
+    def test_error_state_fails(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_returning(json.dumps({"state": "error", "error": "boom"}))
+        )
+        assert result.ok is False
+
+    def test_missing_state_field_fails(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_returning(json.dumps({"registration": "pending"}))
+        )
+        assert result.ok is False
+        assert "None" in result.detail
+
+    def test_file_not_found(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_raising(FileNotFoundError(2, "no such file", "x"))
+        )
+        assert result.ok is False
+        assert "not found" in result.detail
+
+    def test_permission_denied(self) -> None:
+        result = check_wps_connected(
+            reader=_reader_raising(PermissionError(13, "denied", "x"))
+        )
+        assert result.ok is False
+        assert "unreadable" in result.detail
+
+    def test_invalid_json_fails(self) -> None:
+        result = check_wps_connected(reader=_reader_returning("not json {{{"))
+        assert result.ok is False
+        assert "not valid JSON" in result.detail
+
+    def test_non_object_json_fails(self) -> None:
+        result = check_wps_connected(reader=_reader_returning('"connected"'))
+        assert result.ok is False
+        assert "not a JSON object" in result.detail
+
+    def test_default_reader_real_file(self, tmp_path: Any) -> None:
+        status_file = tmp_path / "cms_status.json"
+        status_file.write_text(json.dumps({"state": "connected"}))
+        result = check_wps_connected(status_path=str(status_file))
+        assert result.ok is True
+
+
+# ── slot_confirm aggregator ────────────────────────────────────────────────
+
+
+def _ok_check(name: str) -> CheckResult:
+    return CheckResult(name=name, ok=True, detail="ok")
+
+
+def _fail_check(name: str) -> CheckResult:
+    return CheckResult(name=name, ok=False, detail="bad")
+
+
+class TestSlotConfirm:
+    def test_skipped_when_not_tentative(self) -> None:
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=1, default_slot=1, tentative=False),
+            agora_service_fn=lambda: pytest.fail("should not run"),
+            framebuffer_fn=lambda: pytest.fail("should not run"),
+            data_writable_fn=lambda: pytest.fail("should not run"),
+            wps_connected_fn=lambda: pytest.fail("should not run"),
+        )
+        assert status.ok is True
+        assert status.next_action == "skipped"
+        assert status.checks == ()
+        assert status.running_slot == 1
+        assert status.tentative is False
+
+    def test_error_when_slot_state_raises(self) -> None:
+        def bad() -> Any:
+            raise RuntimeError("boom")
+
+        status = slot_confirm(
+            slot_state_fn=bad,
+            agora_service_fn=lambda: pytest.fail("should not run"),
+            framebuffer_fn=lambda: pytest.fail("should not run"),
+            data_writable_fn=lambda: pytest.fail("should not run"),
+            wps_connected_fn=lambda: pytest.fail("should not run"),
+        )
+        assert status.ok is False
+        assert status.next_action == "error"
+        assert "boom" in status.error
+
+    def test_promote_on_all_pass(self) -> None:
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=lambda: _ok_check("agora_services_active"),
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.ok is True
+        assert status.next_action == "promote"
+        assert len(status.checks) == 4
+        assert all(c.ok for c in status.checks)
+        assert status.running_slot == 2
+        assert status.tentative is True
+
+    def test_strike_on_any_fail(self) -> None:
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=lambda: _ok_check("agora_services_active"),
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _fail_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.ok is False
+        assert status.next_action == "strike"
+        assert sum(1 for c in status.checks if not c.ok) == 1
+
+    def test_strike_when_multiple_fail(self) -> None:
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=lambda: _fail_check("agora_services_active"),
+            framebuffer_fn=lambda: _fail_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.ok is False
+        assert status.next_action == "strike"
+        assert sum(1 for c in status.checks if not c.ok) == 2
+
+    def test_runs_all_4_checks_in_order(self) -> None:
+        order: list[str] = []
+
+        def mk(name: str) -> Any:
+            def fn() -> CheckResult:
+                order.append(name)
+                return _ok_check(name)
+
+            return fn
+
+        slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=mk("services"),
+            framebuffer_fn=mk("fb"),
+            data_writable_fn=mk("data"),
+            wps_connected_fn=mk("wps"),
+        )
+        assert order == ["services", "fb", "data", "wps"]
+
+    def test_tentative_none_still_runs(self) -> None:
+        # When tentative is None (unknown), we still want to run the gate
+        # and emit a recommendation so the caller can decide.
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=1, default_slot=1, tentative=None),
+            agora_service_fn=lambda: _ok_check("agora_services_active"),
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.next_action == "promote"
+        assert status.tentative is None
+
+    def test_default_slot_state_fn_consults_slot_mgr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_mod = SimpleNamespace(
+            slot_state=lambda: FakeStatus(running_slot=1, default_slot=1, tentative=False)
+        )
+        monkeypatch.setitem(sys.modules, "slot_mgr", fake_mod)
+        status = slot_confirm()
+        assert status.next_action == "skipped"
+        assert status.running_slot == 1
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def _capture(self, argv: list[str]) -> tuple[int, dict[str, Any]]:
+        with patch.object(sys, "stdout", new=io.StringIO()) as buf:
+            rc = cli.main(argv)
+        return rc, json.loads(buf.getvalue())
+
+    def test_default_run_exits_0_on_promote(self) -> None:
+        promote_status = ConfirmStatus(
+            ok=True,
+            next_action="promote",
+            checks=(_ok_check("framebuffer"),),
+            running_slot=2,
+            tentative=True,
+        )
+        with patch.object(cli, "slot_confirm", return_value=promote_status):
+            rc, payload = self._capture([])
+        assert rc == 0
+        assert payload["next_action"] == "promote"
+        assert payload["ok"] is True
+        assert "action_taken" not in payload
+
+    def test_default_run_exits_0_on_strike(self) -> None:
+        strike_status = ConfirmStatus(
+            ok=False,
+            next_action="strike",
+            checks=(_fail_check("framebuffer"),),
+            running_slot=2,
+            tentative=True,
+        )
+        with patch.object(cli, "slot_confirm", return_value=strike_status):
+            rc, payload = self._capture([])
+        assert rc == 0
+        assert payload["next_action"] == "strike"
+
+    def test_check_flag_exits_1_on_failure(self) -> None:
+        strike_status = ConfirmStatus(
+            ok=False, next_action="strike", running_slot=2, tentative=True
+        )
+        with patch.object(cli, "slot_confirm", return_value=strike_status):
+            rc, _ = self._capture(["--check"])
+        assert rc == 1
+
+    def test_check_flag_exits_0_on_success(self) -> None:
+        promote_status = ConfirmStatus(
+            ok=True, next_action="promote", running_slot=2, tentative=True
+        )
+        with patch.object(cli, "slot_confirm", return_value=promote_status):
+            rc, _ = self._capture(["--check"])
+        assert rc == 0
+
+    def test_check_flag_exits_0_when_skipped(self) -> None:
+        skipped_status = ConfirmStatus(
+            ok=True, next_action="skipped", running_slot=1, tentative=False
+        )
+        with patch.object(cli, "slot_confirm", return_value=skipped_status):
+            rc, _ = self._capture(["--check"])
+        assert rc == 0
+
+    def test_auto_promote_calls_slot_mgr(self) -> None:
+        promote_status = ConfirmStatus(
+            ok=True, next_action="promote", running_slot=2, tentative=True
+        )
+        fake_promote: list[int] = []
+        fake_mgr = SimpleNamespace(
+            promote_slot=lambda slot: fake_promote.append(slot),
+            record_tryboot_strike=lambda slot, *, reason: pytest.fail(
+                "should not strike"
+            ),
+        )
+        with patch.object(cli, "slot_confirm", return_value=promote_status), patch.dict(
+            sys.modules, {"slot_mgr": fake_mgr}
+        ):
+            rc, payload = self._capture(["--auto"])
+        assert rc == 0
+        assert fake_promote == [2]
+        assert payload["action_taken"] == "promote"
+        assert payload["action_error"] == ""
+
+    def test_auto_strike_calls_slot_mgr(self) -> None:
+        strike_status = ConfirmStatus(
+            ok=False, next_action="strike", running_slot=2, tentative=True
+        )
+        fake_strikes: list[tuple[int, str]] = []
+        fake_mgr = SimpleNamespace(
+            promote_slot=lambda slot: pytest.fail("should not promote"),
+            record_tryboot_strike=lambda slot, *, reason: fake_strikes.append(
+                (slot, reason)
+            ),
+        )
+        with patch.object(cli, "slot_confirm", return_value=strike_status), patch.dict(
+            sys.modules, {"slot_mgr": fake_mgr}
+        ):
+            rc, payload = self._capture(["--auto"])
+        # strike still exits 0 — the gate ran successfully, the slot just
+        # happened to fail. Only `next_action="error"` exits 2.
+        assert rc == 0
+        assert len(fake_strikes) == 1
+        assert fake_strikes[0][0] == 2
+        assert payload["action_taken"] == "strike"
+
+    def test_auto_skipped_is_noop(self) -> None:
+        skipped_status = ConfirmStatus(
+            ok=True, next_action="skipped", running_slot=1, tentative=False
+        )
+        fake_mgr = SimpleNamespace(
+            promote_slot=lambda slot: pytest.fail("noop"),
+            record_tryboot_strike=lambda slot, *, reason: pytest.fail("noop"),
+        )
+        with patch.object(cli, "slot_confirm", return_value=skipped_status), patch.dict(
+            sys.modules, {"slot_mgr": fake_mgr}
+        ):
+            rc, payload = self._capture(["--auto"])
+        assert rc == 0
+        assert payload["action_taken"] == "skipped"
+        assert payload["action_error"] == ""
+
+    def test_auto_error_exits_2(self) -> None:
+        error_status = ConfirmStatus(
+            ok=False,
+            next_action="error",
+            running_slot=None,
+            tentative=None,
+            error="boom",
+        )
+        with patch.object(cli, "slot_confirm", return_value=error_status):
+            rc, payload = self._capture(["--auto"])
+        assert rc == 2
+        assert payload["action_taken"] == "none"
+        assert "boom" in payload["action_error"]
+
+    def test_auto_slot_mgr_raises_recorded(self) -> None:
+        promote_status = ConfirmStatus(
+            ok=True, next_action="promote", running_slot=2, tentative=True
+        )
+
+        def boom(slot: int) -> None:
+            raise RuntimeError("disk full")
+
+        fake_mgr = SimpleNamespace(
+            promote_slot=boom,
+            record_tryboot_strike=lambda slot, *, reason: pytest.fail("noop"),
+        )
+        with patch.object(cli, "slot_confirm", return_value=promote_status), patch.dict(
+            sys.modules, {"slot_mgr": fake_mgr}
+        ):
+            rc, payload = self._capture(["--auto"])
+        # rc=0 because gate completed; we just couldn't act.
+        assert rc == 0
+        assert payload["action_taken"] == "none"
+        assert "disk full" in payload["action_error"]
+
+    def test_payload_includes_check_details(self) -> None:
+        promote_status = ConfirmStatus(
+            ok=True,
+            next_action="promote",
+            checks=(
+                CheckResult(
+                    name="framebuffer",
+                    ok=True,
+                    detail="written",
+                    measurement={"device": "/dev/fb0", "bytes_written": 1},
+                ),
+            ),
+            running_slot=2,
+            tentative=True,
+        )
+        with patch.object(cli, "slot_confirm", return_value=promote_status):
+            _, payload = self._capture([])
+        assert payload["checks"][0]["name"] == "framebuffer"
+        assert payload["checks"][0]["measurement"]["device"] == "/dev/fb0"
+
+    def test_version_flag(self) -> None:
+        with patch.object(sys, "stdout", new=io.StringIO()) as buf:
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main(["--version"])
+        assert exc_info.value.code == 0
+        assert __version__ in buf.getvalue()
+
+
+# ── Module surface ─────────────────────────────────────────────────────────
+
+
+class TestModuleSurface:
+    def test_version_is_string(self) -> None:
+        assert isinstance(__version__, str)
+        assert __version__.count(".") == 2  # MAJOR.MINOR.PATCH
+
+    def test_all_exports_resolve(self) -> None:
+        import slot_confirm
+
+        for name in slot_confirm.__all__:
+            assert hasattr(slot_confirm, name), f"__all__ lists {name!r} but it's missing"
+
+    def test_check_result_is_frozen(self) -> None:
+        result = CheckResult(name="x", ok=True, detail="y")
+        with pytest.raises(Exception):  # FrozenInstanceError subclass of AttributeError
+            result.ok = False  # type: ignore[misc]
+
+    def test_confirm_status_is_frozen(self) -> None:
+        status = ConfirmStatus(ok=True, next_action="skipped")
+        with pytest.raises(Exception):
+            status.ok = False  # type: ignore[misc]
+
+    def test_defaults_match_documented_values(self) -> None:
+        assert scc.DEFAULT_MIN_ACTIVE_SECONDS == 300
+        assert scc.DEFAULT_FRAMEBUFFER_DEVICE == "/dev/fb0"
+        assert scc.DEFAULT_CMS_STATUS_PATH == "/opt/agora/state/cms_status.json"
+        assert scc.DEFAULT_DATA_PROBE_DIR == "/data/agora"
+        assert "agora-api.service" in DEFAULT_AGORA_SERVICES


### PR DESCRIPTION
## Summary

Phase 1 — implements the post-tryboot 4-check gate (`slot_confirm`) and its systemd oneshot unit. After a successful tryboot the device is `tentative`; `agora-slot-mgr.service` runs this gate, and on all-checks-pass calls `slot_mgr.promote_slot()`. On any check fail it calls `slot_mgr.record_tryboot_strike(reason=…)` which 3-strike-pins the slot.

## What's in the gate (plan §136-141)

1. **agora-* services Active ≥5 min** — `systemctl show <unit> --property=ActiveState,ActiveEnterTimestamp` for each of `agora-api`, `agora-cms-client`, `agora-player`, `agora-watchdog`.
2. **Test frame to framebuffer** — open `/dev/fb0` wb, write a 1-byte probe.
3. **/data mounted r/w** — write+unlink a uuid-named probe file under `/data/agora/`.
4. **WPS receiver connected** — parse `/opt/agora/state/cms_status.json`, require `state == "connected"`.

Explicit non-check: CMS reachability (a CMS outage shouldn't strike a healthy device).

## Architecture

Mirrors `precheck.core` and `migration_fence.core`:

* `CheckResult(name, ok, detail, measurement)` dataclass with `measurement: Mapping[str, Any]` for structured telemetry.
* `SlotConfirmError` reserved for programmer errors. Routine failures return `CheckResult(ok=False, ...)`.
* Each check function takes a runner/opener/reader/writer injection seam → tests stub the syscalls.

`slot_confirm()` aggregator wires the 4 checks together and emits a `next_action` of `skipped` / `error` / `promote` / `strike` depending on slot state + check results.

## CLI

* `python3 -m slot_confirm --check` — runs the gate, exits 1 if any check failed (for shell scripts).
* `python3 -m slot_confirm --auto` — invokes the aggregator and dispatches to `slot_mgr.promote_slot()` / `record_tryboot_strike()` based on `next_action`.
* `python3 -m slot_confirm --version` — `slot_confirm 0.1.0`.

## systemd unit

`agora-slot-mgr.service`: Type=oneshot, After=the four agora-* services, ExecStart=`python3 -m slot_confirm --auto`, `Restart=on-failure` with `RestartSec=30s` and `StartLimitBurst=10` — gives ~5 min of retry budget which covers the 5-min Active-state threshold.

## Tests

64 unit tests across 8 classes (parse helpers, each check function, the aggregator, the CLI, public module surface). Full suite remains green: **975 passed, 30 skipped** (+64 from the 911 baseline).

## Phase 1 progress

- [x] p1-slot-mgr (#166)
- [x] p1-watchdog (#167)
- [x] p1-precheck (#168)
- [x] p1-forward-migration-fence (#169)
- [x] p1-slot-confirm (**this PR**)
- [ ] p1-update-tester, p1-chaos-harness (next)