### PR TITLE
feat(update-tester): lab-ring synthetic-load test battery (Phase 1)

### DIFF
--- a/tests/test_update_tester.py
+++ b/tests/test_update_tester.py
@@ -1,0 +1,1522 @@
+"""Tests for the update-tester synthetic-load battery."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import unittest
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+from unittest import mock
+
+from update_tester import core
+from update_tester.core import (
+    DEFAULT_RENDER_DURATION_SECONDS,
+    DEFAULT_RENDER_FPS_TOLERANCE,
+    DEFAULT_RENDER_TARGET_FPS,
+    DEFAULT_STRESS_DURATION_SECONDS,
+    DEFAULT_THERMAL_THROTTLE_CELSIUS,
+    DEFAULT_WPS_FRESHNESS_SECONDS,
+    TestBatteryResult,
+    TestResult,
+    UpdateTesterError,
+    battery_to_dict,
+    check_data_integrity,
+    check_render_canary,
+    check_stress,
+    check_wps_synthetic,
+    run_test_battery,
+)
+
+# Stop pytest from trying to collect these as test classes — they're dataclasses
+# named "TestResult" / "TestBatteryResult" from the library under test.
+TestResult.__test__ = False  # type: ignore[attr-defined]
+TestBatteryResult.__test__ = False  # type: ignore[attr-defined]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _utc(year: int = 2026, month: int = 5, day: int = 13, hour: int = 12) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=timezone.utc)
+
+
+class _TickingNow:
+    """``now_fn`` substitute that ticks forward a fixed delta per call.
+
+    Returns ``start`` on the first call, then ``start + step`` on the
+    second, and so on. Lets the render canary write frames without
+    real sleeps while keeping wall-clock arithmetic exact.
+    """
+
+    def __init__(self, start: datetime, step_seconds: float) -> None:
+        self._next = start
+        self._step = timedelta(seconds=step_seconds)
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        out = self._next
+        self._next = self._next + self._step
+        self.calls += 1
+        return out
+
+
+class _FixedSequenceNow:
+    """``now_fn`` that returns a fixed list of timestamps, then the last."""
+
+    def __init__(self, values: list[datetime]) -> None:
+        assert values, "need at least one value"
+        self._values = list(values)
+        self._last = values[-1]
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        if self._values:
+            return self._values.pop(0)
+        return self._last
+
+
+class _FakeFile:
+    """In-memory file stub supporting write/read/close/flush/fileno."""
+
+    def __init__(self, name: str = "<fake>", mode: str = "wb") -> None:
+        self.name = name
+        self.mode = mode
+        self.buffer = bytearray()
+        self.write_calls = 0
+        self.read_calls = 0
+        self.closed = False
+        self._read_offset = 0
+
+    def write(self, data: bytes) -> int:
+        if self.closed:
+            raise ValueError("write on closed file")
+        self.buffer.extend(data)
+        self.write_calls += 1
+        return len(data)
+
+    def read(self, size: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("read on closed file")
+        self.read_calls += 1
+        if size < 0 or size > len(self.buffer) - self._read_offset:
+            chunk = bytes(self.buffer[self._read_offset :])
+            self._read_offset = len(self.buffer)
+        else:
+            chunk = bytes(
+                self.buffer[self._read_offset : self._read_offset + size]
+            )
+            self._read_offset += size
+        return chunk
+
+    def flush(self) -> None:
+        return None
+
+    def fileno(self) -> int:
+        raise OSError("no fileno in fake")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_runner(responses: dict[str, "subprocess.CompletedProcess[str]"]):
+    """Build a fake runner keyed by the first arg of each invocation.
+
+    Each response is reusable. Calls to unknown commands raise
+    ``AssertionError`` so tests catch unexpected subprocess use.
+    """
+
+    def runner(
+        args, *, check=False, capture_output=True, text=True, timeout=None
+    ):
+        first = args[0]
+        if first not in responses:
+            raise AssertionError(f"unexpected runner call: {args!r}")
+        return responses[first]
+
+    return runner
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.CompletedProcess(
+        args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ── 1. Render canary ───────────────────────────────────────────────────────
+
+
+class TestCheckRenderCanary(unittest.TestCase):
+    def test_happy_path_hits_target_fps(self) -> None:
+        # 10 fps target × 10 s with _TickingNow step 0.1 s yields 99 frames
+        # written in ~10.1 s of mocked wall time (1 extra now() call for
+        # `finished`), giving ~9.80 fps — well inside the 8.5–11.5 fps
+        # tolerance band. Using a longer mocked duration keeps the
+        # off-by-one edge effect of the loop's elapsed check tiny.
+        now = _TickingNow(_utc(), 1.0 / 10)
+        fake = _FakeFile(name="/dev/fb0")
+        sleeps: list[float] = []
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=10.0,
+            target_fps=10.0,
+            opener=lambda path: fake,
+            sleeper=sleeps.append,
+            now_fn=now,
+        )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.name, "render_canary")
+        # Loop exits when elapsed >= duration; 99 writes precede that exit.
+        self.assertEqual(result.measurement["frames_written"], 99)
+        self.assertGreaterEqual(
+            result.measurement["achieved_fps"], result.measurement["fps_low"]
+        )
+        self.assertLessEqual(
+            result.measurement["achieved_fps"], result.measurement["fps_high"]
+        )
+        self.assertEqual(len(sleeps), 99)
+        for s in sleeps:
+            self.assertAlmostEqual(s, 0.1)
+
+    def test_missing_device_fails(self) -> None:
+        def opener(_path: str) -> Any:
+            raise FileNotFoundError(2, "no such device", "/dev/fb0")
+
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            opener=opener,
+            sleeper=lambda _s: None,
+            now_fn=_TickingNow(_utc(), 0.05),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("not found", result.detail)
+        self.assertEqual(result.measurement["errno"], 2)
+
+    def test_permission_denied_fails(self) -> None:
+        def opener(_path: str) -> Any:
+            raise PermissionError(13, "denied", "/dev/fb0")
+
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            opener=opener,
+            sleeper=lambda _s: None,
+            now_fn=_TickingNow(_utc(), 0.05),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("not writable", result.detail)
+        self.assertEqual(result.measurement["errno"], 13)
+
+    def test_generic_oserror_on_open_fails(self) -> None:
+        def opener(_path: str) -> Any:
+            raise OSError(5, "I/O error")
+
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            opener=opener,
+            sleeper=lambda _s: None,
+            now_fn=_TickingNow(_utc(), 0.05),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("open failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 5)
+
+    def test_write_error_mid_stream_fails(self) -> None:
+        class BadWrite(_FakeFile):
+            def write(self, data: bytes) -> int:
+                if self.write_calls >= 2:
+                    raise OSError(5, "EIO mid-write")
+                return super().write(data)
+
+        bad = BadWrite()
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            opener=lambda _p: bad,
+            sleeper=lambda _s: None,
+            now_fn=_TickingNow(_utc(), 0.05),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("write failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 5)
+        self.assertTrue(bad.closed)
+
+    def test_too_slow_fps_fails(self) -> None:
+        # Tick by 1.0 s/call → only 1 frame in 1 s → 1 fps, target 10.
+        now = _TickingNow(_utc(), 1.0)
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            fps_tolerance=0.15,
+            opener=lambda _p: _FakeFile(),
+            sleeper=lambda _s: None,
+            now_fn=now,
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("too slow", result.detail)
+        self.assertLess(
+            result.measurement["achieved_fps"], result.measurement["fps_low"]
+        )
+
+    def test_too_fast_fps_fails(self) -> None:
+        # Tick by 0.001 s/call → 1000 frames in 1 s → 1000 fps, target 10.
+        now = _TickingNow(_utc(), 0.001)
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=1.0,
+            target_fps=10.0,
+            fps_tolerance=0.15,
+            opener=lambda _p: _FakeFile(),
+            sleeper=lambda _s: None,
+            now_fn=now,
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("too fast", result.detail)
+
+    def test_zero_duration_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_render_canary(duration_seconds=0)
+
+    def test_zero_target_fps_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_render_canary(target_fps=0)
+
+    def test_tolerance_out_of_range_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_render_canary(fps_tolerance=1.0)
+        with self.assertRaises(UpdateTesterError):
+            check_render_canary(fps_tolerance=-0.1)
+
+    def test_empty_frame_bytes_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_render_canary(frame_bytes=b"")
+
+    def test_measurement_records_frame_byte_size(self) -> None:
+        now = _TickingNow(_utc(), 0.1)
+        result = check_render_canary(
+            device="/dev/fb0",
+            duration_seconds=10.0,
+            target_fps=10.0,
+            frame_bytes=b"\x00\xff\xaa",
+            opener=lambda _p: _FakeFile(),
+            sleeper=lambda _s: None,
+            now_fn=now,
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.measurement["frame_bytes"], 3)
+
+
+# ── 2. WPS end-to-end ──────────────────────────────────────────────────────
+
+
+def _wps_status_text(
+    *, state: str = "connected", last_seen_at: str = "2026-05-13T11:59:59Z"
+) -> str:
+    return json.dumps({"state": state, "last_seen_at": last_seen_at})
+
+
+class TestCheckWpsSynthetic(unittest.TestCase):
+    def test_happy_path(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now - timedelta(seconds=5)).isoformat()
+        )
+        result = check_wps_synthetic(
+            status_path="/opt/agora/state/cms_status.json",
+            reader=lambda _p: text,
+            now_fn=lambda: now,
+        )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.name, "wps_synthetic")
+        self.assertEqual(result.measurement["state"], "connected")
+        self.assertAlmostEqual(
+            result.measurement["last_seen_age_seconds"], 5.0, places=1
+        )
+
+    def test_missing_status_file_fails(self) -> None:
+        def reader(_p: str) -> str:
+            raise FileNotFoundError(2, "no such file")
+
+        result = check_wps_synthetic(
+            reader=reader, now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("not found", result.detail)
+        self.assertEqual(result.measurement["errno"], 2)
+
+    def test_permission_denied_fails(self) -> None:
+        def reader(_p: str) -> str:
+            raise PermissionError(13, "denied")
+
+        result = check_wps_synthetic(
+            reader=reader, now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("read failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 13)
+
+    def test_invalid_json_fails(self) -> None:
+        result = check_wps_synthetic(
+            reader=lambda _p: "not json {{{",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("JSON invalid", result.detail)
+
+    def test_non_object_json_fails(self) -> None:
+        result = check_wps_synthetic(
+            reader=lambda _p: "[1,2,3]", now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("not an object", result.detail)
+
+    def test_disconnected_state_fails(self) -> None:
+        text = _wps_status_text(state="disconnected")
+        result = check_wps_synthetic(
+            reader=lambda _p: text, now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("disconnected", result.detail)
+        self.assertEqual(result.measurement["state"], "disconnected")
+
+    def test_missing_last_seen_fails(self) -> None:
+        text = json.dumps({"state": "connected"})
+        result = check_wps_synthetic(
+            reader=lambda _p: text, now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("last_seen_at", result.detail)
+
+    def test_unparseable_last_seen_fails(self) -> None:
+        text = _wps_status_text(last_seen_at="garbage")
+        result = check_wps_synthetic(
+            reader=lambda _p: text, now_fn=lambda: _utc()
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("last_seen_at", result.detail)
+
+    def test_stale_heartbeat_fails(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now - timedelta(seconds=120)).isoformat()
+        )
+        result = check_wps_synthetic(
+            freshness_seconds=30, reader=lambda _p: text, now_fn=lambda: now
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("stale", result.detail)
+
+    def test_future_heartbeat_fails(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now + timedelta(seconds=600)).isoformat()
+        )
+        result = check_wps_synthetic(
+            freshness_seconds=30, reader=lambda _p: text, now_fn=lambda: now
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("future", result.detail)
+
+    def test_dispatcher_invoked_and_recorded(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now - timedelta(seconds=5)).isoformat()
+        )
+        seen: list[bool] = []
+
+        def dispatcher() -> Mapping[str, Any]:
+            seen.append(True)
+            return {"id": "synth-42", "ack": True}
+
+        result = check_wps_synthetic(
+            reader=lambda _p: text,
+            now_fn=lambda: now,
+            dispatcher=dispatcher,
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(seen, [True])
+        self.assertEqual(
+            result.measurement["dispatched"], {"id": "synth-42", "ack": True}
+        )
+
+    def test_dispatcher_nonmapping_wrapped(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now - timedelta(seconds=5)).isoformat()
+        )
+        result = check_wps_synthetic(
+            reader=lambda _p: text,
+            now_fn=lambda: now,
+            dispatcher=lambda: "ok",
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.measurement["dispatched"], {"value": "ok"})
+
+    def test_dispatcher_raise_fails(self) -> None:
+        now = _utc()
+        text = _wps_status_text(
+            last_seen_at=(now - timedelta(seconds=5)).isoformat()
+        )
+
+        def dispatcher() -> Mapping[str, Any]:
+            raise RuntimeError("websocket gone")
+
+        result = check_wps_synthetic(
+            reader=lambda _p: text,
+            now_fn=lambda: now,
+            dispatcher=dispatcher,
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("dispatcher raised", result.detail)
+
+    def test_zero_freshness_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_wps_synthetic(freshness_seconds=0)
+
+    def test_handles_naive_datetime_string(self) -> None:
+        now = _utc()
+        # Naive ISO string (no offset) — module treats as UTC.
+        naive = (now - timedelta(seconds=5)).replace(tzinfo=None).isoformat()
+        text = _wps_status_text(last_seen_at=naive)
+        result = check_wps_synthetic(
+            reader=lambda _p: text, now_fn=lambda: now
+        )
+        self.assertTrue(result.ok, result.detail)
+
+
+# ── 3. Memory/CPU stress ───────────────────────────────────────────────────
+
+
+class TestCheckStress(unittest.TestCase):
+    def _runner(
+        self,
+        *,
+        stress_rc: int = 0,
+        stress_stdout: str = "",
+        stress_stderr: str = "",
+        dmesg_text: str = "",
+        timeout: bool = False,
+        missing: bool = False,
+    ):
+        def runner(args, **kwargs):
+            if args[0] == "dmesg":
+                return _completed(0, dmesg_text, "")
+            if args[0] == "stress-ng":
+                if missing:
+                    raise FileNotFoundError(2, "no such file", "stress-ng")
+                if timeout:
+                    raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 60))
+                return _completed(stress_rc, stress_stdout, stress_stderr)
+            raise AssertionError(f"unexpected runner call: {args!r}")
+
+        return runner
+
+    def test_happy_path(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            cpu_workers=1,
+            vm_workers=0,
+            runner=self._runner(stress_rc=0, dmesg_text="kernel boot OK\n"),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.name, "stress")
+        self.assertEqual(result.measurement["returncode"], 0)
+        self.assertEqual(result.measurement["new_oom"], 0)
+        self.assertEqual(result.measurement["post_thermal_celsius"], 55.0)
+
+    def test_missing_binary_fails(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(missing=True),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("not found", result.detail)
+        self.assertEqual(result.measurement["errno"], 2)
+
+    def test_nonzero_returncode_fails(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(
+                stress_rc=2, stress_stderr="vm: unable to mmap\nbailing\n"
+            ),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("returncode=2", result.detail)
+        self.assertIn("stderr_excerpt", result.measurement)
+
+    def test_thermal_throttle_fails(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "82000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("thermal", result.detail)
+        self.assertGreaterEqual(
+            result.measurement["post_thermal_celsius"],
+            DEFAULT_THERMAL_THROTTLE_CELSIUS,
+        )
+
+    def test_thermal_just_below_throttle_passes(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "79900",
+            now_fn=lambda: _utc(),
+        )
+        self.assertTrue(result.ok, result.detail)
+
+    def test_oom_detected_fails(self) -> None:
+        dmesg = (
+            "[12345.0] all good\n"
+            "[12345.5] kernel: Out of memory: Killed process 999 (stress-ng)\n"
+        )
+        # First runner call (pre-dmesg) has zero OOM hits; second call
+        # (post-dmesg) has one. Use a stateful runner.
+        calls = {"n": 0}
+
+        def runner(args, **kwargs):
+            if args[0] == "dmesg":
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return _completed(0, "[12300.0] clean boot\n", "")
+                return _completed(0, dmesg, "")
+            if args[0] == "stress-ng":
+                return _completed(0, "", "")
+            raise AssertionError(args)
+
+        result = check_stress(
+            duration_seconds=10,
+            runner=runner,
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("OOM", result.detail)
+        self.assertEqual(result.measurement["new_oom"], 1)
+
+    def test_preexisting_oom_doesnt_fail(self) -> None:
+        # Same OOM line in both pre- and post-dmesg → new_oom = 0.
+        oom_text = "[1.0] Out of memory: Killed process 99 (oldproc)\n"
+
+        def runner(args, **_kwargs):
+            if args[0] == "dmesg":
+                return _completed(0, oom_text, "")
+            if args[0] == "stress-ng":
+                return _completed(0, "", "")
+            raise AssertionError(args)
+
+        result = check_stress(
+            duration_seconds=10,
+            runner=runner,
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.measurement["new_oom"], 0)
+        self.assertEqual(result.measurement["pre_dmesg_oom"], 1)
+        self.assertEqual(result.measurement["post_dmesg_oom"], 1)
+
+    def test_dmesg_unavailable_is_nonfatal(self) -> None:
+        def runner(args, **_kwargs):
+            if args[0] == "dmesg":
+                raise FileNotFoundError(2, "no dmesg")
+            if args[0] == "stress-ng":
+                return _completed(0, "", "")
+            raise AssertionError(args)
+
+        result = check_stress(
+            duration_seconds=10,
+            runner=runner,
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.measurement["pre_dmesg_oom"], 0)
+        self.assertEqual(result.measurement["post_dmesg_oom"], 0)
+
+    def test_stress_timeout_fails(self) -> None:
+        def runner(args, **kwargs):
+            if args[0] == "dmesg":
+                return _completed(0, "", "")
+            if args[0] == "stress-ng":
+                raise subprocess.TimeoutExpired(args, kwargs.get("timeout", 60))
+            raise AssertionError(args)
+
+        result = check_stress(
+            duration_seconds=10,
+            runner=runner,
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("wall-clock", result.detail)
+
+    def test_duration_zero_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_stress(duration_seconds=0)
+
+    def test_negative_worker_count_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_stress(cpu_workers=-1)
+        with self.assertRaises(UpdateTesterError):
+            check_stress(vm_workers=-1)
+
+    def test_zero_workers_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_stress(cpu_workers=0, vm_workers=0)
+
+    def test_invalid_thermal_returns_none(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "not-a-number",
+            now_fn=lambda: _utc(),
+        )
+        # Stress check passes — thermal None means we can't enforce.
+        self.assertTrue(result.ok, result.detail)
+        self.assertIsNone(result.measurement["post_thermal_celsius"])
+
+    def test_thermal_plain_float_string(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "55.0",
+            now_fn=lambda: _utc(),
+        )
+        # 55.0 in the file is parsed as 55 °C (not 55 mC), since the
+        # int parse fails and float parse succeeds.
+        self.assertTrue(result.ok)
+        self.assertEqual(result.measurement["post_thermal_celsius"], 55.0)
+
+    def test_args_list_records_workers(self) -> None:
+        result = check_stress(
+            duration_seconds=300,
+            cpu_workers=4,
+            vm_workers=2,
+            vm_bytes="256M",
+            runner=self._runner(),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        args = result.measurement["args"]
+        self.assertIn("--cpu", args)
+        self.assertIn("4", args)
+        self.assertIn("--vm", args)
+        self.assertIn("2", args)
+        self.assertIn("--vm-bytes", args)
+        self.assertIn("256M", args)
+        self.assertIn("--timeout", args)
+        self.assertIn("300s", args)
+
+    def test_cpu_workers_zero_omits_cpu_flag(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            cpu_workers=0,
+            vm_workers=2,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        args = result.measurement["args"]
+        self.assertNotIn("--cpu", args)
+        self.assertIn("--vm", args)
+
+    def test_vm_workers_zero_omits_vm_flag(self) -> None:
+        result = check_stress(
+            duration_seconds=10,
+            cpu_workers=1,
+            vm_workers=0,
+            runner=self._runner(),
+            thermal_reader=lambda _p: "55000",
+            now_fn=lambda: _utc(),
+        )
+        args = result.measurement["args"]
+        self.assertNotIn("--vm", args)
+        self.assertIn("--cpu", args)
+
+
+# ── 4. /data integrity sweep ───────────────────────────────────────────────
+
+
+class _Scratch:
+    """Stateful scratch opener that backs files in memory by path."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, _FakeFile] = {}
+        self.unlinked: list[str] = []
+        self.open_calls: list[tuple[str, str]] = []
+
+    def __call__(self, path: str, mode: str) -> _FakeFile:
+        self.open_calls.append((path, mode))
+        if "w" in mode:
+            fh = _FakeFile(name=path, mode=mode)
+            self.files[path] = fh
+            return fh
+        if "r" in mode:
+            existing = self.files.get(path)
+            if existing is None:
+                raise FileNotFoundError(2, "no such file", path)
+            existing._read_offset = 0
+            existing.closed = False
+            existing.mode = mode
+            return existing
+        raise AssertionError(f"unexpected mode {mode!r}")
+
+
+class TestCheckDataIntegrity(unittest.TestCase):
+    def test_happy_path_round_trip(self) -> None:
+        scratch = _Scratch()
+        unlinks: list[str] = []
+        with mock.patch.object(
+            core.os, "unlink", side_effect=unlinks.append
+        ):
+            result = check_data_integrity(
+                schema_version_path="/data/agora/SCHEMA_VERSION",
+                scratch_dir="/data/agora",
+                scratch_size_bytes=4096,
+                chunk_bytes=1024,
+                schema_reader=lambda _p: "1\n",
+                scratch_opener=scratch,
+                now_fn=lambda: _utc(),
+            )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.name, "data_integrity")
+        self.assertEqual(result.measurement["schema_version"], "1")
+        self.assertEqual(result.measurement["bytes_written"], 4096)
+        self.assertEqual(result.measurement["bytes_read"], 4096)
+        self.assertEqual(
+            result.measurement["write_sha256"],
+            result.measurement["read_sha256"],
+        )
+        self.assertEqual(len(unlinks), 1)
+
+    def test_missing_schema_version_fails(self) -> None:
+        def reader(_p: str) -> str:
+            raise FileNotFoundError(2, "missing")
+
+        result = check_data_integrity(
+            schema_reader=reader,
+            scratch_opener=_Scratch(),
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("SCHEMA_VERSION not found", result.detail)
+
+    def test_empty_schema_version_fails(self) -> None:
+        result = check_data_integrity(
+            schema_reader=lambda _p: "   \n",
+            scratch_opener=_Scratch(),
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("empty", result.detail)
+
+    def test_schema_permission_denied_fails(self) -> None:
+        def reader(_p: str) -> str:
+            raise PermissionError(13, "denied")
+
+        result = check_data_integrity(
+            schema_reader=reader,
+            scratch_opener=_Scratch(),
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("read failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 13)
+
+    def test_scratch_open_wb_failure_fails(self) -> None:
+        def opener(path: str, mode: str) -> _FakeFile:
+            raise PermissionError(13, "denied", path)
+
+        result = check_data_integrity(
+            schema_reader=lambda _p: "1",
+            scratch_opener=opener,
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("open(wb)", result.detail)
+        self.assertEqual(result.measurement["errno"], 13)
+
+    def test_scratch_write_oserror_fails(self) -> None:
+        class BadWrite(_FakeFile):
+            def write(self, data: bytes) -> int:
+                raise OSError(28, "ENOSPC")
+
+        def opener(path: str, mode: str) -> _FakeFile:
+            return BadWrite(name=path, mode=mode)
+
+        result = check_data_integrity(
+            schema_reader=lambda _p: "1",
+            scratch_size_bytes=1024,
+            chunk_bytes=512,
+            scratch_opener=opener,
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("write failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 28)
+
+    def test_scratch_open_rb_failure_fails(self) -> None:
+        # write succeeds, but on re-open in read mode the opener raises.
+        scratch = _Scratch()
+
+        def opener(path: str, mode: str) -> _FakeFile:
+            if "r" in mode:
+                raise PermissionError(13, "denied", path)
+            return scratch(path, mode)
+
+        unlinks: list[str] = []
+        with mock.patch.object(
+            core.os, "unlink", side_effect=unlinks.append
+        ):
+            result = check_data_integrity(
+                schema_reader=lambda _p: "1",
+                scratch_size_bytes=1024,
+                chunk_bytes=512,
+                scratch_opener=opener,
+                now_fn=lambda: _utc(),
+            )
+        self.assertFalse(result.ok)
+        self.assertIn("open(rb)", result.detail)
+        self.assertEqual(len(unlinks), 1)
+
+    def test_scratch_read_oserror_fails(self) -> None:
+        class BadRead(_FakeFile):
+            def read(self, size: int = -1) -> bytes:
+                raise OSError(5, "EIO")
+
+        scratch_state: dict[str, _FakeFile] = {}
+
+        def opener(path: str, mode: str) -> _FakeFile:
+            if "w" in mode:
+                fh = _FakeFile(name=path, mode=mode)
+                scratch_state[path] = fh
+                return fh
+            # Read returns BadRead which raises on read().
+            return BadRead(name=path, mode=mode)
+
+        result = check_data_integrity(
+            schema_reader=lambda _p: "1",
+            scratch_size_bytes=1024,
+            chunk_bytes=512,
+            scratch_opener=opener,
+            now_fn=lambda: _utc(),
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("read failed", result.detail)
+        self.assertEqual(result.measurement["errno"], 5)
+
+    def test_checksum_mismatch_fails(self) -> None:
+        # Corrupt one byte on read: wrap _Scratch so the read file
+        # returns a flipped first byte.
+        scratch = _Scratch()
+
+        def opener(path: str, mode: str) -> _FakeFile:
+            fh = scratch(path, mode)
+            if "r" in mode and fh.buffer:
+                fh.buffer[0] ^= 0xFF
+            return fh
+
+        unlinks: list[str] = []
+        with mock.patch.object(core.os, "unlink", side_effect=unlinks.append):
+            result = check_data_integrity(
+                schema_reader=lambda _p: "1",
+                scratch_size_bytes=1024,
+                chunk_bytes=512,
+                scratch_opener=opener,
+                now_fn=lambda: _utc(),
+            )
+        self.assertFalse(result.ok)
+        self.assertIn("checksum mismatch", result.detail)
+        self.assertNotEqual(
+            result.measurement["write_sha256"],
+            result.measurement["read_sha256"],
+        )
+
+    def test_zero_size_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_data_integrity(scratch_size_bytes=0)
+
+    def test_zero_chunk_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            check_data_integrity(chunk_bytes=0)
+
+    def test_round_trip_with_uneven_chunk(self) -> None:
+        # 4097 bytes in 1024-byte chunks → 4×1024 + 1×1.
+        scratch = _Scratch()
+        with mock.patch.object(core.os, "unlink"):
+            result = check_data_integrity(
+                schema_reader=lambda _p: "1",
+                scratch_size_bytes=4097,
+                chunk_bytes=1024,
+                scratch_opener=scratch,
+                now_fn=lambda: _utc(),
+            )
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.measurement["bytes_written"], 4097)
+        self.assertEqual(result.measurement["bytes_read"], 4097)
+
+    def test_records_path_and_sizes(self) -> None:
+        scratch = _Scratch()
+        with mock.patch.object(core.os, "unlink"):
+            result = check_data_integrity(
+                schema_version_path="/data/agora/SCHEMA_VERSION",
+                scratch_dir="/data/agora",
+                scratch_size_bytes=4096,
+                chunk_bytes=2048,
+                schema_reader=lambda _p: "2",
+                scratch_opener=scratch,
+                now_fn=lambda: _utc(),
+            )
+        self.assertTrue(result.ok)
+        self.assertIn(
+            "agora",  # Windows-portable substring (no leading slash check)
+            result.measurement["scratch_path"],
+        )
+        self.assertEqual(result.measurement["scratch_size_bytes"], 4096)
+        self.assertEqual(result.measurement["chunk_bytes"], 2048)
+        self.assertEqual(result.measurement["schema_version"], "2")
+
+
+# ── Aggregator ─────────────────────────────────────────────────────────────
+
+
+def _passing_render_kwargs() -> dict[str, Any]:
+    return {
+        "duration_seconds": 10.0,
+        "target_fps": 10.0,
+        "opener": lambda _p: _FakeFile(),
+        "sleeper": lambda _s: None,
+        # Render check needs its own clock to control achieved-fps math;
+        # the battery aggregator's tiny-step now_fn would make it look
+        # like the render check ran at ~1000 fps and fail "too fast".
+        "now_fn": _TickingNow(_utc(), 0.1),
+    }
+
+
+def _passing_wps_kwargs(now: datetime) -> dict[str, Any]:
+    text = _wps_status_text(
+        last_seen_at=(now - timedelta(seconds=5)).isoformat()
+    )
+    return {"reader": lambda _p: text}
+
+
+def _passing_stress_kwargs() -> dict[str, Any]:
+    def runner(args, **_kwargs):
+        if args[0] == "dmesg":
+            return _completed(0, "", "")
+        if args[0] == "stress-ng":
+            return _completed(0, "", "")
+        raise AssertionError(args)
+
+    return {
+        "duration_seconds": 10,
+        "cpu_workers": 1,
+        "vm_workers": 0,
+        "runner": runner,
+        "thermal_reader": lambda _p: "55000",
+    }
+
+
+def _passing_integrity_kwargs() -> dict[str, Any]:
+    return {
+        "scratch_size_bytes": 1024,
+        "chunk_bytes": 512,
+        "schema_reader": lambda _p: "1",
+        "scratch_opener": _Scratch(),
+    }
+
+
+class TestRunTestBattery(unittest.TestCase):
+    def _now(self) -> _TickingNow:
+        # Step is tiny so render-canary doesn't see deadline pressure.
+        return _TickingNow(_utc(), 0.001)
+
+    def test_happy_path_all_pass(self) -> None:
+        writes: list[tuple[str, dict[str, Any]]] = []
+        now = self._now()
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                run_id="run-happy",
+                output_dir="/data/agora/test-results",
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=now,
+                json_writer=lambda p, payload: writes.append(
+                    (p, dict(payload))
+                ),
+            )
+        self.assertTrue(battery.ok, [t.detail for t in battery.tests if not t.ok])
+        self.assertEqual(battery.run_id, "run-happy")
+        self.assertEqual(len(battery.tests), 4)
+        self.assertEqual(
+            [t.name for t in battery.tests],
+            ["render_canary", "wps_synthetic", "stress", "data_integrity"],
+        )
+        self.assertFalse(battery.deadline_hit)
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0][1]["ok"], True)
+
+    def test_failure_in_one_check_fails_battery(self) -> None:
+        bad_wps = dict(_passing_wps_kwargs(_utc()))
+        bad_wps["reader"] = lambda _p: json.dumps(
+            {"state": "disconnected", "last_seen_at": ""}
+        )
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                deadline_seconds=300,
+                write_output=False,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=bad_wps,
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+            )
+        self.assertFalse(battery.ok)
+        failed = [t for t in battery.tests if not t.ok]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0].name, "wps_synthetic")
+
+    def test_deadline_skips_remaining_tests(self) -> None:
+        # First call to now() = T0 (battery start). Render check internally
+        # calls now() many times for its loop. We need a now_fn that
+        # makes the *second* test see deadline_exceeded()=True. The
+        # cleanest path is to mock now_fn so that after render finishes,
+        # the next deadline_exceeded() call jumps past 5s.
+        timeline = iter([_utc() + timedelta(seconds=i) for i in range(0, 1000)])
+        baseline = [next(timeline) for _ in range(5)]
+        # baseline[0] start, baseline[1] render start, etc.; then a huge jump
+        future = _utc() + timedelta(seconds=9999)
+
+        sequence = [
+            _utc(),  # battery start
+            _utc(),  # check 1 start
+            _utc() + timedelta(seconds=0.5),  # check 1 finish
+            future,  # deadline check before check 2 — exceeds
+            future,  # placeholder skip start
+            future,  # placeholder skip finish
+            future,  # next deadline check
+            future,  # skip
+            future,  # skip
+            future,  # next deadline check
+            future,
+            future,
+            future,
+            future,  # battery finish
+        ]
+        now = _FixedSequenceNow(sequence)
+
+        # The render check itself calls now() during its loop. Easier: use
+        # a render check that doesn't loop (duration ~ tiny). Inject a
+        # render kwargs with duration_seconds=0.01 and a sleeper that
+        # never sleeps. Combine with target_fps=1, achieved_fps will be
+        # near 0 — that fails the render check. So replace render with
+        # a synthetic check that just returns ok=True via monkeypatch.
+        with mock.patch.object(core, "check_render_canary") as m_render, \
+             mock.patch.object(core, "check_wps_synthetic") as m_wps, \
+             mock.patch.object(core, "check_stress") as m_stress, \
+             mock.patch.object(core, "check_data_integrity") as m_int:
+            def render_call(**_kw):
+                t = now()
+                return core._wrap_result(
+                    name="render_canary",
+                    ok=True,
+                    detail="fake",
+                    measurement={},
+                    started=t,
+                    finished=t,
+                )
+            m_render.side_effect = render_call
+            m_wps.side_effect = AssertionError("wps should be skipped")
+            m_stress.side_effect = AssertionError("stress should be skipped")
+            m_int.side_effect = AssertionError("integrity should be skipped")
+
+            battery = run_test_battery(
+                deadline_seconds=10,
+                write_output=False,
+                now_fn=now,
+            )
+
+        self.assertTrue(battery.deadline_hit)
+        self.assertFalse(battery.ok)
+        # First test ran, rest were skipped
+        self.assertTrue(battery.tests[0].ok)
+        for skipped in battery.tests[1:]:
+            self.assertFalse(skipped.ok)
+            self.assertIn("deadline", skipped.detail)
+            self.assertTrue(skipped.measurement.get("skipped_due_to_deadline"))
+
+    def test_zero_deadline_raises(self) -> None:
+        with self.assertRaises(UpdateTesterError):
+            run_test_battery(deadline_seconds=0)
+
+    def test_no_output_skips_artifact(self) -> None:
+        writes: list[Any] = []
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                write_output=False,
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+                json_writer=lambda p, payload: writes.append((p, payload)),
+            )
+        self.assertEqual(writes, [])
+        self.assertEqual(battery.output_path, "")
+        self.assertTrue(battery.ok)
+
+    def test_none_output_dir_skips_artifact(self) -> None:
+        writes: list[Any] = []
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                output_dir=None,
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+                json_writer=lambda p, payload: writes.append((p, payload)),
+            )
+        self.assertEqual(writes, [])
+        self.assertEqual(battery.output_path, "")
+
+    def test_artifact_json_has_expected_keys(self) -> None:
+        writes: list[tuple[str, dict[str, Any]]] = []
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                run_id="rid",
+                output_dir="/tmp/test-results",
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+                json_writer=lambda p, payload: writes.append((p, dict(payload))),
+            )
+        self.assertEqual(len(writes), 1)
+        path, payload = writes[0]
+        # Path joining is OS-dependent; use a Windows-portable substring.
+        self.assertIn("rid.json", path.replace("\\", "/"))
+        for key in (
+            "run_id",
+            "ok",
+            "started_at",
+            "finished_at",
+            "duration_seconds",
+            "deadline_seconds",
+            "deadline_hit",
+            "output_path",
+            "tests",
+        ):
+            self.assertIn(key, payload)
+        self.assertEqual(len(payload["tests"]), 4)
+        self.assertTrue(battery.ok)
+
+    def test_unexpected_exception_in_check_is_wrapped(self) -> None:
+        with mock.patch.object(
+            core, "check_wps_synthetic", side_effect=ValueError("boom")
+        ):
+            with mock.patch.object(core.os, "unlink"):
+                battery = run_test_battery(
+                    write_output=False,
+                    deadline_seconds=300,
+                    render_kwargs=_passing_render_kwargs(),
+                    stress_kwargs=_passing_stress_kwargs(),
+                    integrity_kwargs=_passing_integrity_kwargs(),
+                    now_fn=self._now(),
+                )
+        self.assertFalse(battery.ok)
+        wps = [t for t in battery.tests if t.name == "wps_synthetic"][0]
+        self.assertFalse(wps.ok)
+        self.assertIn("raised unexpectedly", wps.detail)
+        self.assertEqual(wps.measurement["exception_type"], "ValueError")
+
+    def test_programmer_error_propagates(self) -> None:
+        # If a check raises UpdateTesterError (programmer error), it
+        # must propagate — the battery doesn't wrap it.
+        with mock.patch.object(
+            core,
+            "check_render_canary",
+            side_effect=UpdateTesterError("bad arg"),
+        ):
+            with self.assertRaises(UpdateTesterError):
+                run_test_battery(
+                    write_output=False,
+                    deadline_seconds=300,
+                    now_fn=self._now(),
+                )
+
+    def test_artifact_write_failure_records_persist_error(self) -> None:
+        def bad_writer(_path: str, _payload: Mapping[str, Any]) -> None:
+            raise OSError(28, "ENOSPC")
+
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                run_id="r1",
+                output_dir="/tmp",
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+                json_writer=bad_writer,
+            )
+        self.assertFalse(battery.ok)
+        self.assertEqual(battery.output_path, "")
+        last = battery.tests[-1]
+        self.assertEqual(last.name, "artifact_persist")
+        self.assertFalse(last.ok)
+        self.assertEqual(last.measurement["errno"], 28)
+
+    def test_battery_to_dict_is_json_serializable(self) -> None:
+        with mock.patch.object(core.os, "unlink"):
+            battery = run_test_battery(
+                write_output=False,
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+            )
+        # Should round-trip through json without raising.
+        s = json.dumps(battery_to_dict(battery), sort_keys=True)
+        self.assertIn(battery.run_id, s)
+
+    def test_default_run_id_is_fresh(self) -> None:
+        with mock.patch.object(core.os, "unlink"):
+            b1 = run_test_battery(
+                write_output=False,
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+            )
+            b2 = run_test_battery(
+                write_output=False,
+                deadline_seconds=300,
+                render_kwargs=_passing_render_kwargs(),
+                wps_kwargs=_passing_wps_kwargs(_utc()),
+                stress_kwargs=_passing_stress_kwargs(),
+                integrity_kwargs=_passing_integrity_kwargs(),
+                now_fn=self._now(),
+            )
+        self.assertNotEqual(b1.run_id, b2.run_id)
+        # Default is uuid4 hex, length 32.
+        self.assertEqual(len(b1.run_id), 32)
+
+    def test_now_fn_injected_into_checks(self) -> None:
+        # Use a now_fn that records call count; render runs in tight
+        # mocked form to confirm now_fn is threaded through.
+        now = _TickingNow(_utc(), 0.0001)
+        with mock.patch.object(core, "check_render_canary") as m_render, \
+             mock.patch.object(core, "check_wps_synthetic") as m_wps, \
+             mock.patch.object(core, "check_stress") as m_stress, \
+             mock.patch.object(core, "check_data_integrity") as m_int:
+            t = _utc()
+            for m, name in (
+                (m_render, "render_canary"),
+                (m_wps, "wps_synthetic"),
+                (m_stress, "stress"),
+                (m_int, "data_integrity"),
+            ):
+                m.return_value = core._wrap_result(
+                    name=name,
+                    ok=True,
+                    detail="",
+                    measurement={},
+                    started=t,
+                    finished=t,
+                )
+
+            run_test_battery(
+                write_output=False,
+                deadline_seconds=300,
+                now_fn=now,
+            )
+            for m in (m_render, m_wps, m_stress, m_int):
+                m.assert_called_once()
+                kwargs = m.call_args.kwargs
+                self.assertIs(kwargs["now_fn"], now)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestCli(unittest.TestCase):
+    def _make_passing_battery(self) -> TestBatteryResult:
+        return TestBatteryResult(
+            run_id="cli-run",
+            ok=True,
+            started_at="2026-05-13T12:00:00+00:00",
+            finished_at="2026-05-13T12:00:05+00:00",
+            duration_seconds=5.0,
+            deadline_seconds=1800,
+            deadline_hit=False,
+            tests=(
+                TestResult(
+                    name="render_canary",
+                    ok=True,
+                    detail="ok",
+                    started_at="",
+                    finished_at="",
+                    duration_seconds=1.0,
+                ),
+            ),
+            output_path="/tmp/cli-run.json",
+        )
+
+    def _make_failing_battery(self) -> TestBatteryResult:
+        return TestBatteryResult(
+            run_id="cli-run-bad",
+            ok=False,
+            started_at="2026-05-13T12:00:00+00:00",
+            finished_at="2026-05-13T12:00:05+00:00",
+            duration_seconds=5.0,
+            deadline_seconds=1800,
+            deadline_hit=False,
+            tests=(
+                TestResult(
+                    name="render_canary",
+                    ok=False,
+                    detail="too slow",
+                    started_at="",
+                    finished_at="",
+                    duration_seconds=1.0,
+                ),
+            ),
+            output_path="",
+        )
+
+    def test_version_exits_zero(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod.sys, "stdout", new=io.StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                cli_mod.main(["--version"])
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_exit_zero_on_pass(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod, "run_test_battery") as m_run, \
+             mock.patch.object(cli_mod.sys, "stdout", new=io.StringIO()) as out:
+            m_run.return_value = self._make_passing_battery()
+            rc = cli_mod.main(["--no-output"])
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        # JSON should be parseable.
+        payload = json.loads(text)
+        self.assertEqual(payload["run_id"], "cli-run")
+        self.assertTrue(payload["ok"])
+
+    def test_exit_one_on_failure(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod, "run_test_battery") as m_run, \
+             mock.patch.object(cli_mod.sys, "stdout", new=io.StringIO()):
+            m_run.return_value = self._make_failing_battery()
+            rc = cli_mod.main(["--no-output"])
+        self.assertEqual(rc, 1)
+
+    def test_exit_two_on_programmer_error(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod, "run_test_battery") as m_run, \
+             mock.patch.object(cli_mod.sys, "stderr", new=io.StringIO()) as err:
+            m_run.side_effect = UpdateTesterError("bad deadline")
+            rc = cli_mod.main(["--no-output"])
+        self.assertEqual(rc, 2)
+        self.assertIn("bad deadline", err.getvalue())
+
+    def test_no_output_threads_through(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod, "run_test_battery") as m_run, \
+             mock.patch.object(cli_mod.sys, "stdout", new=io.StringIO()):
+            m_run.return_value = self._make_passing_battery()
+            cli_mod.main(["--no-output", "--run-id", "x"])
+            kwargs = m_run.call_args.kwargs
+            self.assertEqual(kwargs["write_output"], False)
+            self.assertIsNone(kwargs["output_dir"])
+            self.assertEqual(kwargs["run_id"], "x")
+
+    def test_default_output_dir(self) -> None:
+        from update_tester import __main__ as cli_mod
+
+        with mock.patch.object(cli_mod, "run_test_battery") as m_run, \
+             mock.patch.object(cli_mod.sys, "stdout", new=io.StringIO()):
+            m_run.return_value = self._make_passing_battery()
+            cli_mod.main([])
+            kwargs = m_run.call_args.kwargs
+            self.assertTrue(kwargs["write_output"])
+            self.assertIn("test-results", kwargs["output_dir"])
+
+
+# ── _atomic_write_json ─────────────────────────────────────────────────────
+
+
+class TestAtomicWriteJson(unittest.TestCase):
+    def test_writes_and_replaces(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "subdir", "result.json")
+            payload = {"run_id": "x", "ok": True, "nested": [1, 2, 3]}
+            core._atomic_write_json(path, payload)
+            with open(path, "r", encoding="utf-8") as fh:
+                loaded = json.load(fh)
+            self.assertEqual(loaded, payload)
+            # No stray temp files left in the parent directory.
+            kids = os.listdir(os.path.dirname(path))
+            self.assertEqual(kids, ["result.json"])
+
+    def test_cleans_up_on_write_failure(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "result.json")
+
+            # Force json.dump to raise.
+            with mock.patch.object(
+                core.json, "dump", side_effect=ValueError("boom")
+            ):
+                with self.assertRaises(ValueError):
+                    core._atomic_write_json(path, {"k": "v"})
+            # Temp file shouldn't survive.
+            kids = os.listdir(td)
+            self.assertEqual(kids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_tester/__init__.py
+++ b/update_tester/__init__.py
@@ -1,0 +1,80 @@
+"""Update-tester synthetic-load test battery for tentative slots.
+
+Public entry point: :func:`run_test_battery`. Runs a 4-test battery
+(render canary, WPS end-to-end, memory/CPU stress, /data integrity)
+on a device that has just passed :func:`slot_confirm.slot_confirm`
+in a ring whose ``gate_type`` is ``confirm_plus_test_suite``
+(plan Decision #6, plan §157-165).
+
+Phase 1 emits structured JSON to
+``/data/agora/test-results/<run-id>.json`` and journald. There is
+no CMS wire-up in Phase 1 — that lands in Phase 3.
+"""
+
+from update_tester.core import (
+    DEFAULT_DEADLINE_SECONDS,
+    DEFAULT_DMESG_RECENT_LINES,
+    DEFAULT_FRAMEBUFFER_DEVICE,
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_RENDER_DURATION_SECONDS,
+    DEFAULT_RENDER_FPS_TOLERANCE,
+    DEFAULT_RENDER_FRAME_BYTES,
+    DEFAULT_RENDER_TARGET_FPS,
+    DEFAULT_SCHEMA_VERSION_PATH,
+    DEFAULT_SCRATCH_CHUNK_BYTES,
+    DEFAULT_SCRATCH_DIR,
+    DEFAULT_SCRATCH_SIZE_BYTES,
+    DEFAULT_STRESS_BINARY,
+    DEFAULT_STRESS_CPU_WORKERS,
+    DEFAULT_STRESS_DURATION_SECONDS,
+    DEFAULT_STRESS_VM_BYTES,
+    DEFAULT_STRESS_VM_WORKERS,
+    DEFAULT_THERMAL_PATH,
+    DEFAULT_THERMAL_THROTTLE_CELSIUS,
+    DEFAULT_WPS_FRESHNESS_SECONDS,
+    DEFAULT_WPS_STATUS_PATH,
+    TestBatteryResult,
+    TestResult,
+    UpdateTesterError,
+    battery_to_dict,
+    check_data_integrity,
+    check_render_canary,
+    check_stress,
+    check_wps_synthetic,
+    run_test_battery,
+)
+
+__all__ = [
+    "DEFAULT_DEADLINE_SECONDS",
+    "DEFAULT_DMESG_RECENT_LINES",
+    "DEFAULT_FRAMEBUFFER_DEVICE",
+    "DEFAULT_OUTPUT_DIR",
+    "DEFAULT_RENDER_DURATION_SECONDS",
+    "DEFAULT_RENDER_FPS_TOLERANCE",
+    "DEFAULT_RENDER_FRAME_BYTES",
+    "DEFAULT_RENDER_TARGET_FPS",
+    "DEFAULT_SCHEMA_VERSION_PATH",
+    "DEFAULT_SCRATCH_CHUNK_BYTES",
+    "DEFAULT_SCRATCH_DIR",
+    "DEFAULT_SCRATCH_SIZE_BYTES",
+    "DEFAULT_STRESS_BINARY",
+    "DEFAULT_STRESS_CPU_WORKERS",
+    "DEFAULT_STRESS_DURATION_SECONDS",
+    "DEFAULT_STRESS_VM_BYTES",
+    "DEFAULT_STRESS_VM_WORKERS",
+    "DEFAULT_THERMAL_PATH",
+    "DEFAULT_THERMAL_THROTTLE_CELSIUS",
+    "DEFAULT_WPS_FRESHNESS_SECONDS",
+    "DEFAULT_WPS_STATUS_PATH",
+    "TestBatteryResult",
+    "TestResult",
+    "UpdateTesterError",
+    "battery_to_dict",
+    "check_data_integrity",
+    "check_render_canary",
+    "check_stress",
+    "check_wps_synthetic",
+    "run_test_battery",
+]
+
+__version__ = "0.1.0"

--- a/update_tester/__main__.py
+++ b/update_tester/__main__.py
@@ -1,0 +1,105 @@
+"""CLI entry point for the update-tester package.
+
+Usage::
+
+    python -m update_tester [--run-id ID] [--output-dir DIR] [--no-output]
+                            [--deadline-seconds N] [--version]
+
+Runs the 4-test synthetic-load battery, prints the result as indented
+JSON to stdout, and (unless ``--no-output``) writes the same JSON to
+``<output-dir>/<run-id>.json`` atomically.
+
+Exit codes:
+
+* ``0`` — every test passed and the deadline was not hit.
+* ``1`` — at least one test failed, or the deadline was hit, or the
+  artifact write failed.
+* ``2`` — a check raised :class:`UpdateTesterError` (programmer
+  error: invalid argument, unsupported combination).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from update_tester import __version__
+from update_tester.core import (
+    DEFAULT_DEADLINE_SECONDS,
+    DEFAULT_OUTPUT_DIR,
+    UpdateTesterError,
+    battery_to_dict,
+    run_test_battery,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="update_tester",
+        description=(
+            "Run the agora update-tester synthetic-load test battery "
+            "(render canary, WPS end-to-end, memory/CPU stress, "
+            "/data integrity) on the currently running slot."
+        ),
+    )
+    p.add_argument(
+        "--run-id",
+        default=None,
+        help="override the generated run id (default: fresh uuid4 hex)",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        help=(
+            "directory to write <run-id>.json into "
+            f"(default: {DEFAULT_OUTPUT_DIR})"
+        ),
+    )
+    p.add_argument(
+        "--no-output",
+        action="store_true",
+        help="skip writing the JSON artifact (still prints to stdout)",
+    )
+    p.add_argument(
+        "--deadline-seconds",
+        type=int,
+        default=DEFAULT_DEADLINE_SECONDS,
+        help=(
+            "overall battery deadline in seconds "
+            f"(default: {DEFAULT_DEADLINE_SECONDS})"
+        ),
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"update_tester {__version__}",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        battery = run_test_battery(
+            run_id=args.run_id,
+            output_dir=None if args.no_output else args.output_dir,
+            write_output=not args.no_output,
+            deadline_seconds=args.deadline_seconds,
+        )
+    except UpdateTesterError as exc:
+        print(f"update_tester: invalid arguments: {exc}", file=sys.stderr)
+        return 2
+
+    payload = battery_to_dict(battery)
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+    return 0 if battery.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/update_tester/core.py
+++ b/update_tester/core.py
@@ -1,0 +1,1336 @@
+"""Implementation of the update-tester synthetic-load test battery.
+
+Runs after :func:`slot_confirm.slot_confirm` passes on devices whose
+ring config has ``gate_type=confirm_plus_test_suite`` (plan Decision
+#6, plan §157-165). Phase 1 emits structured JSON to
+``/data/agora/test-results/<run-id>.json`` and journald — there is
+**no CMS wire-up** in Phase 1, that's Phase 3 (D-#13/#14).
+
+The 4-test battery (plan §160-163):
+
+1. **Render canary** — submit frames to the framebuffer at the target
+   framerate for 5 min; fail if the achieved FPS drifts outside a
+   tolerance band.
+2. **WPS end-to-end** — verify the WPS receiver is currently connected
+   *and* has heartbeated with CMS within a freshness window; dispatcher
+   / observer hooks are exposed for Phase 3 to plug a real synthetic
+   event into.
+3. **Memory/CPU stress** — run ``stress-ng`` for 5 min; fail on
+   non-zero exit, OOM kills in ``dmesg``, or thermal throttling
+   (Pi 5 throttles at 80 °C).
+4. **/data integrity sweep** — re-read ``SCHEMA_VERSION``, then
+   write+read+delete a 100 MB scratch file; verify the round-trip
+   bytes are identical.
+
+Each test is a top-level function returning :class:`TestResult` and has
+runner / opener / writer / reader / sleeper / now_fn injection seams so
+tests can run without root, without ``/dev/fb0``, without ``stress-ng``
+on PATH, without waiting 5 minutes — every external surface is stubbed
+through the documented seam.
+
+The aggregator :func:`run_test_battery` runs the 4 tests in order,
+enforces an overall deadline (default 30 min), and writes a stable JSON
+artifact suitable for hand-inspection or future CMS upload.
+
+Routine failures (stress-ng missing, framebuffer EIO, scratch ENOSPC)
+return ``TestResult(ok=False, …)`` — they never raise.
+:class:`UpdateTesterError` is reserved for programmer errors (invalid
+duration, negative size, missing required argument).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+#: Where Phase 1 writes the per-run JSON result artifact.
+DEFAULT_OUTPUT_DIR: str = "/data/agora/test-results"
+
+#: Framebuffer device used by :func:`check_render_canary`.
+DEFAULT_FRAMEBUFFER_DEVICE: str = "/dev/fb0"
+
+#: Render-canary duration. Plan §160: "render-canary frames at full
+#: framerate for 5 min".
+DEFAULT_RENDER_DURATION_SECONDS: int = 5 * 60
+
+#: Target frames-per-second for the render canary. Pi 5 HDMI runs at
+#: 60 Hz by default; the canary aims for half that to leave headroom
+#: for jitter without falsely failing the gate.
+DEFAULT_RENDER_TARGET_FPS: float = 30.0
+
+#: Fraction of ``target_fps`` the achieved FPS may drift before the
+#: render canary fails (±). Default ±15 % — wide enough to absorb
+#: HDMI vsync jitter on a stock Pi 5 image.
+DEFAULT_RENDER_FPS_TOLERANCE: float = 0.15
+
+#: Bytes written per frame. One byte is enough to exercise the
+#: framebuffer device; larger writes don't add useful signal.
+DEFAULT_RENDER_FRAME_BYTES: bytes = b"\x00"
+
+#: WPS receiver status file. Same path as slot_confirm consumes.
+DEFAULT_WPS_STATUS_PATH: str = "/opt/agora/state/cms_status.json"
+
+#: How recent ``last_seen_at`` must be (relative to ``now_fn()``) for
+#: the WPS check to pass. Plan-driven: the WPS receiver heartbeats
+#: every few seconds, so 30 s gives plenty of margin without admitting
+#: a stale receiver.
+DEFAULT_WPS_FRESHNESS_SECONDS: int = 30
+
+#: stress-ng command name. Resolved through ``$PATH`` by the default
+#: runner.
+DEFAULT_STRESS_BINARY: str = "stress-ng"
+
+#: stress-ng duration. Plan §162: "memory/CPU stress for 5 min".
+DEFAULT_STRESS_DURATION_SECONDS: int = 5 * 60
+
+#: stress-ng CPU worker count. Pi 5 has 4 Cortex-A76 cores.
+DEFAULT_STRESS_CPU_WORKERS: int = 4
+
+#: stress-ng VM worker count. Two workers × 256 MB ≈ ½ GB of resident
+#: pressure on an 8 GB Pi 5 — meaningful but well clear of OOM.
+DEFAULT_STRESS_VM_WORKERS: int = 2
+
+#: Per-worker resident memory for the VM stressor (passed verbatim to
+#: ``stress-ng --vm-bytes``).
+DEFAULT_STRESS_VM_BYTES: str = "256M"
+
+#: Thermal-zone sysfs path. Pi 5 exposes the SoC temperature here in
+#: millidegrees Celsius.
+DEFAULT_THERMAL_PATH: str = "/sys/class/thermal/thermal_zone0/temp"
+
+#: Temperature at which the Pi 5 begins thermal throttling (°C). The
+#: stress check fails if the post-stress reading is at or above this.
+DEFAULT_THERMAL_THROTTLE_CELSIUS: float = 80.0
+
+#: dmesg ring-buffer scan window. Looked at after stress-ng exits to
+#: detect OOM kills produced during the stress run.
+DEFAULT_DMESG_RECENT_LINES: int = 200
+
+#: Where the SCHEMA_VERSION file lives on a healthy device.
+DEFAULT_SCHEMA_VERSION_PATH: str = "/data/agora/SCHEMA_VERSION"
+
+#: Directory under which the integrity check writes its scratch file.
+#: ``slot_mgr`` already owns this directory.
+DEFAULT_SCRATCH_DIR: str = "/data/agora"
+
+#: Size of the integrity-check scratch file. Plan §163: "100 MB".
+DEFAULT_SCRATCH_SIZE_BYTES: int = 100 * 1024 * 1024
+
+#: Chunk size used when streaming the scratch file write/read.
+DEFAULT_SCRATCH_CHUNK_BYTES: int = 1 * 1024 * 1024
+
+#: Battery-wide deadline. Plan §164: "default 30 min".
+DEFAULT_DEADLINE_SECONDS: int = 30 * 60
+
+
+# ── Types ───────────────────────────────────────────────────────────────────
+
+
+class UpdateTesterError(RuntimeError):
+    """Programmer error in calling an update-tester function.
+
+    Routine "the test failed" outcomes return :class:`TestResult` with
+    ``ok=False``; this exception is reserved for bugs in the caller
+    (negative durations, empty test names, missing required keys).
+    """
+
+
+@dataclass(frozen=True)
+class TestResult:
+    """Outcome of one update-tester test."""
+
+    name: str
+    ok: bool
+    detail: str
+    measurement: Mapping[str, Any] = field(default_factory=dict)
+    started_at: str = ""
+    finished_at: str = ""
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
+class TestBatteryResult:
+    """Aggregated outcome of one update-tester battery run."""
+
+    run_id: str
+    ok: bool
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    deadline_seconds: int
+    deadline_hit: bool
+    tests: tuple[TestResult, ...]
+    output_path: str = ""
+
+
+# ── Type aliases for injection seams ───────────────────────────────────────
+
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+NowFn = Callable[[], datetime]
+Sleeper = Callable[[float], None]
+FrameOpener = Callable[[str], Any]
+ProbeWriter = Callable[[str, bytes], None]
+ScratchOpener = Callable[[str, str], Any]
+StatusReader = Callable[[str], str]
+SchemaReader = Callable[[str], str]
+ThermalReader = Callable[[str], str]
+EventDispatcher = Callable[[], Mapping[str, Any]]
+
+
+def _default_runner(
+    args: Sequence[str],
+    *,
+    check: bool = False,
+    capture_output: bool = True,
+    text: bool = True,
+    timeout: Optional[float] = None,
+) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        list(args),
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+    )
+
+
+def _default_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _default_sleeper(seconds: float) -> None:
+    if seconds > 0:
+        import time as _time
+
+        _time.sleep(seconds)
+
+
+def _format_ts(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _wrap_result(
+    name: str,
+    ok: bool,
+    detail: str,
+    measurement: Mapping[str, Any],
+    *,
+    started: datetime,
+    finished: datetime,
+) -> TestResult:
+    return TestResult(
+        name=name,
+        ok=ok,
+        detail=detail,
+        measurement=measurement,
+        started_at=_format_ts(started),
+        finished_at=_format_ts(finished),
+        duration_seconds=max(0.0, (finished - started).total_seconds()),
+    )
+
+
+# ── 1. Render canary ───────────────────────────────────────────────────────
+
+
+def check_render_canary(
+    *,
+    device: str = DEFAULT_FRAMEBUFFER_DEVICE,
+    duration_seconds: float = DEFAULT_RENDER_DURATION_SECONDS,
+    target_fps: float = DEFAULT_RENDER_TARGET_FPS,
+    fps_tolerance: float = DEFAULT_RENDER_FPS_TOLERANCE,
+    frame_bytes: bytes = DEFAULT_RENDER_FRAME_BYTES,
+    opener: Optional[FrameOpener] = None,
+    sleeper: Optional[Sleeper] = None,
+    now_fn: Optional[NowFn] = None,
+) -> TestResult:
+    """Write frames to ``device`` at ``target_fps`` for ``duration_seconds``.
+
+    The achieved FPS is computed as
+    ``frames_written / wall_clock_elapsed``. The check fails when the
+    achieved FPS is outside ``target_fps * (1 ± fps_tolerance)``.
+
+    Failure modes (each surfaces ``ok=False`` with an errno when
+    applicable, never raises):
+
+    * ``device`` missing / non-writable / EIO during write.
+    * Achieved FPS below the lower tolerance band (slow path).
+    * Achieved FPS above the upper tolerance band (the sleeper was
+      ignored or the wall clock skewed — caller bug, but we report
+      rather than raise so a real ``stress-ng``-induced clock blip
+      doesn't crash the battery).
+
+    All wall-clock advances go through ``now_fn``; all sleeps go
+    through ``sleeper``. Tests inject deterministic versions of both.
+    """
+    if duration_seconds <= 0:
+        raise UpdateTesterError(
+            f"duration_seconds must be > 0, got {duration_seconds!r}"
+        )
+    if target_fps <= 0:
+        raise UpdateTesterError(f"target_fps must be > 0, got {target_fps!r}")
+    if not 0 <= fps_tolerance < 1:
+        raise UpdateTesterError(
+            f"fps_tolerance must be in [0, 1), got {fps_tolerance!r}"
+        )
+    if not frame_bytes:
+        raise UpdateTesterError("frame_bytes must be non-empty")
+
+    now = now_fn or _default_now
+    sleep = sleeper or _default_sleeper
+    open_fn: FrameOpener = opener or (lambda path: open(path, "wb"))
+
+    started = now()
+    try:
+        fh = open_fn(device)
+    except FileNotFoundError as exc:
+        finished = now()
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=f"framebuffer device not found: {device}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+            started=started,
+            finished=finished,
+        )
+    except PermissionError as exc:
+        finished = now()
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=f"framebuffer device not writable: {device}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+            started=started,
+            finished=finished,
+        )
+    except OSError as exc:
+        finished = now()
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=f"framebuffer open failed: {exc}",
+            measurement={"device": device, "errno": getattr(exc, "errno", None)},
+            started=started,
+            finished=finished,
+        )
+
+    frame_period = 1.0 / target_fps
+    frames_written = 0
+    write_errno: Optional[int] = None
+    write_error_detail = ""
+    try:
+        while True:
+            elapsed = (now() - started).total_seconds()
+            if elapsed >= duration_seconds:
+                break
+            try:
+                fh.write(frame_bytes)
+            except OSError as exc:
+                write_errno = getattr(exc, "errno", None)
+                write_error_detail = str(exc)
+                break
+            frames_written += 1
+            sleep(frame_period)
+    finally:
+        close = getattr(fh, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+
+    finished = now()
+    wall_seconds = max(0.0, (finished - started).total_seconds())
+    achieved_fps = frames_written / wall_seconds if wall_seconds > 0 else 0.0
+    fps_low = target_fps * (1 - fps_tolerance)
+    fps_high = target_fps * (1 + fps_tolerance)
+
+    measurement = {
+        "device": device,
+        "duration_seconds": duration_seconds,
+        "target_fps": target_fps,
+        "fps_tolerance": fps_tolerance,
+        "fps_low": fps_low,
+        "fps_high": fps_high,
+        "frames_written": frames_written,
+        "wall_seconds": wall_seconds,
+        "achieved_fps": achieved_fps,
+        "frame_bytes": len(frame_bytes),
+    }
+
+    if write_errno is not None or write_error_detail:
+        measurement["errno"] = write_errno
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=f"framebuffer write failed: {write_error_detail}",
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    if achieved_fps < fps_low:
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=(
+                f"render too slow: {achieved_fps:.2f} fps < "
+                f"{fps_low:.2f} fps (target {target_fps:.0f} fps "
+                f"±{fps_tolerance:.0%})"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+    if achieved_fps > fps_high:
+        return _wrap_result(
+            name="render_canary",
+            ok=False,
+            detail=(
+                f"render too fast: {achieved_fps:.2f} fps > "
+                f"{fps_high:.2f} fps (target {target_fps:.0f} fps "
+                f"±{fps_tolerance:.0%}) — sleeper/clock skew?"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    return _wrap_result(
+        name="render_canary",
+        ok=True,
+        detail=(
+            f"rendered {frames_written} frames in "
+            f"{wall_seconds:.1f}s at {achieved_fps:.2f} fps "
+            f"(target {target_fps:.0f} fps ±{fps_tolerance:.0%})"
+        ),
+        measurement=measurement,
+        started=started,
+        finished=finished,
+    )
+
+
+# ── 2. WPS end-to-end ──────────────────────────────────────────────────────
+
+
+def _read_text_file(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _parse_iso_or_none(raw: str) -> Optional[datetime]:
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def check_wps_synthetic(
+    *,
+    status_path: str = DEFAULT_WPS_STATUS_PATH,
+    freshness_seconds: int = DEFAULT_WPS_FRESHNESS_SECONDS,
+    dispatcher: Optional[EventDispatcher] = None,
+    reader: Optional[StatusReader] = None,
+    now_fn: Optional[NowFn] = None,
+) -> TestResult:
+    """Verify the WPS receiver is connected and recently heartbeating.
+
+    Plan §161: "WPS end-to-end: dispatch synthetic event, observe
+    receiver-side". Phase 1's honest interpretation:
+
+    1. Read ``status_path`` (the same file ``slot_confirm`` consumes).
+    2. Require ``state == "connected"``.
+    3. Require ``last_seen_at`` (the WPS receiver's heartbeat
+       timestamp) within ``freshness_seconds`` of ``now_fn()``.
+    4. Optionally invoke ``dispatcher`` — a hook for Phase 3 to plug
+       in a real synthetic-event submission. Phase 1 leaves it
+       unset, which means dispatcher-derived measurements are absent
+       from the result. If the dispatcher raises, the check fails.
+
+    This is a strictly stricter check than
+    :func:`slot_confirm.check_wps_connected`: that one only verifies
+    the state field; this one also enforces freshness.
+
+    Failure modes return ``ok=False``; only programmer errors raise.
+    """
+    if freshness_seconds <= 0:
+        raise UpdateTesterError(
+            f"freshness_seconds must be > 0, got {freshness_seconds!r}"
+        )
+
+    now = now_fn or _default_now
+    read = reader or _read_text_file
+
+    started = now()
+
+    try:
+        raw = read(status_path)
+    except FileNotFoundError as exc:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=f"WPS status file not found: {status_path}",
+            measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            started=started,
+            finished=finished,
+        )
+    except (PermissionError, OSError) as exc:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=f"WPS status read failed: {exc}",
+            measurement={"status_path": status_path, "errno": getattr(exc, "errno", None)},
+            started=started,
+            finished=finished,
+        )
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=f"WPS status JSON invalid: {exc}",
+            measurement={"status_path": status_path, "raw_excerpt": raw[:120]},
+            started=started,
+            finished=finished,
+        )
+    if not isinstance(payload, dict):
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail="WPS status JSON is not an object",
+            measurement={"status_path": status_path, "type": type(payload).__name__},
+            started=started,
+            finished=finished,
+        )
+
+    state = payload.get("state")
+    if state != "connected":
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=f"WPS receiver state is {state!r}, expected 'connected'",
+            measurement={"status_path": status_path, "state": state},
+            started=started,
+            finished=finished,
+        )
+
+    last_seen_raw = payload.get("last_seen_at", "")
+    last_seen = _parse_iso_or_none(str(last_seen_raw)) if last_seen_raw else None
+    measurement: dict[str, Any] = {
+        "status_path": status_path,
+        "freshness_seconds": freshness_seconds,
+        "state": state,
+        "last_seen_at": last_seen_raw,
+    }
+    if last_seen is None:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail="WPS status missing or unparseable 'last_seen_at'",
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    age = (now() - last_seen).total_seconds()
+    measurement["last_seen_age_seconds"] = age
+    if age > freshness_seconds:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=(
+                f"WPS heartbeat stale: {age:.0f}s old, "
+                f"need ≤{freshness_seconds}s"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+    if age < -freshness_seconds:
+        finished = now()
+        return _wrap_result(
+            name="wps_synthetic",
+            ok=False,
+            detail=(
+                f"WPS heartbeat in the future: {-age:.0f}s ahead, "
+                f"clock skew?"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    if dispatcher is not None:
+        try:
+            dispatched = dispatcher()
+        except Exception as exc:  # noqa: BLE001
+            finished = now()
+            return _wrap_result(
+                name="wps_synthetic",
+                ok=False,
+                detail=f"synthetic-event dispatcher raised: {exc}",
+                measurement=measurement,
+                started=started,
+                finished=finished,
+            )
+        if isinstance(dispatched, Mapping):
+            measurement["dispatched"] = dict(dispatched)
+        else:
+            measurement["dispatched"] = {"value": dispatched}
+
+    finished = now()
+    return _wrap_result(
+        name="wps_synthetic",
+        ok=True,
+        detail=(
+            f"WPS receiver connected, last heartbeat {age:.0f}s ago "
+            f"(≤{freshness_seconds}s)"
+        ),
+        measurement=measurement,
+        started=started,
+        finished=finished,
+    )
+
+
+# ── 3. Memory/CPU stress ───────────────────────────────────────────────────
+
+
+def _read_thermal_celsius(
+    path: str,
+    *,
+    reader: ThermalReader,
+) -> Optional[float]:
+    try:
+        raw = reader(path).strip()
+    except OSError:
+        return None
+    if not raw:
+        return None
+    try:
+        # Pi 5 emits millidegrees.
+        return int(raw) / 1000.0
+    except ValueError:
+        try:
+            return float(raw)
+        except ValueError:
+            return None
+
+
+def _count_oom(dmesg_text: str, recent_lines: int) -> int:
+    if recent_lines <= 0:
+        lines = dmesg_text.splitlines()
+    else:
+        lines = dmesg_text.splitlines()[-recent_lines:]
+    count = 0
+    for line in lines:
+        lower = line.lower()
+        if "out of memory" in lower or "killed process" in lower or "oom-kill" in lower:
+            count += 1
+    return count
+
+
+def check_stress(
+    *,
+    duration_seconds: int = DEFAULT_STRESS_DURATION_SECONDS,
+    cpu_workers: int = DEFAULT_STRESS_CPU_WORKERS,
+    vm_workers: int = DEFAULT_STRESS_VM_WORKERS,
+    vm_bytes: str = DEFAULT_STRESS_VM_BYTES,
+    binary: str = DEFAULT_STRESS_BINARY,
+    thermal_path: str = DEFAULT_THERMAL_PATH,
+    throttle_celsius: float = DEFAULT_THERMAL_THROTTLE_CELSIUS,
+    dmesg_recent_lines: int = DEFAULT_DMESG_RECENT_LINES,
+    runner: Optional[Runner] = None,
+    thermal_reader: Optional[ThermalReader] = None,
+    now_fn: Optional[NowFn] = None,
+) -> TestResult:
+    """Run ``stress-ng`` for ``duration_seconds``; check thermal + OOM.
+
+    The default invocation is::
+
+        stress-ng --cpu {cpu_workers} --vm {vm_workers}
+                  --vm-bytes {vm_bytes} --timeout {duration_seconds}s
+                  --metrics-brief
+
+    The check fails if any of these are true:
+
+    * ``stress-ng`` is missing on PATH (``FileNotFoundError``).
+    * ``stress-ng`` exits non-zero.
+    * The post-stress reading from ``thermal_path`` is ≥
+      ``throttle_celsius`` (Pi 5 throttle threshold is 80 °C).
+    * Running ``dmesg --color=never`` shows an OOM kill that
+      didn't appear pre-stress.
+
+    All clocks go through ``now_fn``; tests inject a runner that
+    returns a canned :class:`subprocess.CompletedProcess` so no real
+    stress-ng invocation happens.
+    """
+    if duration_seconds <= 0:
+        raise UpdateTesterError(
+            f"duration_seconds must be > 0, got {duration_seconds!r}"
+        )
+    if cpu_workers < 0 or vm_workers < 0:
+        raise UpdateTesterError(
+            f"worker counts must be ≥0, got cpu={cpu_workers!r} vm={vm_workers!r}"
+        )
+    if cpu_workers == 0 and vm_workers == 0:
+        raise UpdateTesterError("at least one stressor must be enabled")
+
+    run = runner or _default_runner
+    therm_read = thermal_reader or _read_text_file
+    now = now_fn or _default_now
+
+    started = now()
+    pre_thermal = _read_thermal_celsius(thermal_path, reader=therm_read)
+
+    pre_dmesg_oom = 0
+    try:
+        cp = run(
+            ["dmesg", "--color=never"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        pre_dmesg_oom = _count_oom(cp.stdout or "", dmesg_recent_lines)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        # dmesg may be unavailable in containers or rate-limited; the
+        # post-check still catches OOMs by looking at the full window.
+        pass
+
+    args: list[str] = [binary]
+    if cpu_workers > 0:
+        args += ["--cpu", str(cpu_workers)]
+    if vm_workers > 0:
+        args += ["--vm", str(vm_workers), "--vm-bytes", vm_bytes]
+    args += ["--timeout", f"{duration_seconds}s", "--metrics-brief"]
+
+    stress_returncode: Optional[int] = None
+    stress_stderr = ""
+    stress_stdout = ""
+    try:
+        cp = run(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=duration_seconds + 60,
+        )
+        stress_returncode = cp.returncode
+        stress_stdout = cp.stdout or ""
+        stress_stderr = cp.stderr or ""
+    except FileNotFoundError as exc:
+        finished = now()
+        return _wrap_result(
+            name="stress",
+            ok=False,
+            detail=f"stress-ng binary not found: {binary}",
+            measurement={
+                "binary": binary,
+                "errno": getattr(exc, "errno", None),
+            },
+            started=started,
+            finished=finished,
+        )
+    except subprocess.TimeoutExpired:
+        finished = now()
+        return _wrap_result(
+            name="stress",
+            ok=False,
+            detail=(
+                f"stress-ng exceeded {duration_seconds + 60}s wall-clock "
+                f"(internal timeout was {duration_seconds}s)"
+            ),
+            measurement={
+                "binary": binary,
+                "duration_seconds": duration_seconds,
+            },
+            started=started,
+            finished=finished,
+        )
+
+    post_thermal = _read_thermal_celsius(thermal_path, reader=therm_read)
+    post_dmesg_oom = 0
+    try:
+        cp = run(
+            ["dmesg", "--color=never"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        post_dmesg_oom = _count_oom(cp.stdout or "", dmesg_recent_lines)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    new_oom = max(0, post_dmesg_oom - pre_dmesg_oom)
+
+    measurement: dict[str, Any] = {
+        "binary": binary,
+        "duration_seconds": duration_seconds,
+        "cpu_workers": cpu_workers,
+        "vm_workers": vm_workers,
+        "vm_bytes": vm_bytes,
+        "args": args,
+        "returncode": stress_returncode,
+        "pre_thermal_celsius": pre_thermal,
+        "post_thermal_celsius": post_thermal,
+        "throttle_celsius": throttle_celsius,
+        "pre_dmesg_oom": pre_dmesg_oom,
+        "post_dmesg_oom": post_dmesg_oom,
+        "new_oom": new_oom,
+    }
+    if stress_stderr.strip():
+        measurement["stderr_excerpt"] = stress_stderr.strip().splitlines()[-5:]
+    _ = stress_stdout  # available via runner stub for tests
+
+    finished = now()
+    if stress_returncode != 0:
+        return _wrap_result(
+            name="stress",
+            ok=False,
+            detail=f"stress-ng exited with returncode={stress_returncode}",
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+    if new_oom > 0:
+        return _wrap_result(
+            name="stress",
+            ok=False,
+            detail=f"detected {new_oom} OOM kill(s) in dmesg during stress",
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+    if post_thermal is not None and post_thermal >= throttle_celsius:
+        return _wrap_result(
+            name="stress",
+            ok=False,
+            detail=(
+                f"post-stress thermal {post_thermal:.1f} °C ≥ "
+                f"throttle threshold {throttle_celsius:.1f} °C"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    detail_bits = [f"stress-ng ran for {duration_seconds}s (rc=0)"]
+    if post_thermal is not None:
+        detail_bits.append(f"post-thermal {post_thermal:.1f} °C")
+    detail_bits.append("OOM kills during run: 0")
+    return _wrap_result(
+        name="stress",
+        ok=True,
+        detail="; ".join(detail_bits),
+        measurement=measurement,
+        started=started,
+        finished=finished,
+    )
+
+
+# ── 4. /data integrity sweep ───────────────────────────────────────────────
+
+
+def check_data_integrity(
+    *,
+    schema_version_path: str = DEFAULT_SCHEMA_VERSION_PATH,
+    scratch_dir: str = DEFAULT_SCRATCH_DIR,
+    scratch_size_bytes: int = DEFAULT_SCRATCH_SIZE_BYTES,
+    chunk_bytes: int = DEFAULT_SCRATCH_CHUNK_BYTES,
+    schema_reader: Optional[SchemaReader] = None,
+    scratch_opener: Optional[ScratchOpener] = None,
+    now_fn: Optional[NowFn] = None,
+) -> TestResult:
+    """Re-read ``SCHEMA_VERSION`` and round-trip a 100 MB scratch file.
+
+    Plan §163: "/data integrity sweep (re-read SCHEMA_VERSION,
+    write/read/delete a 100 MB scratch file)".
+
+    Behaviour:
+
+    1. Open ``schema_version_path`` and read its (non-empty) contents
+       — failure means slot_confirm has somehow let us run without a
+       valid /data, which is a hard fail.
+    2. Create a uuid-named scratch file under ``scratch_dir`` and
+       write ``scratch_size_bytes`` of a deterministic pseudo-random
+       pattern in ``chunk_bytes``-sized chunks, computing a SHA-256 as
+       we write.
+    3. Read it back, computing a SHA-256 of the read bytes.
+    4. Delete the scratch file (best-effort — leaving 100 MB of
+       garbage on /data is not a check failure of the write/read).
+    5. Fail if the read SHA differs from the write SHA or any I/O
+       step raised.
+
+    Tests inject ``schema_reader`` (returns the SCHEMA_VERSION text)
+    and ``scratch_opener`` (mimics ``open(path, mode)``) — the file
+    object returned must support ``write(bytes)``, ``read(int)``,
+    ``flush()``, ``fileno()`` (optional, ``os.fsync`` is wrapped in
+    try/except), and ``close()``.
+    """
+    if scratch_size_bytes <= 0:
+        raise UpdateTesterError(
+            f"scratch_size_bytes must be > 0, got {scratch_size_bytes!r}"
+        )
+    if chunk_bytes <= 0:
+        raise UpdateTesterError(f"chunk_bytes must be > 0, got {chunk_bytes!r}")
+
+    now = now_fn or _default_now
+    read_schema = schema_reader or _read_text_file
+
+    started = now()
+
+    try:
+        schema_text = read_schema(schema_version_path)
+    except FileNotFoundError as exc:
+        finished = now()
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=f"SCHEMA_VERSION not found: {schema_version_path}",
+            measurement={
+                "schema_version_path": schema_version_path,
+                "errno": getattr(exc, "errno", None),
+            },
+            started=started,
+            finished=finished,
+        )
+    except (PermissionError, OSError) as exc:
+        finished = now()
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=f"SCHEMA_VERSION read failed: {exc}",
+            measurement={
+                "schema_version_path": schema_version_path,
+                "errno": getattr(exc, "errno", None),
+            },
+            started=started,
+            finished=finished,
+        )
+
+    schema_text_stripped = (schema_text or "").strip()
+    if not schema_text_stripped:
+        finished = now()
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=f"SCHEMA_VERSION is empty: {schema_version_path}",
+            measurement={"schema_version_path": schema_version_path},
+            started=started,
+            finished=finished,
+        )
+
+    scratch_name = f".update-tester-scratch-{uuid.uuid4().hex}"
+    scratch_path = os.path.join(scratch_dir, scratch_name)
+    open_fn: ScratchOpener = scratch_opener or (lambda p, m: open(p, m))
+
+    write_hash = hashlib.sha256()
+    seed = uuid.uuid4().bytes
+    bytes_written = 0
+    try:
+        fh = open_fn(scratch_path, "wb")
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        finished = now()
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=f"scratch open(wb) failed: {exc}",
+            measurement={
+                "scratch_path": scratch_path,
+                "errno": getattr(exc, "errno", None),
+            },
+            started=started,
+            finished=finished,
+        )
+    try:
+        try:
+            remaining = scratch_size_bytes
+            counter = 0
+            while remaining > 0:
+                this_chunk = min(chunk_bytes, remaining)
+                # Deterministic pseudo-random chunk: SHA-256(seed || counter)
+                # truncated/repeated to fill ``this_chunk`` bytes.
+                pattern = hashlib.sha256(
+                    seed + counter.to_bytes(8, "big", signed=False)
+                ).digest()
+                repeats = (this_chunk + len(pattern) - 1) // len(pattern)
+                chunk = (pattern * repeats)[:this_chunk]
+                fh.write(chunk)
+                write_hash.update(chunk)
+                bytes_written += this_chunk
+                remaining -= this_chunk
+                counter += 1
+            flush = getattr(fh, "flush", None)
+            if callable(flush):
+                try:
+                    flush()
+                except OSError:
+                    pass
+            fileno = getattr(fh, "fileno", None)
+            if callable(fileno):
+                try:
+                    os.fsync(fileno())
+                except (OSError, ValueError):
+                    pass
+        except OSError as exc:
+            finished = now()
+            return _wrap_result(
+                name="data_integrity",
+                ok=False,
+                detail=f"scratch write failed after {bytes_written} bytes: {exc}",
+                measurement={
+                    "scratch_path": scratch_path,
+                    "bytes_written": bytes_written,
+                    "errno": getattr(exc, "errno", None),
+                    "schema_version": schema_text_stripped,
+                },
+                started=started,
+                finished=finished,
+            )
+    finally:
+        close = getattr(fh, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+
+    read_hash = hashlib.sha256()
+    bytes_read = 0
+    try:
+        fh = open_fn(scratch_path, "rb")
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        try:
+            os.unlink(scratch_path)
+        except OSError:
+            pass
+        finished = now()
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=f"scratch open(rb) failed: {exc}",
+            measurement={
+                "scratch_path": scratch_path,
+                "bytes_written": bytes_written,
+                "errno": getattr(exc, "errno", None),
+                "schema_version": schema_text_stripped,
+            },
+            started=started,
+            finished=finished,
+        )
+    try:
+        try:
+            while True:
+                chunk = fh.read(chunk_bytes)
+                if not chunk:
+                    break
+                read_hash.update(chunk)
+                bytes_read += len(chunk)
+        except OSError as exc:
+            finished = now()
+            return _wrap_result(
+                name="data_integrity",
+                ok=False,
+                detail=f"scratch read failed after {bytes_read} bytes: {exc}",
+                measurement={
+                    "scratch_path": scratch_path,
+                    "bytes_written": bytes_written,
+                    "bytes_read": bytes_read,
+                    "errno": getattr(exc, "errno", None),
+                    "schema_version": schema_text_stripped,
+                },
+                started=started,
+                finished=finished,
+            )
+    finally:
+        close = getattr(fh, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
+
+    try:
+        os.unlink(scratch_path)
+    except OSError:
+        # Best-effort cleanup; not a check failure.
+        pass
+
+    write_digest = write_hash.hexdigest()
+    read_digest = read_hash.hexdigest()
+    measurement = {
+        "schema_version_path": schema_version_path,
+        "schema_version": schema_text_stripped,
+        "scratch_path": scratch_path,
+        "scratch_size_bytes": scratch_size_bytes,
+        "chunk_bytes": chunk_bytes,
+        "bytes_written": bytes_written,
+        "bytes_read": bytes_read,
+        "write_sha256": write_digest,
+        "read_sha256": read_digest,
+    }
+
+    finished = now()
+    if bytes_read != bytes_written:
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=(
+                f"scratch round-trip size mismatch: wrote "
+                f"{bytes_written} bytes, read {bytes_read} bytes"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+    if write_digest != read_digest:
+        return _wrap_result(
+            name="data_integrity",
+            ok=False,
+            detail=(
+                f"scratch round-trip checksum mismatch: "
+                f"wrote sha256 {write_digest[:12]}…, "
+                f"read sha256 {read_digest[:12]}…"
+            ),
+            measurement=measurement,
+            started=started,
+            finished=finished,
+        )
+
+    return _wrap_result(
+        name="data_integrity",
+        ok=True,
+        detail=(
+            f"SCHEMA_VERSION={schema_text_stripped!r}; "
+            f"{bytes_written}-byte scratch round-trip checksum match"
+        ),
+        measurement=measurement,
+        started=started,
+        finished=finished,
+    )
+
+
+# ── Aggregator ─────────────────────────────────────────────────────────────
+
+
+def _atomic_write_json(path: str, payload: Mapping[str, Any]) -> None:
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".update-tester-", suffix=".json", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _result_to_dict(result: TestResult) -> dict[str, Any]:
+    return {
+        "name": result.name,
+        "ok": result.ok,
+        "detail": result.detail,
+        "measurement": dict(result.measurement or {}),
+        "started_at": result.started_at,
+        "finished_at": result.finished_at,
+        "duration_seconds": result.duration_seconds,
+    }
+
+
+def battery_to_dict(result: TestBatteryResult) -> dict[str, Any]:
+    """Render a :class:`TestBatteryResult` as a JSON-friendly dict."""
+    return {
+        "run_id": result.run_id,
+        "ok": result.ok,
+        "started_at": result.started_at,
+        "finished_at": result.finished_at,
+        "duration_seconds": result.duration_seconds,
+        "deadline_seconds": result.deadline_seconds,
+        "deadline_hit": result.deadline_hit,
+        "output_path": result.output_path,
+        "tests": [_result_to_dict(t) for t in result.tests],
+    }
+
+
+def run_test_battery(
+    *,
+    run_id: Optional[str] = None,
+    output_dir: Optional[str] = DEFAULT_OUTPUT_DIR,
+    write_output: bool = True,
+    deadline_seconds: int = DEFAULT_DEADLINE_SECONDS,
+    render_kwargs: Optional[Mapping[str, Any]] = None,
+    wps_kwargs: Optional[Mapping[str, Any]] = None,
+    stress_kwargs: Optional[Mapping[str, Any]] = None,
+    integrity_kwargs: Optional[Mapping[str, Any]] = None,
+    now_fn: Optional[NowFn] = None,
+    json_writer: Optional[Callable[[str, Mapping[str, Any]], None]] = None,
+) -> TestBatteryResult:
+    """Run the 4-test battery in order, enforce a deadline, write JSON.
+
+    Tests run in the listed order: render, WPS, stress, integrity.
+    The deadline is enforced *between* tests: a test that's already
+    running when the deadline elapses runs to completion; subsequent
+    tests are skipped and recorded as ``ok=False`` with
+    ``detail="deadline exceeded; test not run"``. The overall
+    ``ok`` is ``True`` only if every test passed *and* the deadline
+    wasn't hit.
+
+    ``run_id`` defaults to a fresh uuid4 hex. When ``write_output`` is
+    true (default) and ``output_dir`` is set, the per-run JSON
+    artifact is written atomically at
+    ``output_dir/<run_id>.json``. Set ``write_output=False`` (or
+    ``output_dir=None``) for dry-runs and tests.
+
+    Per-check overrides are passed through their ``*_kwargs`` dicts;
+    any unknown key surfaces as ``TypeError`` from the underlying
+    check function. ``now_fn`` is injected into every check for clock
+    consistency.
+    """
+    if deadline_seconds <= 0:
+        raise UpdateTesterError(
+            f"deadline_seconds must be > 0, got {deadline_seconds!r}"
+        )
+
+    now = now_fn or _default_now
+    rid = run_id or uuid.uuid4().hex
+    started = now()
+
+    def deadline_exceeded() -> bool:
+        return (now() - started).total_seconds() > deadline_seconds
+
+    def merge(base: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+        merged: dict[str, Any] = {"now_fn": now}
+        if base:
+            merged.update(dict(base))
+        return merged
+
+    tests: list[TestResult] = []
+    deadline_hit = False
+
+    runners: list[tuple[str, Callable[[], TestResult]]] = [
+        ("render_canary", lambda: check_render_canary(**merge(render_kwargs))),
+        ("wps_synthetic", lambda: check_wps_synthetic(**merge(wps_kwargs))),
+        ("stress", lambda: check_stress(**merge(stress_kwargs))),
+        ("data_integrity", lambda: check_data_integrity(**merge(integrity_kwargs))),
+    ]
+
+    for name, runfn in runners:
+        if deadline_hit or deadline_exceeded():
+            deadline_hit = True
+            t0 = now()
+            tests.append(
+                _wrap_result(
+                    name=name,
+                    ok=False,
+                    detail="deadline exceeded; test not run",
+                    measurement={
+                        "deadline_seconds": deadline_seconds,
+                        "skipped_due_to_deadline": True,
+                    },
+                    started=t0,
+                    finished=t0,
+                )
+            )
+            continue
+        try:
+            result = runfn()
+        except UpdateTesterError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            t0 = now()
+            result = _wrap_result(
+                name=name,
+                ok=False,
+                detail=f"test raised unexpectedly: {type(exc).__name__}: {exc}",
+                measurement={"exception_type": type(exc).__name__},
+                started=t0,
+                finished=t0,
+            )
+        tests.append(result)
+
+    finished = now()
+    duration = max(0.0, (finished - started).total_seconds())
+    overall_ok = (not deadline_hit) and all(t.ok for t in tests)
+
+    output_path = ""
+    if write_output and output_dir:
+        output_path = os.path.join(output_dir, f"{rid}.json")
+
+    battery = TestBatteryResult(
+        run_id=rid,
+        ok=overall_ok,
+        started_at=_format_ts(started),
+        finished_at=_format_ts(finished),
+        duration_seconds=duration,
+        deadline_seconds=deadline_seconds,
+        deadline_hit=deadline_hit,
+        tests=tuple(tests),
+        output_path=output_path,
+    )
+
+    if output_path:
+        write_fn = json_writer or _atomic_write_json
+        try:
+            write_fn(output_path, battery_to_dict(battery))
+        except OSError as exc:
+            battery = TestBatteryResult(
+                run_id=rid,
+                ok=False,
+                started_at=battery.started_at,
+                finished_at=battery.finished_at,
+                duration_seconds=duration,
+                deadline_seconds=deadline_seconds,
+                deadline_hit=deadline_hit,
+                tests=battery.tests
+                + (
+                    _wrap_result(
+                        name="artifact_persist",
+                        ok=False,
+                        detail=f"failed to write {output_path}: {exc}",
+                        measurement={
+                            "output_path": output_path,
+                            "errno": getattr(exc, "errno", None),
+                        },
+                        started=finished,
+                        finished=finished,
+                    ),
+                ),
+                output_path="",
+            )
+
+    return battery


### PR DESCRIPTION
Phase 1 / agora-os multi-replica OTA — adds the lab-ring post-confirm gate.

## What this is
The `agora-update-tester` package (referenced by plan §157-165) is the synthetic-load battery that runs **after** `slot_confirm()` passes when a device is in a ring with `gate_type=confirm_plus_test_suite` (today: the `lab` ring with the single dev Pi).

It writes a structured JSON artifact to `/data/agora/test-results/<run-id>.json`. **Phase 1 only** — no CMS wire-up yet; Phase 3 will read those artifacts and post `update_test_results` rows.

## Library (`update_tester/core.py`)
Four check functions, fully injectable for test (clock, I/O, subprocess, file opener all overridable):

| Check | What it verifies |
|---|---|
| `check_render_canary` | framebuffer writes hold a target fps band |
| `check_wps_synthetic` | WPS receiver state is connected + last-seen-at fresh |
| `check_stress` | stress-ng exits clean, no thermal throttle, no dmesg OOM |
| `check_data_integrity` | SCHEMA_VERSION readable + scratch-file round-trip cleans up |

Plus:
- `TestResult` / `TestBatteryResult` frozen dataclasses
- `run_test_battery()` aggregator with per-test deadline enforcement, unexpected-exception wrapping, and atomic JSON artifact writer
- 22 `DEFAULT_*` constants for production defaults

## CLI (`update_tester/__main__.py`)
`python -m update_tester run-battery --output-dir /data/agora/test-results [...]`

Exit codes: `0` ok, `1` fail, `2` `UpdateTesterError` (programmer error).

## Tests
78 cases across 8 classes — every check function exercised on happy + failure paths, plus the aggregator (happy / failure / deadline-skip / artifact write / unexpected-exception wrap), CLI, and atomic-write helper. Full agora suite: **1053 passed, 30 skipped**.

## Phase 1 progress
- [x] `p1-slot-mgr`         (#166)
- [x] `p1-watchdog`         (#167)
- [x] `p1-precheck`         (#168)
- [x] `p1-forward-migration-fence`  (#169)
- [x] `p1-slot-confirm`     (#170)
- [x] `p1-update-tester`    **(this PR)**
- [ ] `p1-chaos-harness`   next
- [ ] `p1-smart-plug-pick`, `p1-acceptance`  (hardware-blocked)