### PR TITLE
feat(chaos): software-reboot chaos harness for slot-mgr (Phase 1)

### DIFF
--- a/chaos/__init__.py
+++ b/chaos/__init__.py
@@ -1,0 +1,59 @@
+"""Chaos harness for ``slot_mgr`` — Phase 1 software-reboot subset.
+
+The harness simulates power-loss / crashes at each disk-write seam in
+``slot_mgr.core`` (trigger_tryboot, promote_slot, record_tryboot_strike,
+unpin) and verifies that the on-disk state stays recoverable. See
+:mod:`chaos.core` for the framework primitives and :mod:`chaos.scenarios`
+for the concrete injection points.
+
+Public surface:
+
+* :class:`ChaosEnv`, :func:`make_env`, :func:`active_env`,
+  :func:`set_cmdline_slot` — build & activate an isolated filesystem env.
+* :class:`ChaosError`, :class:`ChaosPowerCut` — harness exception types.
+* :func:`inject_after_nth_call`, :func:`inject_first_call` — patch a
+  module-level callable to fault after N successful invocations.
+* :class:`Scenario`, :class:`ScenarioResult` — value types.
+* :func:`run_scenario`, :func:`run_scenarios`, :func:`summarize_results`
+  — execution + reporting.
+* :data:`SCENARIOS`, :func:`list_scenarios`, :func:`get_scenario` — the
+  registered scenario catalogue.
+"""
+
+from chaos.core import (
+    ChaosEnv,
+    ChaosError,
+    ChaosPowerCut,
+    Scenario,
+    ScenarioResult,
+    active_env,
+    inject_after_nth_call,
+    inject_first_call,
+    make_env,
+    run_scenario,
+    run_scenarios,
+    set_cmdline_slot,
+    summarize_results,
+)
+from chaos.scenarios import SCENARIOS, get_scenario, list_scenarios
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "ChaosEnv",
+    "ChaosError",
+    "ChaosPowerCut",
+    "Scenario",
+    "ScenarioResult",
+    "SCENARIOS",
+    "active_env",
+    "get_scenario",
+    "inject_after_nth_call",
+    "inject_first_call",
+    "list_scenarios",
+    "make_env",
+    "run_scenario",
+    "run_scenarios",
+    "set_cmdline_slot",
+    "summarize_results",
+]

--- a/chaos/__main__.py
+++ b/chaos/__main__.py
@@ -1,0 +1,143 @@
+"""Command-line entry point for the chaos harness.
+
+Usage
+-----
+
+::
+
+    python -m chaos list
+    python -m chaos run <scenario-name>
+    python -m chaos run-all [--json]
+
+Exit codes
+----------
+
+* ``0`` — all scenarios passed.
+* ``1`` — at least one scenario failed.
+* ``2`` — programmer / usage error (bad arguments, unknown scenario name,
+  harness raised :class:`chaos.ChaosError`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+from chaos import (
+    ChaosError,
+    SCENARIOS,
+    get_scenario,
+    list_scenarios,
+    make_env,
+    run_scenario,
+    run_scenarios,
+    summarize_results,
+)
+
+
+def _build_env_factory():
+    """Return a callable that mints a fresh :class:`ChaosEnv` in a new tempdir."""
+
+    def factory():
+        root = Path(tempfile.mkdtemp(prefix="chaos-"))
+        return make_env(root)
+
+    return factory
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    scenarios = list_scenarios()
+    if args.json:
+        print(json.dumps({"scenarios": scenarios}, indent=2))
+        return 0
+    for s in scenarios:
+        print(f"{s['name']}")
+        print(f"    {s['description']}")
+    print(f"\n{len(scenarios)} scenario(s)")
+    return 0
+
+
+def _format_result(result, *, verbose: bool) -> str:
+    icon = "PASS" if result.ok else "FAIL"
+    line = f"[{icon}] {result.name}"
+    if result.detail:
+        line += f"  ({result.detail})"
+    if verbose and result.traceback:
+        line += "\n" + result.traceback
+    return line
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    try:
+        scenario = get_scenario(args.name)
+    except KeyError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    env = _build_env_factory()()
+    result = run_scenario(scenario, env)
+    if args.json:
+        print(json.dumps(summarize_results([result]), indent=2))
+    else:
+        print(_format_result(result, verbose=True))
+    return 0 if result.ok else 1
+
+
+def _cmd_run_all(args: argparse.Namespace) -> int:
+    results = run_scenarios(SCENARIOS, _build_env_factory())
+    if args.json:
+        print(json.dumps(summarize_results(results), indent=2))
+    else:
+        for r in results:
+            print(_format_result(r, verbose=args.verbose))
+        passed = sum(1 for r in results if r.ok)
+        total = len(results)
+        print(f"\n{passed}/{total} scenarios passed")
+    return 0 if all(r.ok for r in results) else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m chaos",
+        description="Phase 1 software-reboot chaos harness for slot_mgr.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    list_p = sub.add_parser("list", help="list every registered scenario")
+    list_p.add_argument("--json", action="store_true", help="emit JSON output")
+    list_p.set_defaults(func=_cmd_list)
+
+    run_p = sub.add_parser("run", help="run one scenario by name")
+    run_p.add_argument("name", help="scenario name (see `list`)")
+    run_p.add_argument("--json", action="store_true", help="emit JSON output")
+    run_p.set_defaults(func=_cmd_run)
+
+    all_p = sub.add_parser("run-all", help="run every registered scenario")
+    all_p.add_argument("--json", action="store_true", help="emit JSON output")
+    all_p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="include tracebacks for failures",
+    )
+    all_p.set_defaults(func=_cmd_run_all)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ChaosError as exc:
+        print(f"chaos-harness error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/chaos/core.py
+++ b/chaos/core.py
@@ -1,0 +1,388 @@
+"""Core chaos-harness framework: env builder, injection helpers, scenario runner.
+
+The chaos harness simulates power-loss / crashes during ``slot_mgr`` state
+transitions and verifies that recovery (a notional "next boot") leaves the
+device in a sensible, recoverable state.
+
+Implementation strategy
+-----------------------
+
+Atomic-write *is* atomic in Python: ``tempfile.mkstemp`` + ``os.fdopen`` +
+``os.chmod`` + ``os.replace`` either fully commits or rolls back with no
+partial state on disk. The software-reboot subset of the chaos harness
+therefore models "power loss" as faulting *between* successive disk
+operations (not mid-flight inside a single atomic write); each scenario
+chooses a seam — e.g. "after primary autoboot.txt written, before mirror
+written" — and raises :class:`ChaosPowerCut` there.
+
+Faulting "mid-flight" inside an atomic write is observably indistinguishable
+from faulting before the write started (the tempfile cleanup is part of the
+atomic-write contract). The harness exploits this and only models the
+between-step seams. True mid-flight power cuts (where the kernel itself dies
+mid-write, leaving a half-written FAT32 sector on a boot partition, say)
+require a hardware power-cut rig and are covered by the smart-plug subset
+deferred to ``p1-smart-plug-pick``.
+
+:class:`ChaosPowerCut` subclasses :class:`BaseException` rather than
+:class:`Exception` so production code's ``except Exception`` clauses don't
+accidentally swallow the simulated fault and prevent the scenario from
+exercising recovery.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import traceback
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, Optional, Sequence
+from unittest import mock
+
+from slot_mgr.autoboot import SLOT_TO_BOOT_PARTITION
+
+#: Re-export the slot→boot-partition mapping from :mod:`slot_mgr.autoboot` so
+#: scenarios that build autoboot fixtures stay consistent with the production
+#: layout (slot 1 → partition 1 (boot-A), slot 2 → partition 3 (boot-B)).
+SLOT_TO_BOOT_PART = SLOT_TO_BOOT_PARTITION
+
+
+class ChaosError(RuntimeError):
+    """Programmer error in the harness itself (bad scenario, missing dep)."""
+
+
+class ChaosPowerCut(BaseException):
+    """Simulated power-loss exception.
+
+    Subclasses :class:`BaseException` so ``except Exception:`` clauses in
+    production code don't swallow the fault before the scenario can test
+    recovery. Scenarios that *do* want to catch the fault (to model a
+    successful reboot after the crash) catch this class explicitly.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Environment builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChaosEnv:
+    """Isolated filesystem environment for one scenario.
+
+    Mirrors the on-device layout under a temporary root so scenarios can
+    drive ``slot_mgr`` without touching ``/boot/firmware`` or ``/data``.
+
+    Attributes
+    ----------
+    root:
+        Absolute path of the temporary root directory.
+    autoboot_path:
+        ``<root>/boot/firmware/autoboot.txt`` — primary autoboot file.
+    autoboot_mirror_path:
+        ``<root>/boot/firmware-b/autoboot.txt`` — mirror.
+    data_dir:
+        ``<root>/data/agora`` — equivalent of ``/data/agora``.
+    slot_state_path:
+        ``<root>/data/agora/slot-state.json``.
+    sentinel_path:
+        ``<root>/data/agora/migration-allowed`` (forward-migration fence).
+    cmdline_path:
+        ``<root>/proc/cmdline`` — writable fake; scenarios mutate it to
+        simulate a different boot.
+    """
+
+    root: Path
+    autoboot_path: Path
+    autoboot_mirror_path: Path
+    data_dir: Path
+    slot_state_path: Path
+    sentinel_path: Path
+    cmdline_path: Path
+
+
+def _autoboot_contents(default_slot: int) -> str:
+    """Return a valid autoboot.txt body with the given ``[all]`` slot."""
+    default_bp = SLOT_TO_BOOT_PART[default_slot]
+    tryboot_bp = SLOT_TO_BOOT_PART[2 if default_slot == 1 else 1]
+    return (
+        "[all]\n"
+        f"boot_partition={default_bp}\n"
+        "\n"
+        "[tryboot]\n"
+        f"boot_partition={tryboot_bp}\n"
+    )
+
+
+def _cmdline_contents(running_slot: int) -> str:
+    """Return a valid /proc/cmdline body for the given running slot."""
+    label = "A" if running_slot == 1 else "B"
+    return f"root=PARTLABEL=root-{label} rootfstype=ext4 rootwait\n"
+
+
+def make_env(
+    root: Path,
+    *,
+    running_slot: int = 1,
+    default_slot: int = 1,
+) -> ChaosEnv:
+    """Build a fresh isolated filesystem under ``root``.
+
+    Parameters
+    ----------
+    root:
+        Pre-existing empty directory the harness will populate.
+    running_slot:
+        Which slot the simulated kernel cmdline reports (default 1).
+    default_slot:
+        Which slot the simulated autoboot.txt ``[all]`` block points at
+        (default 1; same as ``running_slot`` ⇒ ``tentative=False``).
+    """
+    if running_slot not in SLOT_TO_BOOT_PART:
+        raise ChaosError(f"running_slot must be 1 or 2, got {running_slot!r}")
+    if default_slot not in SLOT_TO_BOOT_PART:
+        raise ChaosError(f"default_slot must be 1 or 2, got {default_slot!r}")
+
+    firmware = root / "boot" / "firmware"
+    firmware_b = root / "boot" / "firmware-b"
+    data_agora = root / "data" / "agora"
+    proc = root / "proc"
+
+    for d in (firmware, firmware_b, data_agora, proc):
+        d.mkdir(parents=True, exist_ok=True)
+
+    autoboot_path = firmware / "autoboot.txt"
+    mirror_path = firmware_b / "autoboot.txt"
+    cmdline_path = proc / "cmdline"
+
+    autoboot_text = _autoboot_contents(default_slot)
+    autoboot_path.write_text(autoboot_text)
+    mirror_path.write_text(autoboot_text)
+    cmdline_path.write_text(_cmdline_contents(running_slot))
+
+    return ChaosEnv(
+        root=root,
+        autoboot_path=autoboot_path,
+        autoboot_mirror_path=mirror_path,
+        data_dir=data_agora,
+        slot_state_path=data_agora / "slot-state.json",
+        sentinel_path=data_agora / "migration-allowed",
+        cmdline_path=cmdline_path,
+    )
+
+
+@contextmanager
+def active_env(env: ChaosEnv) -> Iterator[ChaosEnv]:
+    """Context manager: set ``AGORA_*`` env vars to point at ``env`` paths.
+
+    Restores prior env-var values on exit. Scenarios always wrap their
+    production-code invocations in this so :mod:`slot_mgr.paths` resolves to
+    the isolated tree.
+    """
+    overrides = {
+        "AGORA_AUTOBOOT_PATH": str(env.autoboot_path),
+        "AGORA_AUTOBOOT_MIRROR_PATH": str(env.autoboot_mirror_path),
+        "AGORA_SLOT_DATA_DIR": str(env.data_dir),
+        "AGORA_PROC_CMDLINE": str(env.cmdline_path),
+    }
+    saved = {k: os.environ.get(k) for k in overrides}
+    os.environ.update(overrides)
+    try:
+        yield env
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def set_cmdline_slot(env: ChaosEnv, slot: int) -> None:
+    """Rewrite ``env.cmdline_path`` to claim we just booted into ``slot``.
+
+    Used by scenarios that simulate a reboot after a chaos injection — the
+    bootloader's pick of slot is reflected in the new ``/proc/cmdline``.
+    """
+    if slot not in SLOT_TO_BOOT_PART:
+        raise ChaosError(f"slot must be 1 or 2, got {slot!r}")
+    env.cmdline_path.write_text(_cmdline_contents(slot))
+
+
+# ---------------------------------------------------------------------------
+# Injection helpers
+# ---------------------------------------------------------------------------
+
+
+def inject_after_nth_call(
+    module: object,
+    attr: str,
+    n: int,
+    *,
+    message: str = "chaos",
+) -> contextlib.AbstractContextManager:
+    """Context manager: let ``module.attr`` run normally for ``n`` calls, then fault.
+
+    On call ``n+1`` (1-indexed), raises :class:`ChaosPowerCut` *before*
+    invoking the original function — so the n+1th call's side effect is
+    not committed.
+
+    Parameters
+    ----------
+    module:
+        The module (or class) holding the attribute to patch.
+    attr:
+        The attribute name to replace.
+    n:
+        Number of calls that should run normally before the fault. ``n=0``
+        means the very first call faults.
+    message:
+        Free-form text included in the ``ChaosPowerCut`` message — names the
+        scenario for easier debugging when a test fails.
+    """
+    if n < 0:
+        raise ChaosError(f"n must be >= 0, got {n!r}")
+    orig = getattr(module, attr)
+    state = {"calls": 0}
+
+    def wrapper(*args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] > n:
+            raise ChaosPowerCut(f"{message} (call {state['calls']})")
+        return orig(*args, **kwargs)
+
+    return mock.patch.object(module, attr, new=wrapper)
+
+
+def inject_first_call(
+    module: object,
+    attr: str,
+    *,
+    message: str = "chaos",
+) -> contextlib.AbstractContextManager:
+    """Shortcut for ``inject_after_nth_call(module, attr, 0, message=…)``."""
+    return inject_after_nth_call(module, attr, 0, message=message)
+
+
+# ---------------------------------------------------------------------------
+# Scenario primitives
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One chaos-injection scenario.
+
+    The ``run`` callable receives a freshly-built :class:`ChaosEnv` already
+    wrapped in :func:`active_env` (so ``slot_mgr`` will route I/O into the
+    isolated tree). It should:
+
+    1. Drive the production-code path that's being chaos-tested.
+    2. Catch :class:`ChaosPowerCut` from the injected fault.
+    3. Optionally simulate "next boot" (e.g. mutate cmdline, restart state).
+    4. Assert the invariants (use plain ``assert`` — :func:`run_scenario`
+       captures :class:`AssertionError` into the result).
+
+    The callable returns ``None`` on success; any uncaught exception is
+    captured as a failure.
+    """
+
+    name: str
+    description: str
+    run: Callable[[ChaosEnv], None]
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    """Outcome of running one scenario.
+
+    Attributes
+    ----------
+    name:
+        Scenario identifier (matches ``Scenario.name``).
+    ok:
+        Whether all invariants held.
+    detail:
+        Short human-readable summary (empty on success; exception message
+        or assertion text on failure).
+    error_type:
+        Exception class name when ``ok=False`` and the failure came from an
+        unexpected exception (not an :class:`AssertionError`); ``None``
+        otherwise.
+    traceback:
+        Full traceback string when ``ok=False``; empty otherwise.
+    """
+
+    name: str
+    ok: bool
+    detail: str = ""
+    error_type: Optional[str] = None
+    traceback: str = ""
+
+
+def run_scenario(scenario: Scenario, env: ChaosEnv) -> ScenarioResult:
+    """Execute one scenario under ``env``. Catches failures into a result."""
+    try:
+        with active_env(env):
+            scenario.run(env)
+        return ScenarioResult(name=scenario.name, ok=True)
+    except AssertionError as exc:
+        return ScenarioResult(
+            name=scenario.name,
+            ok=False,
+            detail=str(exc) or "assertion failed",
+            error_type="AssertionError",
+            traceback=traceback.format_exc(),
+        )
+    except ChaosPowerCut as exc:
+        # ChaosPowerCut leaking out is a bug in the scenario itself - it
+        # should have been caught after the injected fault fired.
+        return ScenarioResult(
+            name=scenario.name,
+            ok=False,
+            detail=f"uncaught ChaosPowerCut: {exc}",
+            error_type="ChaosPowerCut",
+            traceback=traceback.format_exc(),
+        )
+    except Exception as exc:  # noqa: BLE001 - this is the catch-all sink
+        return ScenarioResult(
+            name=scenario.name,
+            ok=False,
+            detail=f"{type(exc).__name__}: {exc}",
+            error_type=type(exc).__name__,
+            traceback=traceback.format_exc(),
+        )
+
+
+def run_scenarios(
+    scenarios: Iterable[Scenario],
+    env_factory: Callable[[], ChaosEnv],
+) -> list[ScenarioResult]:
+    """Run each scenario in a freshly-built env. Returns all results."""
+    results: list[ScenarioResult] = []
+    for scenario in scenarios:
+        env = env_factory()
+        results.append(run_scenario(scenario, env))
+    return results
+
+
+def summarize_results(results: Sequence[ScenarioResult]) -> dict[str, object]:
+    """Return a compact summary dict suitable for ``json.dumps``."""
+    total = len(results)
+    passed = sum(1 for r in results if r.ok)
+    failed = total - passed
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": failed,
+        "ok": failed == 0,
+        "scenarios": [
+            {
+                "name": r.name,
+                "ok": r.ok,
+                "detail": r.detail,
+                "error_type": r.error_type,
+            }
+            for r in results
+        ],
+    }

--- a/chaos/scenarios.py
+++ b/chaos/scenarios.py
@@ -1,0 +1,757 @@
+"""Concrete chaos scenarios for the Phase 1 ≥15-point software-reboot subset.
+
+Each scenario uses :func:`chaos.core.inject_after_nth_call` to fault at a
+specific seam between disk operations in ``slot_mgr``, then verifies that:
+
+* the on-disk artifacts (autoboot.txt, slot-state.json, migration sentinel)
+  are either unchanged or in a documented partially-committed state,
+* re-running the interrupted operation completes successfully (idempotency),
+* the system can still derive a valid :class:`slot_mgr.SlotStatus`.
+
+The Phase 1 plan requires ≥15 software-reboot injection points; this module
+ships 17.
+
+Naming convention
+-----------------
+
+``<operation>/<seam>`` where ``<operation>`` is one of ``trigger-tryboot``,
+``promote``, ``strike``, ``unpin``, ``storm``, ``recovery`` and ``<seam>``
+is a short label for *where* in the operation the fault fires.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, List
+
+from slot_mgr import autoboot as ab
+from slot_mgr.autoboot import BOOT_PARTITION_TO_SLOT
+from slot_mgr import core as sm_core
+from slot_mgr import state as sm_state
+from slot_mgr.state import STRIKE_LIMIT, SlotState, save_state, load_state
+
+from chaos.core import (
+    ChaosEnv,
+    ChaosPowerCut,
+    Scenario,
+    inject_after_nth_call,
+    inject_first_call,
+    set_cmdline_slot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Invariant helpers shared across scenarios
+# ---------------------------------------------------------------------------
+
+
+def _parse_autoboot_default(path: Path) -> int | None:
+    """Return the ``[all] boot_partition`` slot number for ``path``."""
+    parsed = ab.parse_autoboot(path.read_text())
+    return parsed.default_slot()
+
+
+def _parse_autoboot_tryboot(path: Path) -> int | None:
+    """Return the ``[tryboot] boot_partition`` slot number for ``path``."""
+    parsed = ab.parse_autoboot(path.read_text())
+    part = parsed.tryboot_partition()
+    return None if part is None else BOOT_PARTITION_TO_SLOT.get(part)
+
+
+def _assert_autoboot_parseable(env: ChaosEnv) -> None:
+    """Both autoboot files must be parseable (no half-written content)."""
+    primary = ab.parse_autoboot(env.autoboot_path.read_text())
+    assert primary.default_slot() in (1, 2), (
+        f"primary autoboot.txt has invalid [all] slot: {primary.default_slot()!r}"
+    )
+    if env.autoboot_mirror_path.exists():
+        mirror = ab.parse_autoboot(env.autoboot_mirror_path.read_text())
+        assert mirror.default_slot() in (1, 2), (
+            f"mirror autoboot.txt has invalid [all] slot: {mirror.default_slot()!r}"
+        )
+
+
+def _assert_slot_state_parseable(env: ChaosEnv) -> None:
+    """slot-state.json must be parseable as a :class:`SlotState`."""
+    if not env.slot_state_path.exists():
+        # Missing is fine — load_state() returns a fresh default.
+        return
+    SlotState.model_validate_json(env.slot_state_path.read_text())
+
+
+def _assert_no_orphan_tempfiles(env: ChaosEnv) -> None:
+    """No ``.tmp`` files left behind in the directories we wrote to."""
+    for d in (
+        env.autoboot_path.parent,
+        env.autoboot_mirror_path.parent,
+        env.data_dir,
+    ):
+        if not d.exists():
+            continue
+        orphans = [p.name for p in d.iterdir() if p.suffix == ".tmp"]
+        assert not orphans, f"orphan tempfiles in {d}: {orphans!r}"
+
+
+def _assert_slot_state_recoverable(env: ChaosEnv) -> None:
+    """``slot_state()`` must return a valid :class:`SlotStatus`."""
+    status = sm_core.slot_state()
+    assert status.running_slot in (None, 1, 2), (
+        f"running_slot={status.running_slot!r} out of band"
+    )
+    assert status.default_slot in (None, 1, 2), (
+        f"default_slot={status.default_slot!r} out of band"
+    )
+
+
+def _assert_baseline(env: ChaosEnv) -> None:
+    """The full baseline invariant suite (all four checks)."""
+    _assert_autoboot_parseable(env)
+    _assert_slot_state_parseable(env)
+    _assert_no_orphan_tempfiles(env)
+    _assert_slot_state_recoverable(env)
+
+
+def _silent_reboot() -> None:
+    """A no-op reboot function — used when scenarios drive ``trigger_tryboot``
+    with ``reboot=True`` to verify the reboot fires *last* (after all disk
+    side-effects are committed).
+    """
+    return None
+
+
+def _exploding_reboot() -> Callable[[], None]:
+    """Return a reboot function that raises :class:`ChaosPowerCut`.
+
+    Used by the "after-state-before-reboot" scenarios that verify a power-cut
+    during ``subprocess.run`` of ``sudo reboot`` leaves the device in a
+    consistent state (state + autoboot fully committed; just no actual reboot).
+    """
+
+    def _r() -> None:
+        raise ChaosPowerCut("reboot command interrupted")
+
+    return _r
+
+
+# ---------------------------------------------------------------------------
+# 1. trigger_tryboot scenarios
+# ---------------------------------------------------------------------------
+
+
+def _s_trigger_before_any_write(env: ChaosEnv) -> None:
+    """Power-cut before any autoboot write: state must be unchanged."""
+    original_default = _parse_autoboot_default(env.autoboot_path)
+
+    with inject_first_call(
+        ab, "_atomic_write_text", message="before any autoboot write"
+    ):
+        try:
+            sm_core.trigger_tryboot(2, reboot=False)
+        except ChaosPowerCut:
+            pass
+
+    # Invariants: no slot-state.json written, autoboot unchanged.
+    assert not env.slot_state_path.exists(), (
+        "slot-state.json should not exist — write should not have begun"
+    )
+    assert _parse_autoboot_default(env.autoboot_path) == original_default, (
+        "autoboot [all] slot must be unchanged before any write"
+    )
+    _assert_baseline(env)
+
+
+def _s_trigger_between_primary_and_mirror(env: ChaosEnv) -> None:
+    """Primary autoboot written, mirror failed.
+
+    The primary now has the tryboot section pointing at slot 2 (the freshly
+    written value); the mirror was untouched by the failing call. The state
+    save did not run (autoboot write raised before completing).
+    """
+    # Sanity: capture the mirror text before the chaos run so we can assert
+    # it's unchanged afterwards. The fresh env seeds both files identically.
+    mirror_before = env.autoboot_mirror_path.read_text()
+
+    with inject_after_nth_call(
+        ab, "_atomic_write_text", 1, message="between primary and mirror autoboot"
+    ):
+        try:
+            sm_core.trigger_tryboot(2, reboot=False)
+        except ChaosPowerCut:
+            pass
+
+    primary = ab.parse_autoboot(env.autoboot_path.read_text())
+    assert _parse_autoboot_tryboot(env.autoboot_path) == 2, (
+        "primary [tryboot] should point at slot 2 after partial write"
+    )
+    assert env.autoboot_mirror_path.read_text() == mirror_before, (
+        "mirror autoboot.txt must be byte-unchanged when its write failed"
+    )
+    assert not env.slot_state_path.exists(), (
+        "slot-state.json should not exist — write_autoboot raised before save"
+    )
+    _assert_baseline(env)
+
+
+def _s_trigger_between_autoboot_and_state(env: ChaosEnv) -> None:
+    """Both autoboot files written; slot-state.json save failed.
+
+    On next boot we'd try to tryboot to slot 2 (autoboot says so) but no
+    state was saved so ``record_tryboot_strike`` would have nothing to
+    attribute. ``slot_state()`` still reports a valid status.
+    """
+    with inject_first_call(
+        sm_state, "atomic_write", message="between autoboot and state save"
+    ):
+        try:
+            sm_core.trigger_tryboot(2, reboot=False)
+        except ChaosPowerCut:
+            pass
+
+    assert _parse_autoboot_tryboot(env.autoboot_path) == 2, (
+        "primary [tryboot] slot should be set"
+    )
+    assert _parse_autoboot_tryboot(env.autoboot_mirror_path) == 2, (
+        "mirror [tryboot] slot should match primary"
+    )
+    assert not env.slot_state_path.exists(), (
+        "slot-state.json save should have failed before any bytes hit disk"
+    )
+    _assert_baseline(env)
+
+
+def _s_trigger_after_state_before_reboot(env: ChaosEnv) -> None:
+    """All disk side-effects committed; reboot itself failed.
+
+    Equivalent to power-cut during ``sudo reboot``. The device is fully
+    prepared for a tryboot but didn't actually reboot. On a real reboot
+    later, the bootloader picks up the existing autoboot and trybooots.
+    """
+    try:
+        sm_core.trigger_tryboot(2, reboot=True, reboot_fn=_exploding_reboot())
+    except ChaosPowerCut:
+        pass
+
+    assert _parse_autoboot_tryboot(env.autoboot_path) == 2
+    assert _parse_autoboot_tryboot(env.autoboot_mirror_path) == 2
+    assert env.slot_state_path.exists(), "state should be fully committed"
+    state = load_state()
+    assert state.last_tryboot_target == 2, (
+        "state should record we asked for a tryboot to slot 2"
+    )
+    _assert_baseline(env)
+
+
+# ---------------------------------------------------------------------------
+# 2. promote_slot scenarios
+# ---------------------------------------------------------------------------
+
+
+def _stage_post_tryboot(env: ChaosEnv) -> None:
+    """Seed env to look like we just landed on slot 2 after a successful tryboot.
+
+    Used by promote scenarios so the system thinks tryboot already happened
+    (cmdline says slot 2, slot-state has last_tryboot_target=2).
+    """
+    set_cmdline_slot(env, 2)
+    seed = SlotState()
+    seed.last_tryboot_target = 2
+    seed.last_tryboot_at = "2026-01-01T00:00:00Z"
+    save_state(seed)
+
+
+def _s_promote_before_any_write(env: ChaosEnv) -> None:
+    """Power-cut before any autoboot write during promote."""
+    _stage_post_tryboot(env)
+    original_default = _parse_autoboot_default(env.autoboot_path)
+
+    with inject_first_call(
+        ab, "_atomic_write_text", message="promote: before any write"
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    assert _parse_autoboot_default(env.autoboot_path) == original_default, (
+        "autoboot [all] must be unchanged"
+    )
+    assert not env.sentinel_path.exists(), "sentinel must not exist"
+    _assert_baseline(env)
+
+
+def _s_promote_between_primary_and_mirror(env: ChaosEnv) -> None:
+    """Primary autoboot promoted to slot 2; mirror not.
+
+    Device will boot slot 2 normally (primary autoboot is authoritative when
+    the bootloader reads boot-A). State + sentinel never written.
+    """
+    _stage_post_tryboot(env)
+
+    with inject_after_nth_call(
+        ab,
+        "_atomic_write_text",
+        1,
+        message="promote: between primary and mirror",
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    assert _parse_autoboot_default(env.autoboot_path) == 2, (
+        "primary should be promoted to slot 2"
+    )
+    # Mirror still has the pre-chaos default (slot 1).
+    assert _parse_autoboot_default(env.autoboot_mirror_path) == 1, (
+        "mirror should be unchanged"
+    )
+    assert not env.sentinel_path.exists(), (
+        "sentinel must not exist — promote raised before sentinel write"
+    )
+    _assert_baseline(env)
+
+
+def _s_promote_between_autoboot_and_state(env: ChaosEnv) -> None:
+    """Autoboot fully promoted; slot-state save failed.
+
+    Stale ``last_tryboot_target`` survives but autoboot is correctly promoted.
+    Recovery: re-run promote_slot, which is idempotent.
+    """
+    _stage_post_tryboot(env)
+
+    with inject_first_call(
+        sm_state, "atomic_write", message="promote: between autoboot and state"
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    assert _parse_autoboot_default(env.autoboot_path) == 2
+    assert _parse_autoboot_default(env.autoboot_mirror_path) == 2
+    # State was the seed we saved in _stage_post_tryboot — last_tryboot_target=2.
+    state = load_state()
+    assert state.last_tryboot_target == 2, (
+        "state save during promote failed, so seed survives"
+    )
+    assert not env.sentinel_path.exists()
+    _assert_baseline(env)
+
+
+def _s_promote_between_state_and_sentinel(env: ChaosEnv) -> None:
+    """Autoboot + state promoted; sentinel write failed.
+
+    This is the critical bug surface: agora.service refuses to migrate
+    without the sentinel, so the device sits in a "promoted but not
+    migration-allowed" state until promote_slot is re-run.
+    """
+    _stage_post_tryboot(env)
+
+    # The sentinel write uses shared.state.atomic_write via a local import
+    # inside _write_migration_sentinel. Patch the shared module directly.
+    from shared import state as shared_state
+
+    with inject_first_call(
+        shared_state, "atomic_write", message="promote: between state and sentinel"
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    assert _parse_autoboot_default(env.autoboot_path) == 2
+    state = load_state()
+    assert state.last_tryboot_target is None, "promote did update state"
+    assert state.last_success_at is not None, "promote recorded success timestamp"
+    assert not env.sentinel_path.exists(), "sentinel was the step that failed"
+    _assert_baseline(env)
+
+
+def _s_promote_rerun_recovers_after_state_crash(env: ChaosEnv) -> None:
+    """Re-running promote after a state-save crash completes the operation."""
+    _stage_post_tryboot(env)
+
+    with inject_first_call(
+        sm_state, "atomic_write", message="state save crash for rerun test"
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    # Re-run with no chaos injection.
+    sm_core.promote_slot(2)
+
+    assert _parse_autoboot_default(env.autoboot_path) == 2
+    state = load_state()
+    assert state.last_tryboot_target is None, (
+        "rerun should have cleared the stale last_tryboot_target"
+    )
+    assert state.get_strikes(2) == 0, "rerun should have reset strikes for slot 2"
+    assert env.sentinel_path.exists(), "rerun should have written the sentinel"
+    sentinel_body = env.sentinel_path.read_text()
+    assert "slot=2" in sentinel_body
+    _assert_baseline(env)
+
+
+def _s_promote_rerun_recovers_after_sentinel_crash(env: ChaosEnv) -> None:
+    """Re-running promote after a sentinel-write crash writes the sentinel."""
+    _stage_post_tryboot(env)
+
+    from shared import state as shared_state
+
+    with inject_first_call(
+        shared_state, "atomic_write", message="sentinel crash for rerun test"
+    ):
+        try:
+            sm_core.promote_slot(2)
+        except ChaosPowerCut:
+            pass
+
+    assert not env.sentinel_path.exists()
+
+    # Re-run with no chaos injection.
+    sm_core.promote_slot(2)
+
+    assert env.sentinel_path.exists(), "rerun should have written the sentinel"
+    sentinel_body = env.sentinel_path.read_text()
+    assert "slot=2" in sentinel_body
+    _assert_baseline(env)
+
+
+# ---------------------------------------------------------------------------
+# 3. record_tryboot_strike scenarios
+# ---------------------------------------------------------------------------
+
+
+def _s_strike_before_save(env: ChaosEnv) -> None:
+    """Power-cut before strike count is saved: no strike credited."""
+    # Seed an existing state so load_state returns something to mutate.
+    seed = SlotState()
+    seed.set_strikes(2, 1)
+    save_state(seed)
+
+    # Only the next atomic_write call (the strike's save) faults; the seed
+    # save above already ran outside the injection context.
+    with inject_first_call(
+        sm_state, "atomic_write", message="strike: before save"
+    ):
+        try:
+            sm_core.record_tryboot_strike(2)
+        except ChaosPowerCut:
+            pass
+
+    state = load_state()
+    assert state.get_strikes(2) == 1, (
+        f"strike count must be unchanged (still 1, got {state.get_strikes(2)})"
+    )
+    assert not state.pinned, "device must not be pinned"
+    _assert_baseline(env)
+
+
+def _s_strike_at_pin_threshold_crash(env: ChaosEnv) -> None:
+    """Power-cut at pin threshold: device not pinned, strikes unchanged."""
+    seed = SlotState()
+    seed.set_strikes(2, STRIKE_LIMIT - 1)
+    save_state(seed)
+
+    with inject_first_call(
+        sm_state, "atomic_write", message="strike: at pin threshold"
+    ):
+        try:
+            sm_core.record_tryboot_strike(2)
+        except ChaosPowerCut:
+            pass
+
+    state = load_state()
+    assert state.get_strikes(2) == STRIKE_LIMIT - 1, (
+        f"strike count must be unchanged (still {STRIKE_LIMIT - 1})"
+    )
+    assert not state.pinned, "pin must not be committed"
+    _assert_baseline(env)
+
+
+# ---------------------------------------------------------------------------
+# 4. unpin scenarios
+# ---------------------------------------------------------------------------
+
+
+def _s_unpin_before_save(env: ChaosEnv) -> None:
+    """Power-cut before unpin save: device stays pinned."""
+    seed = SlotState()
+    seed.pinned = True
+    seed.pinned_at = "2026-01-01T00:00:00Z"
+    seed.pinned_reason = "test seed"
+    seed.set_strikes(2, STRIKE_LIMIT)
+    save_state(seed)
+
+    with inject_first_call(
+        sm_state, "atomic_write", message="unpin: before save"
+    ):
+        try:
+            sm_core.unpin()
+        except ChaosPowerCut:
+            pass
+
+    state = load_state()
+    assert state.pinned, "device must still be pinned"
+    assert state.get_strikes(2) == STRIKE_LIMIT, "strikes must not be reset"
+    _assert_baseline(env)
+
+
+def _s_unpin_rerun_recovers(env: ChaosEnv) -> None:
+    """Re-running unpin after a save crash clears the pin."""
+    seed = SlotState()
+    seed.pinned = True
+    seed.pinned_at = "2026-01-01T00:00:00Z"
+    seed.pinned_reason = "test seed"
+    seed.set_strikes(2, STRIKE_LIMIT)
+    save_state(seed)
+
+    with inject_first_call(
+        sm_state, "atomic_write", message="unpin: crash before rerun"
+    ):
+        try:
+            sm_core.unpin()
+        except ChaosPowerCut:
+            pass
+
+    sm_core.unpin()
+
+    state = load_state()
+    assert not state.pinned, "rerun should have cleared the pin"
+    assert state.get_strikes(2) == 0, "rerun should have reset strikes"
+    _assert_baseline(env)
+
+
+# ---------------------------------------------------------------------------
+# 5. Multi-step storm scenarios
+# ---------------------------------------------------------------------------
+
+
+def _s_storm_three_failed_trybooots_pin(env: ChaosEnv) -> None:
+    """Three sequential failed trybooots pin the device.
+
+    No chaos injection — verifies the pinning pipeline as an integration
+    sanity check that lives alongside the chaos cases (a stable baseline
+    that *should* always work; if this turns red, something's wrong with
+    the strike/pin logic that the chaos cases also depend on).
+    """
+    for _ in range(STRIKE_LIMIT):
+        sm_core.record_tryboot_strike(2)
+
+    state = load_state()
+    assert state.pinned, "device must be pinned after STRIKE_LIMIT consecutive strikes"
+    assert state.get_strikes(2) == STRIKE_LIMIT
+    _assert_baseline(env)
+
+
+def _s_storm_unpin_restores_functionality(env: ChaosEnv) -> None:
+    """After pinning, unpin clears state and lets trigger_tryboot run again."""
+    for _ in range(STRIKE_LIMIT):
+        sm_core.record_tryboot_strike(2)
+    assert load_state().pinned
+
+    sm_core.unpin()
+
+    state = load_state()
+    assert not state.pinned
+    # Should not raise PinnedError now.
+    sm_core.trigger_tryboot(2, reboot=False)
+    assert _parse_autoboot_tryboot(env.autoboot_path) == 2
+    _assert_baseline(env)
+
+
+def _s_recovery_tryboot_revert_on_simulated_reset(env: ChaosEnv) -> None:
+    """Simulated watchdog reset: cmdline reverts to default; strike credited.
+
+    Sequence:
+    1. trigger_tryboot(2) with reboot=False — state records ``last_tryboot_target=2``.
+    2. Simulate next boot: cmdline still says slot 1 (the watchdog reset
+       caused the bootloader to fall back since [tryboot] is single-shot).
+    3. slot_confirm would notice tentative=False on slot 1 and call
+       record_tryboot_strike for the failed target.
+    4. Assert the strike landed.
+    """
+    sm_core.trigger_tryboot(2, reboot=False)
+    # Simulated next boot: still on slot 1 (watchdog reset, didn't actually
+    # tryboot). cmdline path is already slot 1 in the fresh env.
+    set_cmdline_slot(env, 1)
+
+    status = sm_core.slot_state()
+    assert status.running_slot == 1
+    assert status.last_tryboot_target == 2, (
+        "state still remembers we asked to tryboot slot 2"
+    )
+    assert not status.tentative, "default is 1, running is 1 — not tentative"
+
+    sm_core.record_tryboot_strike(2, reason="watchdog reverted")
+    state = load_state()
+    assert state.get_strikes(2) == 1
+    _assert_baseline(env)
+
+
+# ---------------------------------------------------------------------------
+# Scenario registry
+# ---------------------------------------------------------------------------
+
+
+SCENARIOS: List[Scenario] = [
+    Scenario(
+        name="trigger-tryboot/before-any-write",
+        description=(
+            "Power-cut before any autoboot write during trigger_tryboot. "
+            "Autoboot.txt and slot-state.json must be unchanged."
+        ),
+        run=_s_trigger_before_any_write,
+    ),
+    Scenario(
+        name="trigger-tryboot/between-primary-and-mirror",
+        description=(
+            "Power-cut after primary autoboot.txt write, before mirror. "
+            "Primary holds the new [tryboot] section; mirror is unchanged; "
+            "slot-state.json was not written."
+        ),
+        run=_s_trigger_between_primary_and_mirror,
+    ),
+    Scenario(
+        name="trigger-tryboot/between-autoboot-and-state",
+        description=(
+            "Power-cut after both autoboot files are written, before "
+            "slot-state.json save. Autoboot is fully staged; slot-state.json "
+            "does not exist."
+        ),
+        run=_s_trigger_between_autoboot_and_state,
+    ),
+    Scenario(
+        name="trigger-tryboot/after-state-before-reboot",
+        description=(
+            "All disk side-effects committed; reboot itself failed (e.g. "
+            "power-cut during `sudo reboot`). State is fully consistent; the "
+            "next physical boot will pick up the staged tryboot."
+        ),
+        run=_s_trigger_after_state_before_reboot,
+    ),
+    Scenario(
+        name="promote/before-any-write",
+        description=(
+            "Power-cut before any disk write during promote_slot. Nothing "
+            "must change on disk."
+        ),
+        run=_s_promote_before_any_write,
+    ),
+    Scenario(
+        name="promote/between-primary-and-mirror",
+        description=(
+            "Promote: primary autoboot.txt rewritten to the new [all] slot; "
+            "mirror write failed. Device will boot the promoted slot since "
+            "the primary is authoritative."
+        ),
+        run=_s_promote_between_primary_and_mirror,
+    ),
+    Scenario(
+        name="promote/between-autoboot-and-state",
+        description=(
+            "Promote: both autoboot files written; slot-state.json save "
+            "failed. Stale last_tryboot_target survives; recovery via "
+            "re-running promote_slot (idempotent)."
+        ),
+        run=_s_promote_between_autoboot_and_state,
+    ),
+    Scenario(
+        name="promote/between-state-and-sentinel",
+        description=(
+            "Promote: autoboot + slot-state committed; migration-allowed "
+            "sentinel write failed. agora.service migration is blocked "
+            "until promote is re-run."
+        ),
+        run=_s_promote_between_state_and_sentinel,
+    ),
+    Scenario(
+        name="promote/rerun-recovers-after-state-crash",
+        description=(
+            "After a state-save crash mid-promote, re-running promote_slot "
+            "is idempotent and completes successfully."
+        ),
+        run=_s_promote_rerun_recovers_after_state_crash,
+    ),
+    Scenario(
+        name="promote/rerun-recovers-after-sentinel-crash",
+        description=(
+            "After a sentinel-write crash mid-promote, re-running "
+            "promote_slot writes the sentinel and unblocks migration."
+        ),
+        run=_s_promote_rerun_recovers_after_sentinel_crash,
+    ),
+    Scenario(
+        name="strike/before-save",
+        description=(
+            "Power-cut during record_tryboot_strike before the state save "
+            "completes. Strike count is unchanged."
+        ),
+        run=_s_strike_before_save,
+    ),
+    Scenario(
+        name="strike/at-pin-threshold-crash",
+        description=(
+            "Power-cut during record_tryboot_strike at the pin threshold. "
+            "The pin is not committed (next strike will land it)."
+        ),
+        run=_s_strike_at_pin_threshold_crash,
+    ),
+    Scenario(
+        name="unpin/before-save",
+        description=(
+            "Power-cut during unpin before the state save completes. The "
+            "device remains pinned; strikes are not reset."
+        ),
+        run=_s_unpin_before_save,
+    ),
+    Scenario(
+        name="unpin/rerun-recovers",
+        description=(
+            "After an unpin save crash, re-running unpin clears the pin "
+            "and resets both strike counters."
+        ),
+        run=_s_unpin_rerun_recovers,
+    ),
+    Scenario(
+        name="storm/three-failed-trybooots-pin",
+        description=(
+            "Three consecutive record_tryboot_strike calls (no chaos) pin "
+            "the device — control case verifying the pinning pipeline."
+        ),
+        run=_s_storm_three_failed_trybooots_pin,
+    ),
+    Scenario(
+        name="storm/unpin-restores-functionality",
+        description=(
+            "After a pin, unpin clears state and trigger_tryboot becomes "
+            "callable again — end-to-end recovery from a stuck device."
+        ),
+        run=_s_storm_unpin_restores_functionality,
+    ),
+    Scenario(
+        name="recovery/tryboot-revert-on-simulated-reset",
+        description=(
+            "Simulate a watchdog reset reverting the bootloader to the "
+            "default slot. slot_state() reports non-tentative; strike is "
+            "credited to the failed target."
+        ),
+        run=_s_recovery_tryboot_revert_on_simulated_reset,
+    ),
+]
+
+
+def list_scenarios() -> list[dict[str, str]]:
+    """Return scenario names + descriptions (used by ``python -m chaos list``)."""
+    return [{"name": s.name, "description": s.description} for s in SCENARIOS]
+
+
+def get_scenario(name: str) -> Scenario:
+    """Look up one scenario by name; raises :class:`KeyError` if absent."""
+    for s in SCENARIOS:
+        if s.name == name:
+            return s
+    raise KeyError(f"unknown scenario: {name!r}")

--- a/tests/test_chaos_harness.py
+++ b/tests/test_chaos_harness.py
@@ -1,0 +1,339 @@
+"""Tests for the Phase 1 chaos harness.
+
+Three layers:
+
+* **Framework unit tests** — exercise :mod:`chaos.core` primitives in
+  isolation (env builder, injection helpers, scenario runner).
+* **Parametrized scenario sweep** — runs every entry in
+  :data:`chaos.scenarios.SCENARIOS` against a fresh env and asserts each
+  one passes. This is the meat of the suite: if any of the 17 chaos
+  scenarios regresses, this lights up red.
+* **CLI smoke tests** — invoke ``python -m chaos`` as a subprocess to
+  cover the argparse + exit-code wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from chaos import (
+    ChaosEnv,
+    ChaosError,
+    ChaosPowerCut,
+    SCENARIOS,
+    Scenario,
+    active_env,
+    get_scenario,
+    inject_after_nth_call,
+    inject_first_call,
+    list_scenarios,
+    make_env,
+    run_scenario,
+    run_scenarios,
+    summarize_results,
+)
+from chaos import core as chaos_core
+
+
+# ---------------------------------------------------------------------------
+# Framework: make_env / active_env
+# ---------------------------------------------------------------------------
+
+
+def test_make_env_creates_expected_layout(tmp_path):
+    env = make_env(tmp_path)
+
+    assert env.autoboot_path.exists()
+    assert env.autoboot_mirror_path.exists()
+    assert env.data_dir.exists()
+    assert env.cmdline_path.exists()
+    # slot-state.json and sentinel are NOT pre-created.
+    assert not env.slot_state_path.exists()
+    assert not env.sentinel_path.exists()
+
+    # Both autoboot copies start byte-identical.
+    assert env.autoboot_path.read_text() == env.autoboot_mirror_path.read_text()
+
+
+def test_make_env_rejects_bad_slot(tmp_path):
+    with pytest.raises(ChaosError):
+        make_env(tmp_path, running_slot=99)
+    with pytest.raises(ChaosError):
+        make_env(tmp_path, default_slot=0)
+
+
+def test_active_env_sets_and_restores_envvars(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGORA_AUTOBOOT_PATH", "/sentinel")
+    monkeypatch.delenv("AGORA_SLOT_DATA_DIR", raising=False)
+
+    env = make_env(tmp_path)
+    with active_env(env):
+        import os
+
+        assert os.environ["AGORA_AUTOBOOT_PATH"] == str(env.autoboot_path)
+        assert os.environ["AGORA_SLOT_DATA_DIR"] == str(env.data_dir)
+
+    import os
+
+    assert os.environ["AGORA_AUTOBOOT_PATH"] == "/sentinel"
+    assert "AGORA_SLOT_DATA_DIR" not in os.environ
+
+
+def test_set_cmdline_slot_updates_cmdline(tmp_path):
+    env = make_env(tmp_path, running_slot=1)
+    assert "root-A" in env.cmdline_path.read_text()
+
+    chaos_core.set_cmdline_slot(env, 2)
+    assert "root-B" in env.cmdline_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Framework: injection helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeModule:
+    """Tiny module-like stand-in for the injection tests."""
+
+    counter = 0
+
+    @classmethod
+    def reset(cls):
+        cls.counter = 0
+
+    @classmethod
+    def bump(cls):
+        cls.counter += 1
+        return cls.counter
+
+
+def test_inject_after_nth_call_lets_first_n_through():
+    _FakeModule.reset()
+    with inject_after_nth_call(_FakeModule, "bump", 2, message="x"):
+        assert _FakeModule.bump() == 1
+        assert _FakeModule.bump() == 2
+        with pytest.raises(ChaosPowerCut):
+            _FakeModule.bump()
+
+
+def test_inject_first_call_faults_immediately():
+    _FakeModule.reset()
+    with inject_first_call(_FakeModule, "bump", message="y"):
+        with pytest.raises(ChaosPowerCut):
+            _FakeModule.bump()
+    # Patch was restored: real function works again.
+    _FakeModule.reset()
+    assert _FakeModule.bump() == 1
+
+
+def test_inject_negative_n_is_programmer_error():
+    with pytest.raises(ChaosError):
+        inject_after_nth_call(_FakeModule, "bump", -1)
+
+
+def test_inject_restores_attribute_on_exit():
+    _FakeModule.reset()
+    with inject_first_call(_FakeModule, "bump"):
+        pass
+    # Attribute is back to the real implementation: calls succeed again.
+    assert _FakeModule.bump() == 1
+    assert _FakeModule.bump() == 2
+
+
+# ---------------------------------------------------------------------------
+# Framework: run_scenario error handling
+# ---------------------------------------------------------------------------
+
+
+def _ok_scenario(env: ChaosEnv) -> None:
+    return None
+
+
+def _failing_scenario(env: ChaosEnv) -> None:
+    assert False, "deliberate failure"
+
+
+def _exploding_scenario(env: ChaosEnv) -> None:
+    raise RuntimeError("kaboom")
+
+
+def _leaks_chaos_powercut(env: ChaosEnv) -> None:
+    raise ChaosPowerCut("leaked")
+
+
+def test_run_scenario_passes_on_success(tmp_path):
+    env = make_env(tmp_path)
+    result = run_scenario(
+        Scenario(name="ok", description="d", run=_ok_scenario), env
+    )
+    assert result.ok
+    assert result.detail == ""
+    assert result.error_type is None
+    assert result.traceback == ""
+
+
+def test_run_scenario_captures_assertion_failure(tmp_path):
+    env = make_env(tmp_path)
+    result = run_scenario(
+        Scenario(name="fail", description="d", run=_failing_scenario), env
+    )
+    assert not result.ok
+    assert "deliberate failure" in result.detail
+    assert result.error_type == "AssertionError"
+    assert "deliberate failure" in result.traceback
+
+
+def test_run_scenario_captures_unexpected_exception(tmp_path):
+    env = make_env(tmp_path)
+    result = run_scenario(
+        Scenario(name="boom", description="d", run=_exploding_scenario), env
+    )
+    assert not result.ok
+    assert result.error_type == "RuntimeError"
+    assert "kaboom" in result.detail
+
+
+def test_run_scenario_captures_leaked_chaos_powercut(tmp_path):
+    env = make_env(tmp_path)
+    result = run_scenario(
+        Scenario(name="leak", description="d", run=_leaks_chaos_powercut), env
+    )
+    assert not result.ok
+    assert result.error_type == "ChaosPowerCut"
+    assert "leaked" in result.detail
+
+
+def test_summarize_results_reports_counts(tmp_path):
+    env = make_env(tmp_path)
+    results = [
+        run_scenario(Scenario(name="a", description="", run=_ok_scenario), env),
+        run_scenario(
+            Scenario(name="b", description="", run=_failing_scenario),
+            make_env(tmp_path / "b_root"),
+        ),
+    ]
+    summary = summarize_results(results)
+    assert summary["total"] == 2
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["ok"] is False
+    assert {s["name"] for s in summary["scenarios"]} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_meets_phase_1_minimum_scenario_count():
+    """Phase 1 spec calls for ≥15 software-reboot injection points."""
+    assert len(SCENARIOS) >= 15, (
+        f"Phase 1 requires ≥15 chaos scenarios; got {len(SCENARIOS)}"
+    )
+
+
+def test_registry_names_are_unique():
+    names = [s.name for s in SCENARIOS]
+    assert len(set(names)) == len(names), "duplicate scenario names in SCENARIOS"
+
+
+def test_list_scenarios_matches_registry():
+    listed = list_scenarios()
+    assert len(listed) == len(SCENARIOS)
+    assert {s["name"] for s in listed} == {s.name for s in SCENARIOS}
+
+
+def test_get_scenario_round_trips():
+    s = SCENARIOS[0]
+    assert get_scenario(s.name) is s
+
+
+def test_get_scenario_unknown_name_raises():
+    with pytest.raises(KeyError):
+        get_scenario("no-such-scenario")
+
+
+# ---------------------------------------------------------------------------
+# The main event: every scenario passes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    SCENARIOS,
+    ids=lambda s: s.name,
+)
+def test_chaos_scenario_passes(scenario, tmp_path):
+    env = make_env(tmp_path)
+    result = run_scenario(scenario, env)
+    if not result.ok:
+        pytest.fail(
+            f"{scenario.name} failed: {result.detail}\n\n{result.traceback}"
+        )
+
+
+def test_run_scenarios_walks_every_scenario(tmp_path):
+    counter = {"n": 0}
+
+    def factory():
+        counter["n"] += 1
+        return make_env(tmp_path / f"run_{counter['n']}")
+
+    results = run_scenarios(SCENARIOS, factory)
+    assert len(results) == len(SCENARIOS)
+    assert all(r.ok for r in results), [
+        (r.name, r.detail) for r in results if not r.ok
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "chaos", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_list_prints_every_scenario():
+    p = _run_cli("list")
+    assert p.returncode == 0, p.stderr
+    for s in SCENARIOS:
+        assert s.name in p.stdout
+
+
+def test_cli_list_json_is_machine_readable():
+    p = _run_cli("list", "--json")
+    assert p.returncode == 0, p.stderr
+    payload = json.loads(p.stdout)
+    assert len(payload["scenarios"]) == len(SCENARIOS)
+
+
+def test_cli_run_unknown_scenario_exits_2():
+    p = _run_cli("run", "does-not-exist")
+    assert p.returncode == 2
+    assert "unknown scenario" in p.stderr.lower()
+
+
+def test_cli_run_single_scenario_succeeds():
+    target = SCENARIOS[0].name
+    p = _run_cli("run", target)
+    assert p.returncode == 0, p.stderr + p.stdout
+    assert "PASS" in p.stdout
+    assert target in p.stdout
+
+
+def test_cli_run_all_json_exits_0_when_all_pass():
+    p = _run_cli("run-all", "--json")
+    assert p.returncode == 0, p.stderr + p.stdout
+    payload = json.loads(p.stdout)
+    assert payload["ok"] is True
+    assert payload["passed"] == len(SCENARIOS)

--- a/tools/chaos.sh
+++ b/tools/chaos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Thin wrapper around `python -m chaos` so the script lives at a stable path
+# referenced from plan.md (Phase 1 deliverables) and the Phase 5 runbooks.
+#
+# Usage:
+#   tools/chaos.sh list
+#   tools/chaos.sh run <scenario-name>
+#   tools/chaos.sh run-all [--json] [--verbose]
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+exec python -m chaos "$@"


### PR DESCRIPTION
Adds a fault-injection harness for `slot_mgr`'s persistent-disk-write seams. Last Phase 1 software-only deliverable for the A/B OTA project (issue #544, plan `files/multi-replica-validation-loop.md`).

## What's here

- `chaos/core.py` — `ChaosEnv` (frozen dataclass over the 4 `AGORA_*` env-var seams), `ChaosPowerCut(BaseException)` (subclasses BaseException so production's `except Exception` can't swallow it), `inject_after_nth_call` (n=0 → first call, n=2 → third call), `run_scenario` / `run_scenarios`, `summarize_results`. `SLOT_TO_BOOT_PART = {1: 1, 2: 3}` re-exported from `slot_mgr.paths` so the harness matches Pi 5 production layout.
- `chaos/scenarios.py` — **17 scenarios** in 5 groups:
  - 4 `trigger-tryboot/*` (before-any-write, between-primary-and-mirror, between-autoboot-and-state, after-state-before-reboot)
  - 5 `promote/*` (before-any-write, between-primary-and-mirror, between-autoboot-and-state, between-state-and-sentinel, rerun-recovers-after-{state,sentinel}-crash)
  - 2 `strike/*` (before-save, at-pin-threshold-crash)
  - 2 `unpin/*` (before-save, rerun-recovers)
  - 4 storm/recovery (three-failed-tryboots-pin, unpin-restores-functionality, tryboot-revert-on-simulated-reset)
- `chaos/__main__.py` — `python -m chaos {list|run <name>|run-all}` with `--json` and `--verbose`. Exit codes: 0 all pass / 1 ≥1 fail / 2 usage error. Mints a fresh `tempfile.mkdtemp('chaos-')` per scenario (forensic state, not cleaned up).
- `tools/chaos.sh` — bash wrapper.
- `tests/test_chaos_harness.py` — 41 tests: framework primitives, registry invariants (≥15 scenarios, unique names), **parametrized scenario sweep** (every entry in `chaos.SCENARIOS`), CLI subprocess smoke tests.

## Patching strategy

- `slot_mgr/state.py:save_state` → `from shared.state import atomic_write` at module load → patch `slot_mgr.state.atomic_write`.
- `slot_mgr/core.py:_write_migration_sentinel` → `from shared.state import atomic_write` **inside the function** → patch `shared.state.atomic_write`.
- `slot_mgr/autoboot.py` writes via its own `_atomic_write_text` → patch directly on the autoboot module.

## Test results

\\\
$ python -m pytest tests/test_chaos_harness.py -p no:timeout -q
41 passed in 5.46s

$ python -m pytest -p no:timeout --ignore=tests/test_cms_url_reconnect.py --ignore=tests/test_wss_support.py -q
1094 passed, 30 skipped in 108.05s
\\\

Baseline before this PR was 1053 + 30 skipped; the +41 lines up with new `test_chaos_harness.py`.

## Out of scope

- Smart-plug-driven real-power-cut scenarios (`p1-smart-plug-pick` — hardware-blocked).
- 24h hybrid soak (Phase 5 sign-off).

## Plan reference

Closes the Phase 1 `p1-chaos-harness` todo. Phase 1 software-only deliverables now complete. Remaining Phase 1 items (`p1-smart-plug-pick`, `p1-acceptance`) require lab hardware.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>