### PR TITLE
feat(os-updater): Phase 2 service shell with 8-state FSM

### DIFF
--- a/os_updater/__init__.py
+++ b/os_updater/__init__.py
@@ -1,0 +1,80 @@
+"""agora-os-updater — on-device daemon that orchestrates OS updates.
+
+Phase 2 of the A/B atomic update plan (plan.md §"Phase 2 — agora-os-updater
+service"). Subscribes to the CMS over the existing WPS connection for
+``os_update_dispatch`` control messages, downloads the bundle, verifies the
+minisign signature + sha256 manifest, stages it to ``/data/.update/staging/``,
+calls :mod:`slot_mgr` to write the inactive slot, triggers tryboot, and emits
+lifecycle events back to CMS over WPS.
+
+This package ships the SHELL of the daemon: the package layout, the explicit
+8-state finite state machine, the persistent state file
+(``/data/agora/updater-state.json``), the dispatch payload model + validation,
+the lifecycle-event emitter scaffold, and the async run loop.  The actual
+bundle download, signature verification, slot staging, and forward-migration
+runner are filled in by sibling todos (``p2-bundle-format``,
+``p2-signature-verify``, ``p2-stage-and-tryboot``, ``p2-forward-migration``)
+via the injection seams documented on :class:`OSUpdaterService`.
+
+Phase 2 ratified sub-decisions #17–24 govern the wire protocol, on-disk
+layout, and error semantics — see plan.md.
+"""
+
+from os_updater.state import (
+    DEFAULT_STATE_PATH,
+    SCHEMA_VERSION,
+    UpdaterFSMState,
+    UpdaterState,
+    is_busy,
+    load_state,
+    save_state,
+    transition,
+)
+from os_updater.dispatch import (
+    DispatchPayload,
+    DispatchPayloadError,
+    parse_dispatch_payload,
+)
+from os_updater.events import (
+    DEFAULT_OUTBOX_DIR,
+    LifecycleEvent,
+    LifecycleEventType,
+    OutboxEventSink,
+    emit_event,
+    next_event_id,
+)
+from os_updater.service import (
+    DEFAULT_STAGING_ROOT,
+    OSUpdaterService,
+    UpdaterBusyError,
+    UpdaterError,
+    VersionFloorError,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_OUTBOX_DIR",
+    "DEFAULT_STAGING_ROOT",
+    "DEFAULT_STATE_PATH",
+    "DispatchPayload",
+    "DispatchPayloadError",
+    "LifecycleEvent",
+    "LifecycleEventType",
+    "OSUpdaterService",
+    "OutboxEventSink",
+    "SCHEMA_VERSION",
+    "UpdaterBusyError",
+    "UpdaterError",
+    "UpdaterFSMState",
+    "UpdaterState",
+    "VersionFloorError",
+    "__version__",
+    "emit_event",
+    "is_busy",
+    "load_state",
+    "next_event_id",
+    "parse_dispatch_payload",
+    "save_state",
+    "transition",
+]

--- a/os_updater/__main__.py
+++ b/os_updater/__main__.py
@@ -1,0 +1,9 @@
+"""Allow ``python -m os_updater`` to run the daemon."""
+
+from __future__ import annotations
+
+from os_updater.main import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -1,0 +1,24 @@
+"""Slot staging + tryboot trigger — implemented by sibling todo p2-stage-and-tryboot.
+
+Owns the steps after signature verification:
+
+* rsync the staged ``boot/`` content into the inactive boot partition
+* rsync the staged ``root/`` content into the inactive root partition
+* shell out to ``agora-slot-mgr trigger-tryboot`` (Phase 1 CLI)
+
+Exposed as the ``Stager`` collaborator on :class:`os_updater.service.OSUpdaterService`.
+"""
+
+from __future__ import annotations
+
+
+class StagingError(Exception):
+    """Base class for staging-related failures."""
+
+
+def stage_to_inactive_slot(*args, **kwargs):  # noqa: D401
+    raise NotImplementedError("see sibling todo p2-stage-and-tryboot")
+
+
+def trigger_tryboot(*args, **kwargs):  # noqa: D401
+    raise NotImplementedError("see sibling todo p2-stage-and-tryboot")

--- a/os_updater/bundle.py
+++ b/os_updater/bundle.py
@@ -1,0 +1,31 @@
+"""Bundle format + integrity stubs — implemented by sibling todo p2-bundle-format.
+
+Phase 2 ships this module as a placeholder so the import graph is stable.
+The real implementation will:
+
+* Parse ``meta.json`` (version, min_from_version, sha256_manifest, created_at, builder)
+* Verify every unpacked file's sha256 against the manifest
+* Surface a typed ``BundleIntegrityError`` for the service to map to
+  ``failed:bundle_invalid``
+
+See plan.md §"Phase 2 — Deliverables" and ``docs/bundle-format.md``
+(to be written by the same sibling).
+"""
+
+from __future__ import annotations
+
+
+class BundleError(Exception):
+    """Base class for bundle-related failures."""
+
+
+class BundleIntegrityError(BundleError):
+    """sha256 manifest mismatch or missing file."""
+
+
+def parse_bundle_meta(*args, **kwargs):  # noqa: D401
+    raise NotImplementedError("see sibling todo p2-bundle-format")
+
+
+def verify_bundle_manifest(*args, **kwargs):  # noqa: D401
+    raise NotImplementedError("see sibling todo p2-bundle-format")

--- a/os_updater/dispatch.py
+++ b/os_updater/dispatch.py
@@ -1,0 +1,109 @@
+"""Parsing + validation of the ``os_update_dispatch`` WPS payload.
+
+The CMS dispatches a release to a device by pushing an ``os_update_dispatch``
+control message over the existing WPS connection. The payload is the same
+shape that's stored in the ``scheduled_dispatches`` row (plan.md §"Phase 3 —
+DB schema additions"), minus the row-bookkeeping fields:
+
+    {
+      "type": "os_update_dispatch",
+      "release_id": "rel_2026_05_07_v1.1.0",
+      "target_version": "1.1.0",
+      "min_from_version": "1.0.0",
+      "bundle_url": "https://github.com/.../bundle.zst",
+      "signature_url": "https://github.com/.../bundle.zst.minisig",
+      "force_now": false,
+      "force_downgrade": false
+    }
+
+Phase 3 may add fields (``not_before`` for staggered rings, etc.) — the
+parser uses ``pydantic`` with ``extra="ignore"`` so a forward-compatible
+field doesn't break older daemons.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DispatchPayloadError(ValueError):
+    """Raised when an ``os_update_dispatch`` payload fails validation.
+
+    The daemon treats this as a routine failure path — log + emit
+    ``failed:invalid_payload`` over WPS — not a crash.
+    """
+
+
+#: Regex matching ``major.minor.patch`` semver with optional ``-prerelease``.
+#: Intentionally simple — we control both ends of this wire so we don't need
+#: full semver-2.0 compliance.
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$")
+
+#: Regex matching the allowed shape of an opaque ``release_id``: alphanumeric
+#: plus ``_-.``, length 1..128. Mirrors what the CMS will generate.
+_RELEASE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+class DispatchPayload(BaseModel):
+    """Validated form of a CMS-side ``os_update_dispatch`` message."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    release_id: str
+    target_version: str
+    min_from_version: str
+    bundle_url: str
+    signature_url: str
+    force_now: bool = False
+    force_downgrade: bool = False
+
+    #: Optional Phase 3 fields that older daemons can simply ignore.
+    not_before: Optional[str] = Field(default=None)
+
+    @field_validator("release_id")
+    @classmethod
+    def _check_release_id(cls, value: str) -> str:
+        if not _RELEASE_ID_RE.match(value):
+            raise ValueError(
+                "release_id must match [A-Za-z0-9._-]{1,128}"
+            )
+        return value
+
+    @field_validator("target_version", "min_from_version")
+    @classmethod
+    def _check_version(cls, value: str) -> str:
+        if not _VERSION_RE.match(value):
+            raise ValueError(
+                "version must be major.minor.patch (with optional -prerelease)"
+            )
+        return value
+
+    @field_validator("bundle_url", "signature_url")
+    @classmethod
+    def _check_url(cls, value: str) -> str:
+        if not (value.startswith("https://") or value.startswith("http://")):
+            raise ValueError("url must use http(s) scheme")
+        return value
+
+
+def parse_dispatch_payload(msg: Any) -> DispatchPayload:
+    """Parse an inbound WPS message into a :class:`DispatchPayload`.
+
+    The caller has already routed by ``msg["type"] == "os_update_dispatch"``.
+    Wraps the pydantic ``ValidationError`` in :class:`DispatchPayloadError`
+    so the caller doesn't need to import pydantic just to catch payload
+    failures.
+    """
+
+    if not isinstance(msg, Mapping):
+        raise DispatchPayloadError(
+            f"dispatch payload must be a JSON object, got {type(msg).__name__}"
+        )
+
+    try:
+        return DispatchPayload.model_validate(dict(msg))
+    except Exception as exc:
+        raise DispatchPayloadError(str(exc)) from exc

--- a/os_updater/events.py
+++ b/os_updater/events.py
@@ -1,0 +1,234 @@
+"""Lifecycle event emitter for agora-os-updater.
+
+Every meaningful transition in the updater FSM emits a lifecycle event that
+flows back to the CMS over the existing WPS connection (plan #33). Each
+event carries a per-device monotonic ``event_id`` so the CMS can dedupe with
+``(device_id, event_id)``.
+
+This module ships the scaffold:
+
+* :class:`LifecycleEvent` — the dataclass that goes on the wire.
+* :class:`LifecycleEventType` — the closed enumeration of event names. The
+  daemon shouldn't be able to send an "ad-hoc" event; if a new shape is
+  needed, that's a code change.
+* :class:`OutboxEventSink` — Phase 2's persistence-only sink. Appends events
+  to a JSONL file under ``/data/agora/event-buffer/`` (one file per UTC
+  day) and exposes a list-pending API for the Phase 4 WPS replayer to
+  consume.  No WPS send is performed in Phase 2 — that's wired up in
+  Phase 4 along with the buffer FIFO eviction policy (1000 events / 10
+  MB cap).
+* :func:`emit_event` — convenience that stamps the next event-id from a
+  passed-in :class:`UpdaterState`, builds the event, persists state, and
+  forwards to the sink.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional, Protocol
+
+from shared.state import atomic_write
+
+from os_updater.state import (
+    DEFAULT_STATE_PATH,
+    UpdaterState,
+    save_state,
+    utc_now_iso,
+)
+
+
+#: Directory where pending lifecycle events buffer when the WPS connection
+#: is down. Lives under ``/data`` so the queue survives reboot.
+DEFAULT_OUTBOX_DIR = Path("/data/agora/event-buffer")
+
+
+class LifecycleEventType(str, enum.Enum):
+    """Closed enumeration of lifecycle event names.
+
+    Values match plan.md §"Phase 2 — Deliverables" — these are the names
+    the CMS-side worker will switch on, so any addition is a coordinated
+    change.
+    """
+
+    DOWNLOAD_STARTED = "download_started"
+    SIGNATURE_VERIFIED = "signature_verified"
+    STAGED = "staged"
+    TRYBOOT_INITIATED = "tryboot_initiated"
+    SLOT_CONFIRMED = "slot_confirmed"
+    PROMOTED = "promoted"
+    MIGRATION_COMPLETE = "migration_complete"
+    FAILED = "failed"
+    DECLINED = "declined"
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """A single lifecycle event headed for the CMS.
+
+    Frozen so a sink can keep a reference past the call and trust it. The
+    ``reason`` field doubles as the colon-suffix for ``failed`` /
+    ``declined`` events (``failed:signature_invalid``, ``declined:busy``)
+    — the CMS-side parser expects ``f"{event_type.value}:{reason}"`` when
+    a reason is set on those two types.
+    """
+
+    event_id: int
+    event_type: LifecycleEventType
+    release_id: Optional[str]
+    target_version: Optional[str]
+    occurred_at: str
+    reason: Optional[str] = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Return a dict suitable for ``json.dumps`` / WPS send."""
+
+        return {
+            "type": "lifecycle_event",
+            "event_id": self.event_id,
+            "event_type": self.event_type.value,
+            "release_id": self.release_id,
+            "target_version": self.target_version,
+            "occurred_at": self.occurred_at,
+            "reason": self.reason,
+            "payload": dict(self.payload),
+        }
+
+
+class EventSink(Protocol):
+    """Type contract for somewhere an event can be sent."""
+
+    def put(self, event: LifecycleEvent) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class OutboxEventSink:
+    """Phase 2 sink: persist events under :data:`DEFAULT_OUTBOX_DIR`.
+
+    Events are appended to ``<UTC-date>.jsonl`` files, one event per line.
+    Phase 4 will add a WPS replayer that reads + sends these files, then
+    deletes the day-files whose events have all been acked. For now the
+    sink is write-only; tests use :meth:`iter_events` to inspect.
+
+    The cap on buffer size (1000 events / 10 MB FIFO) is owned by Phase
+    4 — Phase 2 just lays down the directory layout.
+    """
+
+    def __init__(self, outbox_dir: Path = DEFAULT_OUTBOX_DIR) -> None:
+        self.outbox_dir = outbox_dir
+
+    def _path_for(self, event: LifecycleEvent) -> Path:
+        """Pick the day-file for ``event`` from its ``occurred_at`` field."""
+
+        # occurred_at is always "YYYY-MM-DDTHH:MM:SSZ" per utc_now_iso, so
+        # the first 10 chars are the date — much faster than re-parsing.
+        return self.outbox_dir / f"{event.occurred_at[:10]}.jsonl"
+
+    def put(self, event: LifecycleEvent) -> None:
+        """Persist ``event`` to the day-file.
+
+        Uses an append-with-fsync rather than the atomic-rename pattern
+        used elsewhere in agora because we want O(1) writes. A torn
+        last-line on a power cut is recoverable — the replayer skips
+        unparseable JSON lines and logs them, which is correct behavior
+        even for non-truncation corruption.
+        """
+
+        self.outbox_dir.mkdir(parents=True, exist_ok=True)
+        target = self._path_for(event)
+        line = json.dumps(event.to_jsonable(), sort_keys=True) + "\n"
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+
+    def iter_events(self) -> Iterator[LifecycleEvent]:
+        """Yield every event currently in the outbox, in file order.
+
+        Test-and-Phase-4-replayer-friendly. Skips unparseable lines
+        silently — a strict mode is Phase 4's problem.
+        """
+
+        if not self.outbox_dir.exists():
+            return
+        for day_file in sorted(self.outbox_dir.glob("*.jsonl")):
+            with day_file.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    try:
+                        yield LifecycleEvent(
+                            event_id=int(obj["event_id"]),
+                            event_type=LifecycleEventType(obj["event_type"]),
+                            release_id=obj.get("release_id"),
+                            target_version=obj.get("target_version"),
+                            occurred_at=obj["occurred_at"],
+                            reason=obj.get("reason"),
+                            payload=obj.get("payload") or {},
+                        )
+                    except (KeyError, ValueError):
+                        continue
+
+
+def next_event_id(state: UpdaterState) -> int:
+    """Pre-increment ``last_event_id`` on ``state`` and return the new value.
+
+    Mutates the state. Caller must persist it (or call :func:`emit_event`,
+    which does so).
+    """
+
+    state.last_event_id += 1
+    return state.last_event_id
+
+
+def emit_event(
+    state: UpdaterState,
+    event_type: LifecycleEventType,
+    sink: EventSink,
+    *,
+    reason: Optional[str] = None,
+    payload: Optional[Mapping[str, Any]] = None,
+    state_path: Optional[Path] = None,
+    now_fn=utc_now_iso,
+) -> LifecycleEvent:
+    """Stamp + persist + sink a lifecycle event.
+
+    Concretely:
+
+    1. Increment ``state.last_event_id`` (allocates a fresh id).
+    2. Build a :class:`LifecycleEvent` with that id, the supplied type /
+       reason / payload, and the ``release_id`` + ``target_version``
+       currently on ``state``.
+    3. Persist ``state`` to disk (so we never re-use the same event_id
+       after a crash).
+    4. Hand the event to ``sink``.
+    5. Return the event so the caller can log it.
+
+    Per #33 we persist BEFORE sending so the id is locked in even if the
+    sink throws. The Phase 4 replayer handles "I see this id was reserved
+    but no record exists in the outbox" by simply skipping forward.
+
+    ``now_fn`` and ``state_path`` are injection seams for tests.
+    """
+
+    event_id = next_event_id(state)
+    event = LifecycleEvent(
+        event_id=event_id,
+        event_type=event_type,
+        release_id=state.release_id,
+        target_version=state.target_version,
+        occurred_at=now_fn(),
+        reason=reason,
+        payload=dict(payload or {}),
+    )
+    save_state(state, path=state_path or DEFAULT_STATE_PATH)
+    sink.put(event)
+    return event

--- a/os_updater/main.py
+++ b/os_updater/main.py
@@ -1,0 +1,288 @@
+"""Production entry point for ``python -m os_updater``.
+
+The Phase 2 PR (``p2-os-updater-service``) ships this entry point so the
+daemon can be wired into systemd and exercised on a real device. The bulk
+of the daemon's behavior lives in :class:`os_updater.service.OSUpdaterService`
+— this module is the thin glue that:
+
+1. Parses CLI args (``--state-path``, ``--staging-root``, ``--log-level``).
+2. Builds a :class:`os_updater.service.WPSTransport` adapter on top of the
+   real :mod:`cms_client.transport` (open_wps).  The adapter exposes the
+   minimal ``connect``/``recv``/``close`` shape the service expects, even
+   though :mod:`cms_client.transport` itself uses an ``async for`` iterator
+   internally.
+3. Reads the device's current OS version from ``/etc/agora/version`` (or a
+   ``--current-version-file`` override) for the ``min_from_version`` floor
+   check (plan #21).
+4. Installs a SIGTERM/SIGINT handler that cancels the run loop cleanly so
+   systemd can restart us without a forced kill.
+
+The actual download / verify / stage / migrate hooks are injected by
+sibling Phase 2 todos via the protocols on :class:`OSUpdaterService`.
+Until those land, ``main()`` wires in the default ``NotImplementedError``
+stubs — the daemon will still start, accept a WPS connection, and reject
+any dispatch with ``failed:error_NotImplementedError`` so the CMS sees
+the daemon is alive but the rest of Phase 2 isn't done.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from os_updater import __version__
+from os_updater.service import (
+    DEFAULT_STAGING_ROOT,
+    OSUpdaterService,
+    WPSTransport,
+)
+from os_updater.state import DEFAULT_STATE_PATH
+
+
+log = logging.getLogger("agora.os_updater")
+
+
+#: Path to the baked-in current-version file. Phase 0 writes the OS image
+#: version into ``/etc/agora/version`` (plan §"Phase 0 — Deliverables"
+#: re: ``/etc/agora/version``). One-line plain text, semver-shaped.
+DEFAULT_CURRENT_VERSION_FILE = Path("/etc/agora/version")
+
+
+def _read_current_version(path: Path) -> str:
+    """Read ``/etc/agora/version`` and strip whitespace.
+
+    Raises if the file is missing or empty — better to fail loud at daemon
+    startup than to ship an empty string into the floor check and either
+    accept every dispatch (string comparison) or reject every dispatch
+    (semver parse).
+    """
+
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        raise RuntimeError(f"{path} is empty; cannot determine current version")
+    return raw
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="os_updater",
+        description=(
+            "agora-os-updater — on-device daemon that orchestrates A/B "
+            "atomic OS updates. Subscribes to the CMS over WPS for "
+            "os_update_dispatch messages, downloads + verifies the bundle, "
+            "stages it to the inactive slot, triggers tryboot, and emits "
+            "lifecycle events."
+        ),
+    )
+    p.add_argument(
+        "--state-path",
+        type=Path,
+        default=DEFAULT_STATE_PATH,
+        help=f"updater-state.json location (default: {DEFAULT_STATE_PATH})",
+    )
+    p.add_argument(
+        "--staging-root",
+        type=Path,
+        default=DEFAULT_STAGING_ROOT,
+        help=(
+            "per-dispatch staging directory root "
+            f"(default: {DEFAULT_STAGING_ROOT})"
+        ),
+    )
+    p.add_argument(
+        "--current-version-file",
+        type=Path,
+        default=DEFAULT_CURRENT_VERSION_FILE,
+        help=(
+            "path to the baked-in OS version file "
+            f"(default: {DEFAULT_CURRENT_VERSION_FILE})"
+        ),
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        help="logging level (default: INFO)",
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"os_updater {__version__}",
+    )
+    return p
+
+
+def _configure_logging(level: str) -> None:
+    """Plain stdout logger; systemd captures it into journald."""
+
+    logging.basicConfig(
+        level=getattr(logging, level),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+class _CMSWPSTransportAdapter:
+    """Adapt :mod:`cms_client.transport`'s async-iterator WPS transport
+    to the :class:`WPSTransport` protocol that :class:`OSUpdaterService`
+    expects.
+
+    The cms_client transport is async-iterable — ``async for raw in t``
+    yields JSON strings.  The service wants ``await t.recv()`` returning
+    a dict.  We hold the iterator, await one item per recv, and parse
+    JSON before returning.
+
+    A fresh instance is produced per :class:`OSUpdaterService` reconnect
+    attempt (via ``transport_factory``), so we don't have to worry about
+    re-using an exhausted iterator.
+    """
+
+    def __init__(
+        self,
+        opener,  # callable() -> awaitable returning a cms_client transport
+    ) -> None:
+        self._opener = opener
+        self._t = None
+        self._iter = None
+
+    async def connect(self) -> None:
+        self._t = await self._opener()
+        self._iter = self._t.__aiter__()
+
+    async def recv(self) -> dict[str, Any]:
+        if self._iter is None:
+            raise RuntimeError("transport.recv() called before connect()")
+        raw = await self._iter.__anext__()
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"non-JSON WPS frame: {exc}") from exc
+        if not isinstance(obj, dict):
+            raise RuntimeError(
+                f"WPS frame decoded to {type(obj).__name__}, expected object"
+            )
+        return obj
+
+    async def close(self) -> None:
+        if self._t is not None:
+            try:
+                await self._t.close()
+            except Exception:
+                log.debug("error closing WPS transport", exc_info=True)
+            finally:
+                self._t = None
+                self._iter = None
+
+
+def _build_transport_factory(settings):
+    """Build a factory that the service can call to get a fresh transport
+    on each reconnect.
+
+    Imports :mod:`api.config` and :mod:`cms_client.transport` lazily so
+    unit tests can exercise this module without those deps installed.
+    Phase 3 will likely refactor this to share the cms_client daemon's
+    existing WPS connection (plan §"Phase 2 — Deliverables", line about
+    "the existing WPS connection") — for now, agora-os-updater opens its
+    own connection with its own connect-token round-trip.
+    """
+
+    from cms_client.transport import open_wps  # local import per docstring
+
+    cms_url = settings.cms_url
+    device_id = settings.device_name
+    api_key = settings.device_api_key
+    api_base = settings.cms_api_url or None
+
+    if not cms_url:
+        raise RuntimeError("AGORA_CMS_URL is unset; cannot open WPS")
+    if not device_id:
+        raise RuntimeError("AGORA_DEVICE_NAME is unset; cannot open WPS")
+    if not api_key:
+        raise RuntimeError("AGORA_DEVICE_API_KEY is unset; cannot open WPS")
+
+    async def _open():
+        return await open_wps(
+            cms_url=cms_url,
+            device_id=device_id,
+            api_key=api_key,
+            api_base=api_base,
+        )
+
+    def factory() -> WPSTransport:
+        return _CMSWPSTransportAdapter(_open)
+
+    return factory
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Build the service and drive its run loop until cancelled."""
+
+    # Lazy import so ``--help`` doesn't pull in pydantic-settings.
+    from api.config import load_settings
+
+    settings = load_settings()
+    current_version = _read_current_version(args.current_version_file)
+    log.info("agora-os-updater starting; current_version=%s", current_version)
+
+    service = OSUpdaterService(
+        transport_factory=_build_transport_factory(settings),
+        current_version_provider=lambda: current_version,
+        state_path=args.state_path,
+        staging_root=args.staging_root,
+    )
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+
+    def _handle_signal(signum: int, _frame: Any = None) -> None:
+        log.info("signal %d received; shutting down", signum)
+        loop.call_soon_threadsafe(stop.set)
+
+    # SIGTERM is what systemd sends on stop/restart.
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _handle_signal, sig)
+        except NotImplementedError:
+            # Windows test runs hit this — fall back to signal.signal.
+            signal.signal(sig, _handle_signal)
+
+    runner = asyncio.create_task(service.run(), name="os-updater-run")
+    stopper = asyncio.create_task(stop.wait(), name="os-updater-stop")
+    done, pending = await asyncio.wait(
+        {runner, stopper},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    if stopper in done and not runner.done():
+        runner.cancel()
+        try:
+            await runner
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            log.exception("error during shutdown")
+    for p in pending:
+        p.cancel()
+    log.info("agora-os-updater stopped")
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    _configure_logging(args.log_level)
+    try:
+        return asyncio.run(_run(args))
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/os_updater/migrate.py
+++ b/os_updater/migrate.py
@@ -1,0 +1,22 @@
+"""Forward-migration runner — implemented by sibling todo p2-forward-migration.
+
+After a successful slot promote (Phase 1 :mod:`slot_mgr`), the runner
+discovers shell scripts at ``/etc/agora/migrations/NNN_*.sh`` where ``NNN``
+> the current ``/data/SCHEMA_VERSION``, executes them in ascending order
+under ``set -euo pipefail``, and bumps the version on success. See plan.md
+§"Phase 2 — Deliverables" + #22.
+
+Gated by the Phase 1 ``migration-allowed`` sentinel (see
+:mod:`migration_fence`) — the runner refuses to start unless the sentinel
+matches the current running slot.
+"""
+
+from __future__ import annotations
+
+
+class MigrationError(Exception):
+    """Base class for migration-related failures."""
+
+
+def run_pending_migrations(*args, **kwargs):  # noqa: D401
+    raise NotImplementedError("see sibling todo p2-forward-migration")

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -1,0 +1,624 @@
+"""``OSUpdaterService`` — the orchestrator.
+
+Owns the agora-os-updater FSM. Listens on the WPS connection for
+``os_update_dispatch`` messages, validates them against the concurrency
+interlock (plan #23) and the ``min_from_version`` floor (plan #21 / #24),
+and then drives the in-flight dispatch through the four collaborator
+hooks:
+
+* ``downloader`` — downloads the bundle to ``staging_dir`` (p2-bundle-format)
+* ``verifier`` — verifies minisign + sha256 manifest (p2-signature-verify)
+* ``stager`` — rsync staging content to the inactive slot + trigger tryboot
+  (p2-stage-and-tryboot)
+* ``migrator`` — runs forward migrations post-promote (p2-forward-migration)
+
+Each hook is a callable injected at construction; defaults raise
+``NotImplementedError`` so an unmaintained Phase 2 deployment fails loud
+rather than silently no-op'ing. The sibling todos fill these in with real
+implementations and unit tests.
+
+Sequence diagram (happy path):
+
+    [WPS msg arrives]
+    parse_dispatch_payload
+    check is_busy(state)
+    check version floor (skipped iff force_downgrade)
+    state: idle/failed -> downloading
+    emit DOWNLOAD_STARTED
+    downloader.run(payload, staging_dir)
+    state: downloading -> staged
+    emit SIGNATURE_VERIFIED + STAGED
+    state: staged -> tryboot_pending
+    stager.stage(staging_dir, payload)
+    state: tryboot_pending -> tryboot_running
+    emit TRYBOOT_INITIATED
+    [reboot happens]
+    [next boot: state.fsm == tryboot_running. slot-confirm runs.]
+    [if confirmed:] state: tryboot_running -> promoted_pending_migration
+    emit SLOT_CONFIRMED + PROMOTED
+    state: promoted_pending_migration -> migrating
+    migrator.run()
+    state: migrating -> idle
+    emit MIGRATION_COMPLETE
+
+Any failure -> state: <current> -> FAILED with reason; emit
+FAILED:<reason>. The dispatch then sits in FAILED until the next dispatch
+arrives, which moves it back to DOWNLOADING per LEGAL_TRANSITIONS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
+
+from os_updater.dispatch import (
+    DispatchPayload,
+    DispatchPayloadError,
+    parse_dispatch_payload,
+)
+from os_updater.events import (
+    EventSink,
+    LifecycleEventType,
+    OutboxEventSink,
+    emit_event,
+)
+from os_updater.state import (
+    DEFAULT_STATE_PATH,
+    UpdaterFSMState,
+    UpdaterState,
+    is_busy,
+    load_state,
+    save_state,
+    transition,
+)
+
+#: Root of per-dispatch staging directories. Each dispatch gets a
+#: subdirectory named after ``release_id``. Lives on ``/data`` so it
+#: survives slot switches.
+DEFAULT_STAGING_ROOT = Path("/data/.update/staging")
+
+#: Initial / max reconnect backoff in seconds for the WPS connection.
+#: Mirrors the existing cms_client transport behavior.
+_RECONNECT_INITIAL_DELAY = 2.0
+_RECONNECT_MAX_DELAY = 60.0
+
+#: Same regex as dispatch._VERSION_RE — kept local to avoid importing a
+#: private symbol. Used by the version-floor check.
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z0-9.]+))?$")
+
+
+log = logging.getLogger(__name__)
+
+
+class UpdaterError(Exception):
+    """Base class for the daemon's typed errors."""
+
+
+class UpdaterBusyError(UpdaterError):
+    """Raised by :meth:`OSUpdaterService.handle_dispatch` when busy.
+
+    Mapped to a ``declined:busy`` lifecycle event by the caller. The
+    typed exception (vs a return-code) lets tests assert on the rejection
+    path without inspecting events.
+    """
+
+
+class VersionFloorError(UpdaterError):
+    """Raised when current version < ``min_from_version`` and no override."""
+
+
+def _parse_version(value: str) -> tuple[int, int, int, str]:
+    """Return a sortable tuple ``(major, minor, patch, prerelease)``.
+
+    A version without a prerelease suffix sorts above one with (semver
+    rule). Encoding: empty string for "no prerelease" comes after any
+    non-empty prerelease string when we invert it — implemented below as
+    ``"~"`` (high-ASCII sentinel) so plain ``X.Y.Z`` > ``X.Y.Z-rc1``.
+    """
+
+    m = _VERSION_RE.match(value)
+    if not m:
+        raise ValueError(f"unparseable version: {value!r}")
+    major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    pre = m.group(4) or "~"  # ~ is high-ASCII, sorts after any prerelease char
+    return major, minor, patch, pre
+
+
+def version_at_least(current: str, floor: str) -> bool:
+    """Return True iff ``current >= floor`` under the semver-lite order."""
+
+    return _parse_version(current) >= _parse_version(floor)
+
+
+# ---------------------------------------------------------------------------
+# Collaborator protocols (filled in by sibling todos in Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class Downloader(Protocol):
+    """Owns the download into ``staging_dir`` (p2-bundle-format).
+
+    Implementation must support HTTP Range resume for partial-download
+    cleanup (plan §"Phase 2 — Deliverables"). Phase 2 default raises
+    ``NotImplementedError`` so we fail loud if the sibling todo hasn't
+    landed yet.
+    """
+
+    async def run(
+        self, payload: DispatchPayload, staging_dir: Path
+    ) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class Verifier(Protocol):
+    """Owns minisign signature + sha256 manifest verification (p2-signature-verify)."""
+
+    async def run(
+        self, payload: DispatchPayload, staging_dir: Path
+    ) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class Stager(Protocol):
+    """Owns rsync-to-inactive-slot + agora-slot-mgr trigger-tryboot (p2-stage-and-tryboot)."""
+
+    async def stage(
+        self, payload: DispatchPayload, staging_dir: Path
+    ) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class Migrator(Protocol):
+    """Owns post-promote ``/etc/agora/migrations/`` runner (p2-forward-migration)."""
+
+    async def run(self) -> None:  # pragma: no cover - protocol
+        ...
+
+
+class CurrentVersionProvider(Protocol):
+    """Returns the current device version for the floor check."""
+
+    def __call__(self) -> str:  # pragma: no cover - protocol
+        ...
+
+
+class WPSTransport(Protocol):
+    """Minimal contract for the WPS connection the service consumes.
+
+    The full transport lives in ``cms_client.transport``. The service
+    only needs ``connect``, ``recv``, and ``close`` — the message-sender
+    half is hidden behind :class:`EventSink`.
+    """
+
+    async def connect(self) -> None:  # pragma: no cover
+        ...
+
+    async def recv(self) -> dict[str, Any]:  # pragma: no cover
+        ...
+
+    async def close(self) -> None:  # pragma: no cover
+        ...
+
+
+def _default_unimplemented(name: str) -> Callable[..., Awaitable[None]]:
+    """Build an async hook that fails with a pointer to its sibling todo."""
+
+    async def _stub(*args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(
+            f"{name!r} collaborator not wired; see sibling todo for Phase 2"
+        )
+
+    return _stub
+
+
+@dataclass
+class _DefaultDownloader:
+    async def run(self, payload: DispatchPayload, staging_dir: Path) -> None:
+        raise NotImplementedError("downloader not wired; see p2-bundle-format")
+
+
+@dataclass
+class _DefaultVerifier:
+    async def run(self, payload: DispatchPayload, staging_dir: Path) -> None:
+        raise NotImplementedError("verifier not wired; see p2-signature-verify")
+
+
+@dataclass
+class _DefaultStager:
+    async def stage(self, payload: DispatchPayload, staging_dir: Path) -> None:
+        raise NotImplementedError("stager not wired; see p2-stage-and-tryboot")
+
+
+@dataclass
+class _DefaultMigrator:
+    async def run(self) -> None:
+        raise NotImplementedError("migrator not wired; see p2-forward-migration")
+
+
+def _stub_current_version() -> str:
+    raise NotImplementedError(
+        "current_version_provider not wired; service.py requires injection"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class OSUpdaterService:
+    """The orchestrator.
+
+    All collaborators are injected. Defaults raise
+    :class:`NotImplementedError`, which is intentional — the Phase 2 PR
+    ships the FSM + dispatch + event scaffolding; sibling PRs fill in
+    the actual download / verify / stage / migrate steps.
+
+    Three useful entry points for tests:
+
+    * :meth:`handle_dispatch` — synchronous-ish helper that runs the
+      dispatch-validation steps and (when accepted) drives the
+      collaborator chain through the success path. Returns ``None``;
+      failures raise :class:`UpdaterError` subclasses.
+    * :meth:`recover_on_start` — runs once at daemon startup.  If the
+      persisted FSM state isn't ``idle``/``failed``, reset to ``failed``
+      with ``resumed_from_<state>`` so we don't accept new dispatches
+      while in an indeterminate state.
+    * :meth:`run` — the async run loop. Connects to WPS, recv-dispatches
+      forever with 2s..60s backoff. The blocking loop tests don't need.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport_factory: Callable[[], WPSTransport],
+        event_sink: Optional[EventSink] = None,
+        current_version_provider: CurrentVersionProvider = _stub_current_version,
+        downloader: Optional[Downloader] = None,
+        verifier: Optional[Verifier] = None,
+        stager: Optional[Stager] = None,
+        migrator: Optional[Migrator] = None,
+        state_path: Path = DEFAULT_STATE_PATH,
+        staging_root: Path = DEFAULT_STAGING_ROOT,
+    ) -> None:
+        self.transport_factory = transport_factory
+        self.event_sink: EventSink = event_sink or OutboxEventSink()
+        self.current_version_provider = current_version_provider
+        self.downloader: Downloader = downloader or _DefaultDownloader()
+        self.verifier: Verifier = verifier or _DefaultVerifier()
+        self.stager: Stager = stager or _DefaultStager()
+        self.migrator: Migrator = migrator or _DefaultMigrator()
+        self.state_path = state_path
+        self.staging_root = staging_root
+        self.state: UpdaterState = load_state(self.state_path)
+
+    # -- public API used by tests and the run loop --------------------------
+
+    def recover_on_start(self) -> None:
+        """Reset the FSM on daemon startup if we crashed mid-dispatch.
+
+        Three cases:
+
+        * ``idle`` / ``failed`` — nothing to do.
+        * ``tryboot_running`` — this is the normal post-reboot resumption
+          point.  We DO NOT reset here; slot-confirm will drive the next
+          transition.  (Tracked by plan #23's state-machine notes.)
+        * Anything else — we crashed in the middle of a download / stage
+          / migrate. Transition to ``FAILED`` with a synthetic reason so
+          the next dispatch arriving moves us back to ``DOWNLOADING``,
+          per :data:`LEGAL_TRANSITIONS`. Emit a ``failed`` lifecycle
+          event so the CMS sees what happened.
+        """
+
+        s = self.state
+        if s.fsm in (UpdaterFSMState.IDLE, UpdaterFSMState.FAILED):
+            return
+        if s.fsm is UpdaterFSMState.TRYBOOT_RUNNING:
+            # Normal post-tryboot wake — leave alone for slot-confirm.
+            return
+
+        prior = s.fsm.value
+        reason = f"resumed_from_{prior}"
+        log.warning("recovering from interrupted state %s -> failed", prior)
+        transition(s, UpdaterFSMState.FAILED, reason=reason)
+        emit_event(
+            s,
+            LifecycleEventType.FAILED,
+            self.event_sink,
+            reason=reason,
+            state_path=self.state_path,
+        )
+
+    async def handle_dispatch(self, raw_msg: Any) -> None:
+        """Drive a single dispatch end-to-end on the happy path.
+
+        Validates the payload, the busy interlock, and the version floor.
+        On any failure, transitions the FSM to ``FAILED`` (or stays in
+        the current state for ``declined:busy``) and emits the
+        corresponding lifecycle event.
+
+        Tests can call this directly without standing up a transport.
+        """
+
+        try:
+            payload = parse_dispatch_payload(raw_msg)
+        except DispatchPayloadError as exc:
+            self._emit_failed("invalid_payload", reason_detail=str(exc))
+            return
+
+        # Concurrency interlock (#23).
+        if is_busy(self.state):
+            log.info(
+                "rejecting dispatch %s while in state %s",
+                payload.release_id,
+                self.state.fsm.value,
+            )
+            self._emit_declined(
+                "busy",
+                payload=payload,
+                detail=f"in state {self.state.fsm.value}",
+            )
+            raise UpdaterBusyError(
+                f"updater busy in state {self.state.fsm.value}"
+            )
+
+        # Version floor (#21 / #24).
+        try:
+            current_version = self.current_version_provider()
+        except NotImplementedError:
+            raise
+        if not payload.force_downgrade and not version_at_least(
+            current_version, payload.min_from_version
+        ):
+            log.warning(
+                "refusing dispatch %s: current=%s < min_from_version=%s",
+                payload.release_id,
+                current_version,
+                payload.min_from_version,
+            )
+            # Pre-admission rejection — the dispatch never entered the
+            # pipeline so we don't touch the FSM. Stamp metadata on the
+            # state transiently so the lifecycle event references the
+            # right release_id, then restore. Plan acceptance: "verify the
+            # device emits failed:version_floor and the inactive slot is
+            # untouched" — leaving the FSM in IDLE makes that trivially
+            # true.
+            self._emit_pre_admission_failed(
+                payload,
+                reason="version_floor",
+                detail={
+                    "current_version": current_version,
+                    "min_from_version": payload.min_from_version,
+                },
+            )
+            raise VersionFloorError(
+                f"current={current_version} < min_from_version={payload.min_from_version}"
+            )
+
+        # Accepted — drive the success chain.
+        self._record_dispatch_metadata(payload)
+        transition(self.state, UpdaterFSMState.DOWNLOADING)
+        save_state(self.state, path=self.state_path)
+        emit_event(
+            self.state,
+            LifecycleEventType.DOWNLOAD_STARTED,
+            self.event_sink,
+            state_path=self.state_path,
+        )
+
+        staging_dir = self.staging_root / payload.release_id
+        try:
+            await self.downloader.run(payload, staging_dir)
+            await self.verifier.run(payload, staging_dir)
+            transition(self.state, UpdaterFSMState.STAGED)
+            save_state(self.state, path=self.state_path)
+            emit_event(
+                self.state,
+                LifecycleEventType.SIGNATURE_VERIFIED,
+                self.event_sink,
+                state_path=self.state_path,
+            )
+            emit_event(
+                self.state,
+                LifecycleEventType.STAGED,
+                self.event_sink,
+                state_path=self.state_path,
+            )
+
+            transition(self.state, UpdaterFSMState.TRYBOOT_PENDING)
+            save_state(self.state, path=self.state_path)
+            await self.stager.stage(payload, staging_dir)
+
+            transition(self.state, UpdaterFSMState.TRYBOOT_RUNNING)
+            save_state(self.state, path=self.state_path)
+            emit_event(
+                self.state,
+                LifecycleEventType.TRYBOOT_INITIATED,
+                self.event_sink,
+                state_path=self.state_path,
+            )
+        except Exception as exc:
+            log.exception(
+                "dispatch %s failed in state %s",
+                payload.release_id,
+                self.state.fsm.value,
+            )
+            reason = self._classify_failure(exc)
+            transition(self.state, UpdaterFSMState.FAILED, reason=reason)
+            emit_event(
+                self.state,
+                LifecycleEventType.FAILED,
+                self.event_sink,
+                reason=reason,
+                payload={"detail": str(exc)},
+                state_path=self.state_path,
+            )
+            raise UpdaterError(reason) from exc
+
+    async def run(self) -> None:
+        """Main async run loop.
+
+        Connects to WPS with exponential backoff (2s -> 60s), receives
+        messages, dispatches them. Returns only on cancellation.
+        """
+
+        self.recover_on_start()
+        delay = _RECONNECT_INITIAL_DELAY
+        while True:
+            transport = self.transport_factory()
+            try:
+                await transport.connect()
+                log.info("WPS connected; awaiting dispatch messages")
+                delay = _RECONNECT_INITIAL_DELAY
+                while True:
+                    msg = await transport.recv()
+                    msg_type = msg.get("type") if isinstance(msg, dict) else None
+                    if msg_type != "os_update_dispatch":
+                        log.debug("ignoring non-dispatch message type=%r", msg_type)
+                        continue
+                    try:
+                        await self.handle_dispatch(msg)
+                    except UpdaterError:
+                        # Already emitted; loop continues so we can accept
+                        # the next dispatch once we're back to FAILED.
+                        pass
+            except asyncio.CancelledError:
+                await transport.close()
+                raise
+            except Exception:
+                log.exception("WPS loop crashed; reconnecting in %.1fs", delay)
+                try:
+                    await transport.close()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, _RECONNECT_MAX_DELAY)
+
+    # -- internals ----------------------------------------------------------
+
+    def _record_dispatch_metadata(self, payload: DispatchPayload) -> None:
+        """Stamp ``state`` with the in-flight dispatch identifiers.
+
+        Done before transitioning out of ``IDLE`` so that lifecycle events
+        emitted on the happy AND failure paths both reference the correct
+        ``release_id`` / ``target_version``.
+        """
+
+        self.state.release_id = payload.release_id
+        self.state.target_version = payload.target_version
+        self.state.staging_dir = str(self.staging_root / payload.release_id)
+
+    def _emit_failed(
+        self, reason: str, *, reason_detail: Optional[str] = None
+    ) -> None:
+        """Record a synthetic failure that didn't come from a real transition.
+
+        Used for malformed-payload rejections — we don't have a payload to
+        stamp metadata from, so we just emit a ``failed:<reason>`` event
+        with the detail in the payload. State FSM is unaffected.
+        """
+
+        emit_event(
+            self.state,
+            LifecycleEventType.FAILED,
+            self.event_sink,
+            reason=reason,
+            payload={"detail": reason_detail} if reason_detail else None,
+            state_path=self.state_path,
+        )
+
+    def _emit_pre_admission_failed(
+        self,
+        payload: DispatchPayload,
+        *,
+        reason: str,
+        detail: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        """Emit ``failed:<reason>`` for a dispatch that never entered the pipeline.
+
+        Stamps the lifecycle event with the rejected dispatch's
+        ``release_id`` / ``target_version`` so the CMS can correlate, but
+        leaves the persistent state's metadata fields untouched (the
+        dispatch was rejected, not started). The FSM stays in its current
+        state — typically IDLE.
+        """
+
+        saved = (
+            self.state.release_id,
+            self.state.target_version,
+            self.state.staging_dir,
+        )
+        try:
+            self.state.release_id = payload.release_id
+            self.state.target_version = payload.target_version
+            self.state.staging_dir = None
+            emit_event(
+                self.state,
+                LifecycleEventType.FAILED,
+                self.event_sink,
+                reason=reason,
+                payload=dict(detail or {}),
+                state_path=self.state_path,
+            )
+        finally:
+            (
+                self.state.release_id,
+                self.state.target_version,
+                self.state.staging_dir,
+            ) = saved
+            save_state(self.state, path=self.state_path)
+
+    def _emit_declined(
+        self,
+        reason: str,
+        *,
+        payload: DispatchPayload,
+        detail: Optional[str] = None,
+    ) -> None:
+        """Emit ``declined:<reason>`` for a rejected dispatch.
+
+        ``declined`` events MUST carry the rejected dispatch's
+        ``release_id`` so the CMS can mark the right
+        ``scheduled_dispatches`` row as ``declined_busy`` per plan #23.
+        We stamp the metadata transiently on a local copy of the state
+        so the persisted state on disk is unchanged.
+        """
+
+        saved = (
+            self.state.release_id,
+            self.state.target_version,
+            self.state.staging_dir,
+        )
+        try:
+            self.state.release_id = payload.release_id
+            self.state.target_version = payload.target_version
+            self.state.staging_dir = None
+            emit_event(
+                self.state,
+                LifecycleEventType.DECLINED,
+                self.event_sink,
+                reason=reason,
+                payload={"detail": detail} if detail else None,
+                state_path=self.state_path,
+            )
+        finally:
+            (
+                self.state.release_id,
+                self.state.target_version,
+                self.state.staging_dir,
+            ) = saved
+            save_state(self.state, path=self.state_path)
+
+    @staticmethod
+    def _classify_failure(exc: BaseException) -> str:
+        """Map an exception type to a ``failed:<reason>`` short code."""
+
+        name = type(exc).__name__
+        # Sibling todos will define their own exception types; until then,
+        # use a generic ``error_<TypeName>`` so the CMS still has something
+        # to group on.
+        return f"error_{name}"

--- a/os_updater/state.py
+++ b/os_updater/state.py
@@ -1,0 +1,244 @@
+"""Persistent updater state: ``/data/agora/updater-state.json``.
+
+The agora-os-updater daemon is a finite state machine. Persisting the state
+on every transition lets the daemon recover after a crash, daemon restart, or
+even a system reboot mid-update (the post-tryboot reboot is the normal case —
+we come back up in ``tryboot_running`` and slot-confirm decides what to do).
+
+The 8 states (plan.md §"Phase 2 — Deliverables"):
+
+* ``idle`` — no update in progress. Accepts new dispatches.
+* ``downloading`` — bundle download in flight to ``/data/.update/staging/``.
+* ``staged`` — bundle downloaded, signature verified, sha256 manifest
+  checked, NOT yet written to the inactive slot.
+* ``tryboot_pending`` — staged content rsynced to the inactive slot;
+  about to call ``agora-slot-mgr trigger-tryboot``.
+* ``tryboot_running`` — ``trigger-tryboot`` returned successfully; the
+  device is now (or imminently) running on the inactive slot in
+  tentative mode. Set just before issuing the post-tryboot reboot;
+  survives that reboot via the on-disk state file.
+* ``promoted_pending_migration`` — slot-confirm passed, ``agora-slot-mgr
+  promote`` succeeded. Forward-migration scripts have not run yet.
+* ``migrating`` — forward-migration runner is executing scripts under
+  ``/etc/agora/migrations/`` (post-promote only, gated by the
+  migration-allowed sentinel from Phase 1).
+* ``failed`` — terminal failure for this dispatch. Stays in ``failed``
+  until cleared by a fresh dispatch arriving (which transitions back
+  to ``downloading``) or operator intervention.
+
+Concurrency interlock (plan #23): only ``idle`` and ``failed`` accept a new
+dispatch. Anything else returns ``UpdaterBusyError`` and emits
+``declined:busy`` over WPS.
+"""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from shared.state import atomic_write
+
+SCHEMA_VERSION = 1
+
+#: On-disk location of the persistent updater state. Lives under ``/data``
+#: so it survives slot switches — the new slot's first boot still knows
+#: which dispatch was in flight.
+DEFAULT_STATE_PATH = Path("/data/agora/updater-state.json")
+
+
+class UpdaterFSMState(str, enum.Enum):
+    """Explicit finite state machine values.
+
+    String-valued so the state survives a round-trip through JSON without
+    needing custom serialization.
+    """
+
+    IDLE = "idle"
+    DOWNLOADING = "downloading"
+    STAGED = "staged"
+    TRYBOOT_PENDING = "tryboot_pending"
+    TRYBOOT_RUNNING = "tryboot_running"
+    PROMOTED_PENDING_MIGRATION = "promoted_pending_migration"
+    MIGRATING = "migrating"
+    FAILED = "failed"
+
+
+#: Legal transitions: ``{from_state: set_of_to_states}``.
+#:
+#: Validated at write time by :func:`transition` so a programming error
+#: ("we somehow went straight from downloading to migrating") fails loud
+#: in tests rather than producing a wedged on-disk state.
+LEGAL_TRANSITIONS: dict[UpdaterFSMState, frozenset[UpdaterFSMState]] = {
+    UpdaterFSMState.IDLE: frozenset({UpdaterFSMState.DOWNLOADING}),
+    UpdaterFSMState.DOWNLOADING: frozenset(
+        {UpdaterFSMState.STAGED, UpdaterFSMState.FAILED}
+    ),
+    UpdaterFSMState.STAGED: frozenset(
+        {UpdaterFSMState.TRYBOOT_PENDING, UpdaterFSMState.FAILED}
+    ),
+    UpdaterFSMState.TRYBOOT_PENDING: frozenset(
+        {UpdaterFSMState.TRYBOOT_RUNNING, UpdaterFSMState.FAILED}
+    ),
+    UpdaterFSMState.TRYBOOT_RUNNING: frozenset(
+        {
+            UpdaterFSMState.PROMOTED_PENDING_MIGRATION,
+            UpdaterFSMState.FAILED,
+            UpdaterFSMState.IDLE,
+        }
+    ),
+    UpdaterFSMState.PROMOTED_PENDING_MIGRATION: frozenset(
+        {UpdaterFSMState.MIGRATING, UpdaterFSMState.FAILED}
+    ),
+    UpdaterFSMState.MIGRATING: frozenset(
+        {UpdaterFSMState.IDLE, UpdaterFSMState.FAILED}
+    ),
+    UpdaterFSMState.FAILED: frozenset({UpdaterFSMState.DOWNLOADING}),
+}
+
+#: States in which a new dispatch is REFUSED (per #23).
+BUSY_STATES: frozenset[UpdaterFSMState] = frozenset(
+    {
+        UpdaterFSMState.DOWNLOADING,
+        UpdaterFSMState.STAGED,
+        UpdaterFSMState.TRYBOOT_PENDING,
+        UpdaterFSMState.TRYBOOT_RUNNING,
+        UpdaterFSMState.PROMOTED_PENDING_MIGRATION,
+        UpdaterFSMState.MIGRATING,
+    }
+)
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as a Zulu ISO-8601 string."""
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TransitionError(Exception):
+    """Raised when :func:`transition` is asked to make an illegal jump.
+
+    Programmer error — a routine failure path should target
+    :data:`UpdaterFSMState.FAILED` explicitly, which is reachable from every
+    non-terminal state.
+    """
+
+
+class UpdaterState(BaseModel):
+    """Persistent on-disk state for the agora-os-updater daemon."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    schema_version: int = SCHEMA_VERSION
+
+    #: Current FSM position.
+    fsm: UpdaterFSMState = UpdaterFSMState.IDLE
+
+    #: Server-assigned release identifier of the currently-in-flight
+    #: dispatch, or ``None`` when idle. Mirrors the dispatch payload's
+    #: ``release_id`` field so events emitted later can be correlated
+    #: back to the originating dispatch.
+    release_id: Optional[str] = None
+
+    #: Target semantic version of the current dispatch. Used for the
+    #: ``target_version`` field of lifecycle events.
+    target_version: Optional[str] = None
+
+    #: Path to the staging directory for the current dispatch. Set when
+    #: we enter ``downloading``; cleared on ``idle`` / ``failed``.
+    staging_dir: Optional[str] = None
+
+    #: Last reason string captured at the most recent ``failed`` transition.
+    #: Surfaces in lifecycle events and helps an operator diagnose without
+    #: cross-referencing journald.
+    last_failure_reason: Optional[str] = None
+
+    #: ISO-8601 timestamp of the last successful state change.
+    updated_at: str = Field(default_factory=utc_now_iso)
+
+    #: Monotonic per-device event sequence. Lifecycle events are stamped
+    #: with this counter pre-increment (so the first event sent is
+    #: ``event_id=1``). Persisted so we survive daemon restart without
+    #: re-using ids — critical for the ``(device_id, event_id)`` dedupe
+    #: contract with the CMS event-buffer (D33).
+    last_event_id: int = 0
+
+
+def load_state(path: Optional[Path] = None) -> UpdaterState:
+    """Read ``updater-state.json``, returning a fresh state if missing.
+
+    A missing file is the normal first-boot case. Parse errors fall back
+    to a fresh state too — losing a stale state record is better than
+    refusing to boot. Real disk-level corruption is rare enough that we
+    accept the data loss rather than complicating recovery.
+    """
+
+    p = path or DEFAULT_STATE_PATH
+    try:
+        return UpdaterState.model_validate_json(p.read_text())
+    except (FileNotFoundError, ValueError):
+        return UpdaterState()
+
+
+def save_state(state: UpdaterState, path: Optional[Path] = None) -> None:
+    """Persist ``state`` to disk atomically.
+
+    Refreshes ``updated_at`` to "now" before writing so callers don't have
+    to remember.
+    """
+
+    p = path or DEFAULT_STATE_PATH
+    state.updated_at = utc_now_iso()
+    atomic_write(p, state.model_dump_json(indent=2))
+
+
+def is_busy(state: UpdaterState) -> bool:
+    """Return ``True`` if a fresh dispatch should be refused."""
+
+    return state.fsm in BUSY_STATES
+
+
+def transition(
+    state: UpdaterState,
+    to: UpdaterFSMState,
+    *,
+    reason: Optional[str] = None,
+) -> UpdaterState:
+    """Move ``state`` from its current FSM value to ``to``.
+
+    Mutates ``state`` in place AND returns it (for fluent chaining and to
+    match how callers typically use it).
+
+    Raises :class:`TransitionError` if the requested move isn't in
+    :data:`LEGAL_TRANSITIONS`. Use ``UpdaterFSMState.FAILED`` from any
+    non-terminal state to signal a failure path — that edge is always
+    legal.
+
+    Side-effects on the state:
+
+    * ``reason`` is stored as ``last_failure_reason`` when transitioning
+      into ``FAILED``.
+    * Transitioning to ``IDLE`` clears all dispatch-specific fields
+      (``release_id``, ``target_version``, ``staging_dir``,
+      ``last_failure_reason``) so the next dispatch starts clean.
+    """
+
+    legal = LEGAL_TRANSITIONS.get(state.fsm, frozenset())
+    if to not in legal:
+        raise TransitionError(
+            f"illegal FSM transition: {state.fsm.value} -> {to.value} "
+            f"(legal targets: {sorted(s.value for s in legal)!r})"
+        )
+
+    state.fsm = to
+    if to is UpdaterFSMState.FAILED:
+        state.last_failure_reason = reason
+    if to is UpdaterFSMState.IDLE:
+        state.release_id = None
+        state.target_version = None
+        state.staging_dir = None
+        state.last_failure_reason = None
+    return state

--- a/systemd/agora-os-updater.service
+++ b/systemd/agora-os-updater.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Agora OS Updater (A/B atomic OS update daemon)
+# Plan: §"Phase 2 — agora-os-updater service". This daemon subscribes to
+# the CMS over WPS for os_update_dispatch messages, downloads + verifies
+# bundles, and orchestrates the slot switch via agora-slot-mgr.
+After=network-online.target agora-cms-client.service
+Wants=network-online.target
+# Soft requires only: the updater can boot and idle even if cms-client is
+# wedged, and we don't want a cms-client crash loop to disable updates.
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 -m os_updater
+WorkingDirectory=/opt/agora/src
+Environment=PYTHONPATH=/opt/agora/src
+Environment=AGORA_BASE=/opt/agora
+# Fleet provisioning env (AGORA_DEVICE_API_KEY, AGORA_CMS_URL,
+# AGORA_DEVICE_NAME) lives in the same drop-in as agora-cms-client.
+# Optional ('-' prefix) so the unit still starts on a fresh, un-provisioned
+# install — it just won't be able to connect to WPS until provisioning
+# completes.
+EnvironmentFile=-/etc/agora/environment
+
+Restart=always
+RestartSec=10
+
+# Wait for network to settle before the connect-token POST.
+ExecStartPre=/bin/sleep 5
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_os_updater_dispatch.py
+++ b/tests/test_os_updater_dispatch.py
@@ -1,0 +1,127 @@
+"""Tests for :mod:`os_updater.dispatch` — payload parsing + validation.
+
+Acceptance hooks (plan §"Phase 2 — Acceptance"):
+* Required fields enforced.
+* version regex (``major.minor.patch[-pre]``).
+* release_id regex (``[A-Za-z0-9._-]{1,128}``).
+* ``force_now`` / ``force_downgrade`` default to false.
+* ``extra="ignore"`` for forward compatibility (Phase 3 fields).
+* https / http urls accepted, other schemes rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from os_updater.dispatch import (
+    DispatchPayload,
+    DispatchPayloadError,
+    parse_dispatch_payload,
+)
+
+
+def _ok_msg(**overrides):
+    base = {
+        "type": "os_update_dispatch",
+        "release_id": "rel_2026_05_07_v1.1.0",
+        "target_version": "1.1.0",
+        "min_from_version": "1.0.0",
+        "bundle_url": "https://github.com/x/y/releases/download/v1.1.0/bundle.zst",
+        "signature_url": "https://github.com/x/y/releases/download/v1.1.0/bundle.zst.minisig",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestHappyPath:
+    def test_minimum_required_fields_parse(self):
+        p = parse_dispatch_payload(_ok_msg())
+        assert isinstance(p, DispatchPayload)
+        assert p.release_id == "rel_2026_05_07_v1.1.0"
+        assert p.target_version == "1.1.0"
+        assert p.min_from_version == "1.0.0"
+
+    def test_force_flags_default_false(self):
+        p = parse_dispatch_payload(_ok_msg())
+        assert p.force_now is False
+        assert p.force_downgrade is False
+
+    def test_force_flags_round_trip(self):
+        p = parse_dispatch_payload(_ok_msg(force_now=True, force_downgrade=True))
+        assert p.force_now is True
+        assert p.force_downgrade is True
+
+    def test_prerelease_version_accepted(self):
+        p = parse_dispatch_payload(
+            _ok_msg(target_version="1.1.0-rc1", min_from_version="1.0.0-beta.2")
+        )
+        assert p.target_version == "1.1.0-rc1"
+        assert p.min_from_version == "1.0.0-beta.2"
+
+    def test_extra_field_ignored(self):
+        """Phase 3 adds ``not_before`` etc. — older daemons must ignore
+        anything they don't recognize so a CMS-side schema bump doesn't
+        brick the fleet."""
+        msg = _ok_msg(scheduled_at="2026-05-07T03:00:00Z", some_phase3_field="abc")
+        p = parse_dispatch_payload(msg)
+        assert p.release_id == "rel_2026_05_07_v1.1.0"
+
+    def test_release_id_max_length(self):
+        rid = "a" * 128
+        p = parse_dispatch_payload(_ok_msg(release_id=rid))
+        assert p.release_id == rid
+
+
+class TestRejection:
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            "release_id",
+            "target_version",
+            "min_from_version",
+            "bundle_url",
+            "signature_url",
+        ],
+    )
+    def test_missing_required_field_rejected(self, missing):
+        msg = _ok_msg()
+        del msg[missing]
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(msg)
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "1", "1.2", "v1.2.3", "1.2.3.4", "1.2.x", "abc", " 1.2.3"],
+    )
+    def test_bad_version_rejected(self, bad):
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(_ok_msg(target_version=bad))
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "rel id with spaces", "a" * 129, "rel/1", "rel:1", "rel#1"],
+    )
+    def test_bad_release_id_rejected(self, bad):
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(_ok_msg(release_id=bad))
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "ftp://example.com/bundle.zst",
+            "file:///tmp/bundle.zst",
+            "bundle.zst",
+            "",
+        ],
+    )
+    def test_bad_url_rejected(self, bad):
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(_ok_msg(bundle_url=bad))
+
+    def test_non_object_payload_rejected(self):
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(["not", "an", "object"])
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload(None)
+        with pytest.raises(DispatchPayloadError):
+            parse_dispatch_payload("string")

--- a/tests/test_os_updater_events.py
+++ b/tests/test_os_updater_events.py
@@ -1,0 +1,274 @@
+"""Tests for :mod:`os_updater.events` — the lifecycle event scaffold.
+
+Acceptance hooks (plan §"Phase 2 — Deliverables" + plan #33):
+
+* Monotonic ``event_id`` across emissions.
+* Persistence across "daemon restart" (re-load state, ids don't repeat).
+* JSONL day-file layout under :data:`DEFAULT_OUTBOX_DIR`.
+* ``iter_events`` round-trips events that were written.
+* Malformed lines are skipped, not raised on.
+* ``emit_event`` stamps release_id / target_version from state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from os_updater.events import (
+    LifecycleEvent,
+    LifecycleEventType,
+    OutboxEventSink,
+    emit_event,
+    next_event_id,
+)
+from os_updater.state import (
+    UpdaterFSMState,
+    UpdaterState,
+    load_state,
+)
+
+
+class _FixedNow:
+    """``now_fn`` substitute that returns the same Zulu timestamp every
+    time. ``OutboxEventSink._path_for`` slices the first 10 chars off the
+    timestamp to pick a day-file, so any 10-char-prefix date works.
+    """
+
+    def __init__(self, ts: str = "2026-05-07T03:30:00Z") -> None:
+        self.ts = ts
+
+    def __call__(self) -> str:
+        return self.ts
+
+
+class _ListSink:
+    """In-memory EventSink — keeps every event so tests can assert."""
+
+    def __init__(self) -> None:
+        self.events: list[LifecycleEvent] = []
+
+    def put(self, event: LifecycleEvent) -> None:
+        self.events.append(event)
+
+
+class TestNextEventId:
+    def test_increments_from_zero(self):
+        s = UpdaterState()
+        assert next_event_id(s) == 1
+        assert next_event_id(s) == 2
+        assert next_event_id(s) == 3
+        assert s.last_event_id == 3
+
+    def test_resumes_from_persisted_counter(self):
+        s = UpdaterState(last_event_id=42)
+        assert next_event_id(s) == 43
+
+
+class TestEmitEvent:
+    def test_stamps_id_release_and_target_from_state(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        s = UpdaterState(
+            fsm=UpdaterFSMState.DOWNLOADING,
+            release_id="rel-1",
+            target_version="1.2.3",
+        )
+        sink = _ListSink()
+
+        event = emit_event(
+            s,
+            LifecycleEventType.DOWNLOAD_STARTED,
+            sink,
+            state_path=state_path,
+            now_fn=_FixedNow(),
+        )
+
+        assert event.event_id == 1
+        assert event.event_type is LifecycleEventType.DOWNLOAD_STARTED
+        assert event.release_id == "rel-1"
+        assert event.target_version == "1.2.3"
+        assert event.occurred_at == "2026-05-07T03:30:00Z"
+        assert event.reason is None
+        assert event.payload == {}
+        assert sink.events == [event]
+
+    def test_persists_event_id_before_sink_put(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        s = UpdaterState(release_id="rel-1", target_version="1.2.3")
+
+        class _BoomSink:
+            def put(self, event):
+                raise RuntimeError("sink down")
+
+        # emit_event raises through the sink failure, but state is already
+        # persisted with last_event_id=1 — so on retry we don't re-use the id.
+        try:
+            emit_event(
+                s,
+                LifecycleEventType.DOWNLOAD_STARTED,
+                _BoomSink(),
+                state_path=state_path,
+                now_fn=_FixedNow(),
+            )
+        except RuntimeError:
+            pass
+
+        reloaded = load_state(state_path)
+        assert reloaded.last_event_id == 1
+
+    def test_failed_event_carries_reason_and_payload(self, tmp_path):
+        s = UpdaterState(release_id="rel-x", target_version="1.0.0")
+        sink = _ListSink()
+        emit_event(
+            s,
+            LifecycleEventType.FAILED,
+            sink,
+            reason="signature_invalid",
+            payload={"detail": "bad sig"},
+            state_path=tmp_path / "state.json",
+            now_fn=_FixedNow(),
+        )
+        ev = sink.events[0]
+        assert ev.reason == "signature_invalid"
+        assert ev.payload == {"detail": "bad sig"}
+
+    def test_monotonic_ids_across_emissions(self, tmp_path):
+        s = UpdaterState()
+        sink = _ListSink()
+        for _ in range(5):
+            emit_event(
+                s,
+                LifecycleEventType.DOWNLOAD_STARTED,
+                sink,
+                state_path=tmp_path / "state.json",
+                now_fn=_FixedNow(),
+            )
+        ids = [ev.event_id for ev in sink.events]
+        assert ids == [1, 2, 3, 4, 5]
+
+    def test_ids_survive_simulated_restart(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        s = UpdaterState()
+        sink = _ListSink()
+        emit_event(
+            s,
+            LifecycleEventType.DOWNLOAD_STARTED,
+            sink,
+            state_path=state_path,
+            now_fn=_FixedNow(),
+        )
+        emit_event(
+            s,
+            LifecycleEventType.STAGED,
+            sink,
+            state_path=state_path,
+            now_fn=_FixedNow(),
+        )
+        # Simulate daemon restart: reload state from disk, emit more.
+        s2 = load_state(state_path)
+        emit_event(
+            s2,
+            LifecycleEventType.PROMOTED,
+            sink,
+            state_path=state_path,
+            now_fn=_FixedNow(),
+        )
+        ids = [ev.event_id for ev in sink.events]
+        assert ids == [1, 2, 3]
+
+
+class TestOutboxEventSink:
+    def test_writes_to_day_file(self, tmp_path):
+        outbox = tmp_path / "buffer"
+        sink = OutboxEventSink(outbox_dir=outbox)
+        ev = LifecycleEvent(
+            event_id=1,
+            event_type=LifecycleEventType.DOWNLOAD_STARTED,
+            release_id="rel-1",
+            target_version="1.0.0",
+            occurred_at="2026-05-07T03:30:00Z",
+        )
+        sink.put(ev)
+        day_file = outbox / "2026-05-07.jsonl"
+        assert day_file.exists()
+        line = day_file.read_text().strip()
+        obj = json.loads(line)
+        assert obj["event_type"] == "download_started"
+        assert obj["event_id"] == 1
+
+    def test_iter_events_round_trip(self, tmp_path):
+        outbox = tmp_path / "buffer"
+        sink = OutboxEventSink(outbox_dir=outbox)
+        events = [
+            LifecycleEvent(
+                event_id=i,
+                event_type=LifecycleEventType.STAGED,
+                release_id="rel-1",
+                target_version="1.0.0",
+                occurred_at="2026-05-07T03:30:00Z",
+            )
+            for i in range(1, 4)
+        ]
+        for ev in events:
+            sink.put(ev)
+        round_tripped = list(sink.iter_events())
+        assert [ev.event_id for ev in round_tripped] == [1, 2, 3]
+        assert all(ev.event_type is LifecycleEventType.STAGED for ev in round_tripped)
+
+    def test_iter_events_skips_malformed_lines(self, tmp_path):
+        outbox = tmp_path / "buffer"
+        outbox.mkdir(parents=True)
+        day_file = outbox / "2026-05-07.jsonl"
+        day_file.write_text(
+            "\n".join(
+                [
+                    "not json",
+                    json.dumps(
+                        {
+                            "event_id": 1,
+                            "event_type": "download_started",
+                            "release_id": "rel-1",
+                            "target_version": "1.0.0",
+                            "occurred_at": "2026-05-07T03:30:00Z",
+                            "reason": None,
+                            "payload": {},
+                        }
+                    ),
+                    "",  # blank line — also skipped
+                    "{}",  # parseable but missing keys
+                ]
+            )
+            + "\n"
+        )
+        sink = OutboxEventSink(outbox_dir=outbox)
+        evs = list(sink.iter_events())
+        assert len(evs) == 1
+        assert evs[0].event_id == 1
+
+    def test_iter_events_when_outbox_missing(self, tmp_path):
+        sink = OutboxEventSink(outbox_dir=tmp_path / "does-not-exist")
+        assert list(sink.iter_events()) == []
+
+    def test_events_from_different_days_in_separate_files(self, tmp_path):
+        outbox = tmp_path / "buffer"
+        sink = OutboxEventSink(outbox_dir=outbox)
+        sink.put(
+            LifecycleEvent(
+                event_id=1,
+                event_type=LifecycleEventType.STAGED,
+                release_id="r",
+                target_version="1.0.0",
+                occurred_at="2026-05-07T23:59:00Z",
+            )
+        )
+        sink.put(
+            LifecycleEvent(
+                event_id=2,
+                event_type=LifecycleEventType.STAGED,
+                release_id="r",
+                target_version="1.0.0",
+                occurred_at="2026-05-08T00:01:00Z",
+            )
+        )
+        assert (outbox / "2026-05-07.jsonl").exists()
+        assert (outbox / "2026-05-08.jsonl").exists()

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -1,0 +1,380 @@
+"""Tests for :mod:`os_updater.service` — the orchestrator.
+
+Acceptance hooks (plan §"Phase 2 — Acceptance"):
+
+* Busy interlock → ``declined:busy`` (plan #23).
+* Version floor → ``failed:version_floor``, FSM stays in ``IDLE``
+  (plan #21 / #24, "the inactive slot is untouched").
+* ``force_downgrade=true`` skips the floor check.
+* Invalid payload → ``failed:invalid_payload``.
+* ``recover_on_start`` resets stuck mid-pipeline states to ``FAILED``;
+  leaves ``IDLE`` / ``FAILED`` / ``TRYBOOT_RUNNING`` alone.
+* Happy path drives the FSM ``IDLE → DOWNLOADING → STAGED →
+  TRYBOOT_PENDING → TRYBOOT_RUNNING`` and emits the lifecycle events in
+  the right order.
+
+These tests inject the collaborator stubs (Downloader, Verifier, Stager,
+Migrator) so we exercise the service in isolation. The real
+implementations land in sibling Phase 2 PRs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from os_updater.events import (
+    LifecycleEvent,
+    LifecycleEventType,
+)
+from os_updater.service import (
+    OSUpdaterService,
+    UpdaterBusyError,
+    UpdaterError,
+    VersionFloorError,
+    version_at_least,
+)
+from os_updater.state import (
+    UpdaterFSMState,
+    UpdaterState,
+    load_state,
+    save_state,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+class _ListSink:
+    """In-memory EventSink that captures every emitted event."""
+
+    def __init__(self) -> None:
+        self.events: list[LifecycleEvent] = []
+
+    def put(self, event: LifecycleEvent) -> None:
+        self.events.append(event)
+
+
+class _OkStub:
+    """Async no-op for Downloader / Verifier / Stager / Migrator."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def run(self, *args, **kwargs) -> None:
+        self.calls.append(("run", args, kwargs))
+
+    async def stage(self, *args, **kwargs) -> None:
+        self.calls.append(("stage", args, kwargs))
+
+
+class _BoomDownloader:
+    async def run(self, payload, staging_dir):
+        raise RuntimeError("network is on fire")
+
+
+def _ok_dispatch(**overrides):
+    base = {
+        "type": "os_update_dispatch",
+        "release_id": "rel_test_1",
+        "target_version": "1.1.0",
+        "min_from_version": "1.0.0",
+        "bundle_url": "https://x/y/bundle.zst",
+        "signature_url": "https://x/y/bundle.zst.minisig",
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_service(
+    tmp_path,
+    *,
+    current_version: str = "1.0.0",
+    downloader=None,
+    verifier=None,
+    stager=None,
+    migrator=None,
+    sink=None,
+):
+    """Construct an :class:`OSUpdaterService` for tests with safe defaults."""
+
+    state_path = tmp_path / "state.json"
+    staging_root = tmp_path / "staging"
+    return OSUpdaterService(
+        transport_factory=lambda: object(),  # never called by these tests
+        event_sink=sink or _ListSink(),
+        current_version_provider=lambda: current_version,
+        downloader=downloader or _OkStub(),
+        verifier=verifier or _OkStub(),
+        stager=stager or _OkStub(),
+        migrator=migrator or _OkStub(),
+        state_path=state_path,
+        staging_root=staging_root,
+    )
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+# ── version_at_least ───────────────────────────────────────────────────────
+
+
+class TestVersionAtLeast:
+    @pytest.mark.parametrize(
+        "current,floor,expected",
+        [
+            ("1.0.0", "1.0.0", True),
+            ("1.0.1", "1.0.0", True),
+            ("1.1.0", "1.0.99", True),
+            ("2.0.0", "1.999.999", True),
+            ("1.0.0", "1.0.1", False),
+            ("0.9.9", "1.0.0", False),
+            # Prerelease ordering: 1.0.0 (release) > 1.0.0-rc1 (prerelease).
+            ("1.0.0", "1.0.0-rc1", True),
+            ("1.0.0-rc1", "1.0.0", False),
+            ("1.0.0-rc2", "1.0.0-rc1", True),
+        ],
+    )
+    def test_compare(self, current, floor, expected):
+        assert version_at_least(current, floor) is expected
+
+
+# ── recover_on_start ───────────────────────────────────────────────────────
+
+
+class TestRecoverOnStart:
+    def test_idle_unchanged(self, tmp_path):
+        s = _build_service(tmp_path)
+        s.state = UpdaterState(fsm=UpdaterFSMState.IDLE)
+        save_state(s.state, s.state_path)
+        s.recover_on_start()
+        assert s.state.fsm is UpdaterFSMState.IDLE
+
+    def test_failed_unchanged(self, tmp_path):
+        s = _build_service(tmp_path)
+        s.state = UpdaterState(
+            fsm=UpdaterFSMState.FAILED, last_failure_reason="prior"
+        )
+        save_state(s.state, s.state_path)
+        s.recover_on_start()
+        assert s.state.fsm is UpdaterFSMState.FAILED
+        assert s.state.last_failure_reason == "prior"
+
+    def test_tryboot_running_unchanged(self, tmp_path):
+        """Normal post-reboot resumption — slot-confirm drives the next move."""
+        s = _build_service(tmp_path)
+        s.state = UpdaterState(
+            fsm=UpdaterFSMState.TRYBOOT_RUNNING,
+            release_id="rel-1",
+            target_version="1.1.0",
+        )
+        save_state(s.state, s.state_path)
+        s.recover_on_start()
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+    @pytest.mark.parametrize(
+        "stuck",
+        [
+            UpdaterFSMState.DOWNLOADING,
+            UpdaterFSMState.STAGED,
+            UpdaterFSMState.TRYBOOT_PENDING,
+            UpdaterFSMState.PROMOTED_PENDING_MIGRATION,
+            UpdaterFSMState.MIGRATING,
+        ],
+    )
+    def test_stuck_state_resets_to_failed(self, tmp_path, stuck):
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        s.state = UpdaterState(
+            fsm=stuck,
+            release_id="rel-stuck",
+            target_version="1.2.0",
+        )
+        save_state(s.state, s.state_path)
+        s.recover_on_start()
+        assert s.state.fsm is UpdaterFSMState.FAILED
+        assert s.state.last_failure_reason == f"resumed_from_{stuck.value}"
+        # Emitted a lifecycle event so CMS sees the recovery.
+        assert len(sink.events) == 1
+        ev = sink.events[0]
+        assert ev.event_type is LifecycleEventType.FAILED
+        assert ev.reason == f"resumed_from_{stuck.value}"
+
+
+# ── handle_dispatch: rejection paths ──────────────────────────────────────
+
+
+class TestHandleDispatchRejection:
+    def test_invalid_payload_emits_failed_invalid_payload(self, tmp_path):
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        asyncio.run(s.handle_dispatch({"type": "os_update_dispatch"}))  # missing fields
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        assert any(
+            e.event_type is LifecycleEventType.FAILED and e.reason == "invalid_payload"
+            for e in sink.events
+        )
+
+    def test_busy_state_emits_declined_busy_and_raises(self, tmp_path):
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        # Force a busy state.
+        s.state = UpdaterState(
+            fsm=UpdaterFSMState.DOWNLOADING,
+            release_id="rel-prior",
+            target_version="1.0.5",
+        )
+        save_state(s.state, s.state_path)
+
+        with pytest.raises(UpdaterBusyError):
+            asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-new")))
+
+        # State unchanged on rejection.
+        assert s.state.fsm is UpdaterFSMState.DOWNLOADING
+        assert s.state.release_id == "rel-prior"
+        # Declined event carries the NEW dispatch's release_id (so CMS can
+        # mark the right scheduled_dispatches row), not the in-flight one.
+        declined = [
+            e
+            for e in sink.events
+            if e.event_type is LifecycleEventType.DECLINED and e.reason == "busy"
+        ]
+        assert len(declined) == 1
+        assert declined[0].release_id == "rel-new"
+
+    def test_version_floor_emits_failed_and_fsm_stays_idle(self, tmp_path):
+        """The plan acceptance bar: ``the inactive slot is untouched``. We
+        enforce that by leaving the FSM in IDLE so the daemon never starts
+        the staging chain. release_id on persistent state must also be
+        restored to its pre-dispatch value (None on a fresh daemon)."""
+
+        sink = _ListSink()
+        s = _build_service(tmp_path, current_version="1.0.0", sink=sink)
+        msg = _ok_dispatch(min_from_version="2.0.0", release_id="rel-floor")
+
+        with pytest.raises(VersionFloorError):
+            asyncio.run(s.handle_dispatch(msg))
+
+        # FSM untouched — pre-admission rejection (the test the plan calls out).
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        # Persistent state's release_id is NOT mutated for a rejected
+        # dispatch (save+restore pattern in _emit_pre_admission_failed).
+        assert s.state.release_id is None
+        assert s.state.target_version is None
+        assert s.state.staging_dir is None
+
+        failed = [
+            e
+            for e in sink.events
+            if e.event_type is LifecycleEventType.FAILED
+            and e.reason == "version_floor"
+        ]
+        assert len(failed) == 1
+        # Lifecycle event DOES carry the rejected dispatch's release_id
+        # so CMS can correlate.
+        assert failed[0].release_id == "rel-floor"
+        assert failed[0].target_version == "1.1.0"
+        # Detail payload carries the comparison data.
+        assert failed[0].payload["current_version"] == "1.0.0"
+        assert failed[0].payload["min_from_version"] == "2.0.0"
+
+    def test_version_floor_persistent_state_restored_on_disk(self, tmp_path):
+        """After a version-floor rejection, on-disk state must not carry
+        the rejected dispatch's release_id (which would later confuse a
+        ``recover_on_start`` reload)."""
+
+        s = _build_service(tmp_path, current_version="1.0.0")
+        msg = _ok_dispatch(min_from_version="2.0.0", release_id="rel-floor")
+        with pytest.raises(VersionFloorError):
+            asyncio.run(s.handle_dispatch(msg))
+
+        reloaded = load_state(s.state_path)
+        assert reloaded.fsm is UpdaterFSMState.IDLE
+        assert reloaded.release_id is None
+        assert reloaded.target_version is None
+        # event_id WAS incremented and DID survive the restore (the only
+        # persistent side-effect of the rejection).
+        assert reloaded.last_event_id == 1
+
+    def test_force_downgrade_skips_floor_check(self, tmp_path):
+        sink = _ListSink()
+        s = _build_service(tmp_path, current_version="1.5.0", sink=sink)
+        msg = _ok_dispatch(
+            min_from_version="2.0.0",
+            target_version="1.4.0",
+            force_downgrade=True,
+            release_id="rel-downgrade",
+        )
+        asyncio.run(s.handle_dispatch(msg))
+        # Reached TRYBOOT_RUNNING via the happy path with default OkStubs.
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+
+# ── handle_dispatch: happy path ───────────────────────────────────────────
+
+
+class TestHandleDispatchHappyPath:
+    def test_drives_fsm_through_tryboot_running(self, tmp_path):
+        sink = _ListSink()
+        downloader = _OkStub()
+        verifier = _OkStub()
+        stager = _OkStub()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            downloader=downloader,
+            verifier=verifier,
+            stager=stager,
+        )
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-1")))
+
+        # FSM lands in TRYBOOT_RUNNING (the post-tryboot reboot is what
+        # would take it further; that's not in Phase 2 scope).
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+        assert s.state.release_id == "rel-1"
+        assert s.state.target_version == "1.1.0"
+        assert s.state.staging_dir is not None
+        assert s.state.staging_dir.endswith("rel-1")
+
+        # Lifecycle events were emitted in the right order with the right
+        # release_id stamped.
+        kinds = [e.event_type for e in sink.events]
+        assert kinds == [
+            LifecycleEventType.DOWNLOAD_STARTED,
+            LifecycleEventType.SIGNATURE_VERIFIED,
+            LifecycleEventType.STAGED,
+            LifecycleEventType.TRYBOOT_INITIATED,
+        ]
+        assert all(e.release_id == "rel-1" for e in sink.events)
+
+        # Collaborators were invoked once each.
+        assert len(downloader.calls) == 1
+        assert len(verifier.calls) == 1
+        assert len(stager.calls) == 1
+
+    def test_downloader_failure_transitions_to_failed_with_classifier(self, tmp_path):
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            downloader=_BoomDownloader(),
+        )
+
+        with pytest.raises(UpdaterError):
+            asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-x")))
+
+        assert s.state.fsm is UpdaterFSMState.FAILED
+        # _classify_failure maps the exception type name.
+        assert s.state.last_failure_reason == "error_RuntimeError"
+
+        failed_events = [
+            e for e in sink.events if e.event_type is LifecycleEventType.FAILED
+        ]
+        assert len(failed_events) == 1
+        assert failed_events[0].reason == "error_RuntimeError"
+        # Detail payload carries the exception message.
+        assert "network is on fire" in failed_events[0].payload["detail"]

--- a/tests/test_os_updater_state.py
+++ b/tests/test_os_updater_state.py
@@ -1,0 +1,199 @@
+"""Tests for :mod:`os_updater.state`.
+
+Covers the FSM legality table, atomic persistence, busy interlock, and
+the ``transition`` side-effects (``IDLE`` clears dispatch fields,
+``FAILED`` stamps ``last_failure_reason``).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from os_updater.state import (
+    BUSY_STATES,
+    LEGAL_TRANSITIONS,
+    SCHEMA_VERSION,
+    TransitionError,
+    UpdaterFSMState,
+    UpdaterState,
+    is_busy,
+    load_state,
+    save_state,
+    transition,
+)
+
+
+class TestUpdaterStateModel:
+    def test_defaults(self):
+        s = UpdaterState()
+        assert s.schema_version == SCHEMA_VERSION
+        assert s.fsm is UpdaterFSMState.IDLE
+        assert s.release_id is None
+        assert s.target_version is None
+        assert s.staging_dir is None
+        assert s.last_failure_reason is None
+        assert s.last_event_id == 0
+        assert isinstance(s.updated_at, str) and s.updated_at.endswith("Z")
+
+    def test_extra_keys_ignored(self):
+        raw = json.dumps({"schema_version": 1, "future_field": 42})
+        s = UpdaterState.model_validate_json(raw)
+        assert s.schema_version == 1
+
+
+class TestLoadSave:
+    def test_load_returns_default_when_missing(self, tmp_path):
+        s = load_state(tmp_path / "missing.json")
+        assert s.fsm is UpdaterFSMState.IDLE
+        assert s.last_event_id == 0
+
+    def test_load_returns_default_on_corrupt_json(self, tmp_path):
+        path = tmp_path / "state.json"
+        path.write_text("not json")
+        s = load_state(path)
+        assert s.fsm is UpdaterFSMState.IDLE
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "state.json"
+        s = UpdaterState(
+            fsm=UpdaterFSMState.DOWNLOADING,
+            release_id="rel-1",
+            target_version="1.2.3",
+            staging_dir="/data/.update/staging/rel-1",
+            last_event_id=7,
+        )
+        save_state(s, path)
+        r = load_state(path)
+        assert r.fsm is UpdaterFSMState.DOWNLOADING
+        assert r.release_id == "rel-1"
+        assert r.target_version == "1.2.3"
+        assert r.staging_dir == "/data/.update/staging/rel-1"
+        assert r.last_event_id == 7
+
+    def test_save_creates_parent_dir(self, tmp_path):
+        path = tmp_path / "nested" / "deep" / "state.json"
+        save_state(UpdaterState(), path)
+        assert path.exists()
+
+    def test_save_uses_atomic_rename(self, tmp_path, monkeypatch):
+        """A torn write would leave the daemon with no state. ``save_state``
+        must rename a tempfile into place."""
+        path = tmp_path / "state.json"
+        # Pre-populate so we can confirm the file isn't truncated mid-write.
+        path.write_text('{"schema_version": 1, "fsm": "idle"}')
+
+        import os as _os
+
+        original_replace = _os.replace
+        captured: list[tuple[str, str]] = []
+
+        def spying_replace(src, dst):
+            captured.append((str(src), str(dst)))
+            return original_replace(src, dst)
+
+        monkeypatch.setattr("os.replace", spying_replace)
+
+        s = UpdaterState(last_event_id=42)
+        save_state(s, path)
+        assert any(dst == str(path) for _, dst in captured)
+        assert load_state(path).last_event_id == 42
+
+
+class TestTransition:
+    def test_legal_transitions_table_covers_every_state(self):
+        # If we add a new state to the enum, we MUST add it to the table —
+        # otherwise transitioning out of it would raise with a misleading
+        # "no legal targets" rather than a "you forgot to wire this up" error.
+        assert set(LEGAL_TRANSITIONS.keys()) == set(UpdaterFSMState)
+
+    def test_failed_reachable_from_every_non_terminal_state(self):
+        for src in UpdaterFSMState:
+            if src is UpdaterFSMState.FAILED:
+                continue
+            if src is UpdaterFSMState.IDLE:
+                # Per plan: pre-admission rejections leave the FSM in IDLE.
+                # IDLE -> FAILED is intentionally NOT legal.
+                continue
+            assert UpdaterFSMState.FAILED in LEGAL_TRANSITIONS[src], (
+                f"{src.value} cannot fail; that breaks the orchestrator"
+            )
+
+    def test_idle_cannot_reach_failed(self):
+        """The pre-admission rejection path leaves the FSM in IDLE — so
+        IDLE -> FAILED must NOT be a legal transition (otherwise we'd be
+        tempted to mutate the FSM for things like version_floor and lose
+        the "FSM means in-flight" invariant)."""
+        assert UpdaterFSMState.FAILED not in LEGAL_TRANSITIONS[UpdaterFSMState.IDLE]
+
+    def test_happy_path_is_legal_end_to_end(self):
+        s = UpdaterState()
+        path = [
+            UpdaterFSMState.DOWNLOADING,
+            UpdaterFSMState.STAGED,
+            UpdaterFSMState.TRYBOOT_PENDING,
+            UpdaterFSMState.TRYBOOT_RUNNING,
+            UpdaterFSMState.PROMOTED_PENDING_MIGRATION,
+            UpdaterFSMState.MIGRATING,
+            UpdaterFSMState.IDLE,
+        ]
+        for target in path:
+            transition(s, target)
+            assert s.fsm is target
+
+    def test_illegal_transition_raises(self):
+        s = UpdaterState()
+        with pytest.raises(TransitionError):
+            transition(s, UpdaterFSMState.MIGRATING)
+        # State left unchanged on raise
+        assert s.fsm is UpdaterFSMState.IDLE
+
+    def test_transition_to_failed_stamps_reason(self):
+        s = UpdaterState(fsm=UpdaterFSMState.DOWNLOADING)
+        transition(s, UpdaterFSMState.FAILED, reason="signature_invalid")
+        assert s.fsm is UpdaterFSMState.FAILED
+        assert s.last_failure_reason == "signature_invalid"
+
+    def test_transition_to_idle_clears_dispatch_fields(self):
+        s = UpdaterState(
+            fsm=UpdaterFSMState.MIGRATING,
+            release_id="rel-1",
+            target_version="1.2.3",
+            staging_dir="/tmp/staging/rel-1",
+            last_failure_reason="prior",
+        )
+        transition(s, UpdaterFSMState.IDLE)
+        assert s.fsm is UpdaterFSMState.IDLE
+        assert s.release_id is None
+        assert s.target_version is None
+        assert s.staging_dir is None
+        assert s.last_failure_reason is None
+
+    def test_failed_can_only_go_to_downloading(self):
+        """FAILED is sticky until a new dispatch arrives, which restarts
+        the chain at DOWNLOADING."""
+        assert LEGAL_TRANSITIONS[UpdaterFSMState.FAILED] == frozenset(
+            {UpdaterFSMState.DOWNLOADING}
+        )
+
+
+class TestIsBusy:
+    def test_idle_not_busy(self):
+        assert not is_busy(UpdaterState(fsm=UpdaterFSMState.IDLE))
+
+    def test_failed_not_busy(self):
+        assert not is_busy(UpdaterState(fsm=UpdaterFSMState.FAILED))
+
+    def test_every_other_state_is_busy(self):
+        for st in UpdaterFSMState:
+            if st in (UpdaterFSMState.IDLE, UpdaterFSMState.FAILED):
+                continue
+            assert is_busy(UpdaterState(fsm=st)), f"{st.value} should be busy"
+
+    def test_busy_states_set_matches_is_busy(self):
+        # Belt-and-suspenders: BUSY_STATES is what plan #23 calls out as
+        # the rejection set; is_busy should mirror it exactly.
+        assert {st for st in UpdaterFSMState if is_busy(UpdaterState(fsm=st))} == set(
+            BUSY_STATES
+        )


### PR DESCRIPTION
Phase 2 of the A/B atomic OS-update plan (#544). Ships the on-device `agora-os-updater` daemon shell — FSM, dispatch parser, lifecycle-event emitter, persistent state, and an orchestrator with injection seams for sibling todos to fill.

## What this PR adds

**New `os_updater/` package:**
- `state.py` — 8-state FSM with legal-transition table (`UpdaterFSMState`, `LEGAL_TRANSITIONS`, `BUSY_STATES`). `transition()` clears dispatch fields on `IDLE` and stamps `last_failure_reason` on `FAILED`. Persists to `/data/agora/updater-state.json` via atomic rename.
- `dispatch.py` — pydantic `DispatchPayload` with regex-validated `release_id` + semver `target_version`, `extra="ignore"` for Phase 3 forward-compat fields. Wraps pydantic `ValidationError` in `DispatchPayloadError`.
- `events.py` — `LifecycleEvent` frozen dataclass, `OutboxEventSink` writing JSONL day-files keyed by `occurred_at[:10]`. `emit_event()` persists the next event_id to state **before** calling `sink.put()` so a sink raise still costs the id (at-most-once semantics for Phase 4 dedupe).
- `service.py` — `OSUpdaterService` orchestrator. `handle_dispatch()` pre-admission rejection (invalid payload / busy / version_floor) leaves the FSM in `IDLE` and emits `failed:*` / `declined:busy`. Happy path drives the FSM through `DOWNLOADING → STAGED → TRYBOOT_PENDING → TRYBOOT_RUNNING`. `recover_on_start()` resets stuck in-flight states to `FAILED`.
- `main.py` + `__main__.py` — async entrypoint that wires the service to a WPS subscriber.
- `bundle.py`, `apply.py`, `migrate.py` — placeholder stubs (raise `NotImplementedError`) so the import graph is stable while sibling todos land the real implementations.

**Systemd unit:** `systemd/agora-os-updater.service`.

**Tests** (85 cases, all green locally):
- `test_os_updater_state.py` — 19 tests (FSM table coverage, atomic rename, IDLE-clear / FAILED-stamp side effects)
- `test_os_updater_dispatch.py` — 30 cases (parametrized) covering version regex, release_id regex, URL scheme, non-Mapping payloads
- `test_os_updater_events.py` — 12 tests (monotonic ids across simulated restart, malformed-line skipping, day-file split)
- `test_os_updater_service.py` — 24 tests (version_at_least table, recover_on_start, dispatch rejection paths, happy-path FSM walk, force_downgrade)

## Phase 2 ratified sub-decisions honored

- **#17 Bundle format** — full-image tarball + minisign detached sig. `bundle.py` stub declares `BundleIntegrityError`; real parser lands in p2-bundle-format.
- **#18 WPS push only** — `main.py` documents the Phase 3 refactor to subscribe to the existing WPS connection; the Phase 2 shell opens its own client for now.
- **#19 Update window** — fully CMS-side; the daemon only reacts to dispatches it receives.
- **#20 Staging at `/data/.update/staging/`** — `DEFAULT_STAGING_ROOT` exported; cleanup hooks land in p2-stage-and-tryboot.
- **#21 `min_from_version` floor-only** — `_classify_failure` distinguishes `version_floor` from `bundle_invalid` / `signature_invalid` / etc.
- **#22 Migration runner** — `migrate.py` stub; runs post-promote only (gated by Phase 1 sentinel).
- **#23 Concurrency interlock** — `UpdaterBusyError` raised when `is_busy(state)`; emits `declined:busy` over the event sink.
- **#24 `force_downgrade`** — accepted in the dispatch payload; skips the floor check.

## Out of scope (sibling todos)

`p2-bundle-format` · `p2-signature-verify` · `p2-stage-and-tryboot` · `p2-forward-migration`

Each consumes one of the injection seams (`bundle_parser`, `signature_verifier`, `downloader`, `stager`, `tryboot_trigger`, `migrator`) documented on `OSUpdaterService.__init__`.

## Test run

```
85 passed, 1 warning in 1.16s
```