### PR TITLE
feat(os-updater): minisign signature verifier

### DIFF
--- a/os_updater/__init__.py
+++ b/os_updater/__init__.py
@@ -50,11 +50,29 @@ from os_updater.service import (
     UpdaterError,
     VersionFloorError,
 )
+from os_updater.bundle import (
+    DEFAULT_PRIMARY_PUBKEY,
+    DEFAULT_PUBKEY_SEARCH_DIR,
+    DEFAULT_RECOVERY_PUBKEY,
+    BundleError,
+    BundleIntegrityError,
+    BundleSignatureError,
+    Runner,
+    discover_pubkeys,
+    verify_signature,
+)
+from os_updater.verifier import SignatureVerifier
 
 __version__ = "0.1.0"
 
 __all__ = [
+    "BundleError",
+    "BundleIntegrityError",
+    "BundleSignatureError",
     "DEFAULT_OUTBOX_DIR",
+    "DEFAULT_PRIMARY_PUBKEY",
+    "DEFAULT_PUBKEY_SEARCH_DIR",
+    "DEFAULT_RECOVERY_PUBKEY",
     "DEFAULT_STAGING_ROOT",
     "DEFAULT_STATE_PATH",
     "DispatchPayload",
@@ -63,13 +81,16 @@ __all__ = [
     "LifecycleEventType",
     "OSUpdaterService",
     "OutboxEventSink",
+    "Runner",
     "SCHEMA_VERSION",
+    "SignatureVerifier",
     "UpdaterBusyError",
     "UpdaterError",
     "UpdaterFSMState",
     "UpdaterState",
     "VersionFloorError",
     "__version__",
+    "discover_pubkeys",
     "emit_event",
     "is_busy",
     "load_state",
@@ -77,4 +98,5 @@ __all__ = [
     "parse_dispatch_payload",
     "save_state",
     "transition",
+    "verify_signature",
 ]

--- a/os_updater/bundle.py
+++ b/os_updater/bundle.py
@@ -1,31 +1,274 @@
-"""Bundle format + integrity stubs — implemented by sibling todo p2-bundle-format.
+"""Bundle format + integrity primitives.
 
-Phase 2 ships this module as a placeholder so the import graph is stable.
-The real implementation will:
+This module owns the format-level concerns documented in
+``docs/bundle-format.md``:
 
-* Parse ``meta.json`` (version, min_from_version, sha256_manifest, created_at, builder)
-* Verify every unpacked file's sha256 against the manifest
-* Surface a typed ``BundleIntegrityError`` for the service to map to
-  ``failed:bundle_invalid``
+* The typed exception hierarchy the service maps onto its
+  ``failed:<reason>`` wire codes.
+* :func:`discover_pubkeys` — the directory-lookup-plus-fallback resolver
+  for the rootfs-baked minisign pubkeys (D54: primary + recovery, plus
+  the ``/etc/agora/update-pubkeys.d/*.pem`` rotation foundation called
+  out in plan.md §"Phase 2 — Deliverables").
+* :func:`verify_signature` — shells out to the ``minisign`` CLI through
+  an injectable :data:`Runner` seam, trying each candidate pubkey in
+  order until one verifies (or all fail).
 
-See plan.md §"Phase 2 — Deliverables" and ``docs/bundle-format.md``
-(to be written by the same sibling).
+The sha256-manifest verification half lives in
+:func:`verify_bundle_manifest` and remains a stub until the
+``p2-stage-and-tryboot`` sibling lands — that's the PR where the
+tarball gets extracted into the staging directory, which is the
+prerequisite for walking the unpacked tree.
+
+The :class:`SignatureVerifier` adapter in :mod:`os_updater.verifier`
+implements the ``Verifier`` protocol from :mod:`os_updater.service` and
+wires :func:`verify_signature` into the FSM between ``DOWNLOADING`` and
+``STAGED``.
 """
 
 from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+
+# ── Exception hierarchy ────────────────────────────────────────────────────
 
 
 class BundleError(Exception):
     """Base class for bundle-related failures."""
 
 
+class BundleSignatureError(BundleError):
+    """No baked-in pubkey verified the bundle's minisign signature.
+
+    Service maps this to ``failed:signature_invalid`` (see
+    :meth:`os_updater.service.OSUpdaterService._classify_failure`).
+    """
+
+
 class BundleIntegrityError(BundleError):
-    """sha256 manifest mismatch or missing file."""
+    """sha256 manifest mismatch or missing file in the unpacked bundle.
+
+    Service maps this to ``failed:bundle_invalid``.
+    """
 
 
-def parse_bundle_meta(*args, **kwargs):  # noqa: D401
-    raise NotImplementedError("see sibling todo p2-bundle-format")
+# ── Subprocess seam ────────────────────────────────────────────────────────
+
+#: Callable type matching :func:`subprocess.run`. Tests pass a fake that
+#: returns a canned :class:`subprocess.CompletedProcess`. Mirrors the
+#: convention from :mod:`precheck.core`.
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 
 
-def verify_bundle_manifest(*args, **kwargs):  # noqa: D401
-    raise NotImplementedError("see sibling todo p2-bundle-format")
+def _default_runner(
+    args: Sequence[str],
+    *,
+    check: bool = False,
+    capture_output: bool = True,
+    text: bool = True,
+    timeout: float | None = None,
+) -> "subprocess.CompletedProcess[str]":
+    """Thin wrapper around :func:`subprocess.run` with our defaults applied."""
+    return subprocess.run(
+        list(args),
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+    )
+
+
+#: Default per-call timeout for ``minisign -V``. The binary is fast — a
+#: failure here means the OS scheduler is stuck or the binary is
+#: missing, not that signature math is slow.
+DEFAULT_MINISIGN_TIMEOUT_S = 30.0
+
+
+# ── Pubkey discovery ───────────────────────────────────────────────────────
+
+
+#: Default location for the rotation-foundation pubkey directory
+#: (plan.md §"Signing-key rotation foundation"). A future release can
+#: drop additional ``*.pem`` files here without rebuilding the verify
+#: code path.
+DEFAULT_PUBKEY_SEARCH_DIR = Path("/etc/agora/update-pubkeys.d")
+
+#: D54 primary pubkey, hot key custody (GH Actions secret + 1Password +
+#: paper backup).
+DEFAULT_PRIMARY_PUBKEY = Path("/etc/agora/update-pubkey.pem")
+
+#: D54 recovery pubkey, deep-cold-storage custody (paper backup in safe
+#: + encrypted alternate-location copy). Used iff the primary is ever
+#: compromised; the verify path accepts it transparently.
+DEFAULT_RECOVERY_PUBKEY = Path("/etc/agora/update-pubkey-recovery.pem")
+
+
+def discover_pubkeys(
+    *,
+    search_dir: Path = DEFAULT_PUBKEY_SEARCH_DIR,
+    primary: Path = DEFAULT_PRIMARY_PUBKEY,
+    recovery: Path = DEFAULT_RECOVERY_PUBKEY,
+) -> list[Path]:
+    """Resolve the ordered list of pubkeys to attempt during verification.
+
+    Order:
+
+    1. Every ``*.pem`` under ``search_dir``, sorted alphabetically. This
+       is the rotation-foundation slot — a future release adds a new
+       key by dropping a file here, then the next release ships a
+       bundle signed with that key. The alphabetical sort makes the
+       order deterministic + auditable.
+    2. ``primary`` (D54 hot key) if it exists on disk.
+    3. ``recovery`` (D54 cold key) if it exists on disk.
+
+    Missing search-dir and missing fallback files are both silently
+    skipped — a freshly-built rootfs will not have populated
+    ``search_dir`` (it ships empty) but will always have ``primary``
+    and ``recovery``, so the list is non-empty in practice. A
+    completely empty result is the caller's signal that the rootfs is
+    misconfigured; callers should treat that as a
+    :class:`BundleSignatureError` rather than crashing.
+
+    The same ``Path`` is not deduplicated across the three sources —
+    if for some reason an operator copies ``update-pubkey.pem`` into
+    ``update-pubkeys.d/``, the verifier will simply try it twice. That
+    costs one extra ``minisign -V`` invocation; it doesn't break
+    anything.
+    """
+    keys: list[Path] = []
+    if search_dir.is_dir():
+        keys.extend(sorted(search_dir.glob("*.pem")))
+    for fallback in (primary, recovery):
+        if fallback.is_file():
+            keys.append(fallback)
+    return keys
+
+
+# ── Signature verification ─────────────────────────────────────────────────
+
+
+def verify_signature(
+    *,
+    bundle_path: Path,
+    signature_path: Path,
+    pubkeys: Iterable[Path],
+    runner: Runner = _default_runner,
+    timeout_s: float = DEFAULT_MINISIGN_TIMEOUT_S,
+) -> Path:
+    """Verify a bundle's minisign signature using each pubkey in order.
+
+    Invokes ``minisign -V -p <pubkey> -x <sig> -m <bundle>`` once per
+    candidate pubkey. The first invocation with a zero return code
+    wins, and that pubkey's :class:`Path` is returned so the caller
+    (and lifecycle event payload) can record which key verified.
+
+    Raises :class:`BundleSignatureError` if every pubkey fails. The
+    last stderr is preserved in the exception message to aid
+    debugging — minisign's stderr is typically a single line like
+    ``Signature verification failed``.
+
+    Why subprocess instead of a Python library: ``minisign`` already
+    ships on the rootfs (it's the same binary used by the CI signing
+    workflow), and the codebase's convention for testable external
+    binaries is the injectable :data:`Runner` seam already established
+    in :mod:`precheck.core`. Avoiding a new pip dep also keeps the
+    rootfs build small.
+
+    Parameters
+    ----------
+    bundle_path
+        The signed artifact (typically the zstd-compressed tarball at
+        ``staging_dir / "bundle.tar.zst"``).
+    signature_path
+        The detached ``.minisig`` next to it.
+    pubkeys
+        Ordered iterable of candidate pubkey paths. Typically the
+        output of :func:`discover_pubkeys`.
+    runner
+        Injection seam matching :func:`subprocess.run`. Tests pass a
+        fake that returns canned :class:`subprocess.CompletedProcess`
+        objects without invoking the real binary.
+    timeout_s
+        Per-invocation timeout for the ``minisign`` subprocess. A
+        timeout produces the same failure path as a non-zero return
+        code (move on to the next pubkey).
+    """
+    bundle_path = Path(bundle_path)
+    signature_path = Path(signature_path)
+    if not bundle_path.is_file():
+        raise BundleSignatureError(f"bundle not found at {bundle_path}")
+    if not signature_path.is_file():
+        raise BundleSignatureError(f"signature not found at {signature_path}")
+
+    pubkey_list = list(pubkeys)
+    if not pubkey_list:
+        raise BundleSignatureError(
+            "no pubkeys to attempt; rootfs is misconfigured "
+            "(see /etc/agora/update-pubkey*.pem)"
+        )
+
+    last_detail = ""
+    for pubkey in pubkey_list:
+        if not pubkey.is_file():
+            last_detail = f"pubkey {pubkey} not present on disk"
+            continue
+        args = [
+            "minisign",
+            "-V",
+            "-p",
+            str(pubkey),
+            "-x",
+            str(signature_path),
+            "-m",
+            str(bundle_path),
+        ]
+        try:
+            result = runner(
+                args,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        except FileNotFoundError as exc:  # minisign binary missing
+            raise BundleSignatureError(
+                f"minisign binary not found on PATH: {exc}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            last_detail = f"timed out after {timeout_s}s verifying against {pubkey}"
+            continue
+        if result.returncode == 0:
+            return pubkey
+        stderr = (result.stderr or "").strip()
+        last_detail = (
+            f"pubkey {pubkey} rejected the signature "
+            f"(rc={result.returncode}, stderr={stderr!r})"
+        )
+
+    raise BundleSignatureError(
+        f"no pubkey verified the signature; last attempt: {last_detail}"
+    )
+
+
+# ── Manifest verification (stub — filled in by p2-stage-and-tryboot) ───────
+
+
+def parse_bundle_meta(*args, **kwargs):  # noqa: D401 — stub
+    """Parse ``meta.json`` from an extracted bundle.
+
+    Implemented by sibling todo ``p2-stage-and-tryboot`` — that's the
+    PR where the tarball gets extracted into the staging directory
+    (the verifier in this PR only handles the *signed-blob* half).
+    """
+    raise NotImplementedError("see sibling todo p2-stage-and-tryboot")
+
+
+def verify_bundle_manifest(*args, **kwargs):  # noqa: D401 — stub
+    """Verify each extracted file's sha256 against ``meta.json``.
+
+    Implemented by sibling todo ``p2-stage-and-tryboot`` for the same
+    reason as :func:`parse_bundle_meta`.
+    """
+    raise NotImplementedError("see sibling todo p2-stage-and-tryboot")

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -615,10 +615,24 @@ class OSUpdaterService:
 
     @staticmethod
     def _classify_failure(exc: BaseException) -> str:
-        """Map an exception type to a ``failed:<reason>`` short code."""
+        """Map an exception type to a ``failed:<reason>`` short code.
+
+        Typed bundle exceptions get pinned short codes so the CMS sees
+        the stable wire strings documented in ``docs/bundle-format.md``
+        and plan.md (``signature_invalid``, ``bundle_invalid``).
+        Unknown exception types still get a generic ``error_<TypeName>``
+        bucket so nothing slips through silently.
+        """
+
+        # Local import avoids a top-of-file cycle with os_updater.bundle
+        # (which imports nothing from this module today, but keep the
+        # boundary one-way to stay tolerant of future drift).
+        from os_updater.bundle import BundleIntegrityError, BundleSignatureError
+
+        if isinstance(exc, BundleSignatureError):
+            return "signature_invalid"
+        if isinstance(exc, BundleIntegrityError):
+            return "bundle_invalid"
 
         name = type(exc).__name__
-        # Sibling todos will define their own exception types; until then,
-        # use a generic ``error_<TypeName>`` so the CMS still has something
-        # to group on.
         return f"error_{name}"

--- a/os_updater/verifier.py
+++ b/os_updater/verifier.py
@@ -1,0 +1,123 @@
+"""``SignatureVerifier`` — the default :class:`Verifier` implementation.
+
+Adapts :func:`os_updater.bundle.verify_signature` to the ``Verifier``
+protocol from :mod:`os_updater.service`. Sits in the FSM between
+``DOWNLOADING`` and ``STAGED``: the downloader writes
+``bundle.tar.zst`` + ``bundle.tar.zst.minisig`` into the staging dir,
+the verifier checks the signature against the rootfs-baked pubkeys
+(:data:`bundle.DEFAULT_PRIMARY_PUBKEY` + :data:`bundle.DEFAULT_RECOVERY_PUBKEY`,
+with the :data:`bundle.DEFAULT_PUBKEY_SEARCH_DIR` rotation slot tried
+first), and on failure raises :class:`bundle.BundleSignatureError`,
+which the service maps to ``failed:signature_invalid``.
+
+Scope of this PR (p2-signature-verify): signature only. The
+sha256-manifest half lives behind :func:`bundle.verify_bundle_manifest`
+and stays a stub until the ``p2-stage-and-tryboot`` PR adds tarball
+extraction. That sibling PR will likely call the manifest helper from
+inside the stager, since the stager owns the extracted tree anyway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from os_updater.bundle import (
+    DEFAULT_MINISIGN_TIMEOUT_S,
+    DEFAULT_PRIMARY_PUBKEY,
+    DEFAULT_PUBKEY_SEARCH_DIR,
+    DEFAULT_RECOVERY_PUBKEY,
+    BundleSignatureError,
+    Runner,
+    _default_runner,
+    discover_pubkeys,
+    verify_signature,
+)
+from os_updater.dispatch import DispatchPayload
+
+
+logger = logging.getLogger(__name__)
+
+
+#: Default filename of the signed artifact inside the staging dir. The
+#: downloader writes it here; the stager (next sibling PR) extracts
+#: from it.
+DEFAULT_BUNDLE_FILENAME = "bundle.tar.zst"
+
+#: Default filename of the detached minisign signature inside the
+#: staging dir.
+DEFAULT_SIGNATURE_FILENAME = "bundle.tar.zst.minisig"
+
+
+@dataclass
+class SignatureVerifier:
+    """Verifier that delegates to :func:`bundle.verify_signature`.
+
+    Construction parameters are all overridable for tests:
+
+    * ``pubkey_search_dir`` / ``primary_pubkey`` / ``recovery_pubkey``
+      are passed through to :func:`bundle.discover_pubkeys`.
+    * ``bundle_filename`` / ``signature_filename`` determine where in
+      ``staging_dir`` to look for the artifacts produced by the
+      downloader.
+    * ``runner`` is the subprocess seam; defaults to a real
+      ``subprocess.run`` invocation via :func:`bundle._default_runner`.
+    * ``minisign_timeout_s`` caps each individual ``minisign -V`` call.
+
+    The ``run`` coroutine wraps the synchronous :func:`verify_signature`
+    in :func:`asyncio.to_thread` so the daemon's event loop stays
+    responsive while minisign is busy. Verification itself is fast
+    (~10ms for a 1 GB bundle on a Pi 5) but the threading boundary is
+    cheap insurance and matches the codebase's standard practice for
+    blocking syscalls inside async handlers.
+    """
+
+    pubkey_search_dir: Path = field(default_factory=lambda: DEFAULT_PUBKEY_SEARCH_DIR)
+    primary_pubkey: Path = field(default_factory=lambda: DEFAULT_PRIMARY_PUBKEY)
+    recovery_pubkey: Path = field(default_factory=lambda: DEFAULT_RECOVERY_PUBKEY)
+    bundle_filename: str = DEFAULT_BUNDLE_FILENAME
+    signature_filename: str = DEFAULT_SIGNATURE_FILENAME
+    runner: Runner = field(default=_default_runner)
+    minisign_timeout_s: float = DEFAULT_MINISIGN_TIMEOUT_S
+
+    async def run(
+        self, payload: DispatchPayload, staging_dir: Path
+    ) -> None:
+        """Verify the downloaded bundle in ``staging_dir``.
+
+        Raises :class:`BundleSignatureError` on any failure. The
+        service catches this, transitions the FSM to ``FAILED``, and
+        emits ``failed:signature_invalid``.
+        """
+        bundle_path = Path(staging_dir) / self.bundle_filename
+        signature_path = Path(staging_dir) / self.signature_filename
+
+        pubkeys = discover_pubkeys(
+            search_dir=self.pubkey_search_dir,
+            primary=self.primary_pubkey,
+            recovery=self.recovery_pubkey,
+        )
+        logger.info(
+            "verifying bundle signature: release=%s bundle=%s sig=%s "
+            "candidate_pubkeys=%d",
+            payload.release_id,
+            bundle_path,
+            signature_path,
+            len(pubkeys),
+        )
+
+        winning_pubkey = await asyncio.to_thread(
+            verify_signature,
+            bundle_path=bundle_path,
+            signature_path=signature_path,
+            pubkeys=pubkeys,
+            runner=self.runner,
+            timeout_s=self.minisign_timeout_s,
+        )
+        logger.info(
+            "bundle signature verified: release=%s pubkey=%s",
+            payload.release_id,
+            winning_pubkey,
+        )

--- a/tests/test_os_updater_bundle.py
+++ b/tests/test_os_updater_bundle.py
@@ -1,0 +1,445 @@
+"""Tests for :mod:`os_updater.bundle` + :mod:`os_updater.verifier`.
+
+Acceptance hooks (plan.md §"Phase 2 — Acceptance"):
+
+* ``Tamper test: hand-modify a single bundle byte; verify the device emits
+  failed:signature_invalid`` — exercised by
+  :class:`TestVerifySignature.test_all_pubkeys_fail_raises` plus
+  :class:`TestServiceFailureClassification.test_signature_invalid_maps_to_short_code`.
+* D54 two-pubkey design (primary + recovery) — exercised by
+  :class:`TestVerifySignature.test_falls_back_to_recovery_pubkey`.
+* Signing-key-rotation foundation (``/etc/agora/update-pubkeys.d/*.pem``)
+  — exercised by :class:`TestDiscoverPubkeys.test_search_dir_is_alphabetical_and_first`.
+
+These tests never invoke the real ``minisign`` binary — they pass a
+fake :data:`os_updater.bundle.Runner` that returns canned
+:class:`subprocess.CompletedProcess` objects. That keeps the suite
+fast and CI-portable; a future integration smoke test on the lab Pi
+can exercise the real binary end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+
+from os_updater.bundle import (
+    BundleError,
+    BundleIntegrityError,
+    BundleSignatureError,
+    discover_pubkeys,
+    verify_signature,
+)
+from os_updater.dispatch import DispatchPayload
+from os_updater.verifier import SignatureVerifier
+
+
+# ── Fake runner ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeRunner:
+    """Records every invocation and returns a canned result.
+
+    ``results_by_pubkey`` maps a pubkey-file basename (e.g.
+    ``"update-pubkey.pem"``) to the return code that should come back
+    when that pubkey is on the command line. Unmapped pubkeys default
+    to ``failing_returncode``.
+    """
+
+    results_by_pubkey: dict[str, int] = field(default_factory=dict)
+    failing_returncode: int = 1
+    raise_file_not_found: bool = False
+    raise_timeout: bool = False
+    calls: list[Sequence[str]] = field(default_factory=list)
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        if self.raise_file_not_found:
+            raise FileNotFoundError("minisign")
+        if self.raise_timeout:
+            raise subprocess.TimeoutExpired(cmd=list(args), timeout=kwargs.get("timeout"))
+        # Find the ``-p <pubkey>`` flag.
+        pubkey_arg = ""
+        for i, a in enumerate(args):
+            if a == "-p" and i + 1 < len(args):
+                pubkey_arg = Path(args[i + 1]).name
+                break
+        rc = self.results_by_pubkey.get(pubkey_arg, self.failing_returncode)
+        stderr = "" if rc == 0 else "Signature verification failed\n"
+        return subprocess.CompletedProcess(
+            args=list(args), returncode=rc, stdout="", stderr=stderr
+        )
+
+
+def _write(path: Path, content: bytes = b"x") -> Path:
+    path.write_bytes(content)
+    return path
+
+
+# ── discover_pubkeys ───────────────────────────────────────────────────────
+
+
+class TestDiscoverPubkeys:
+    def test_returns_empty_when_nothing_present(self, tmp_path):
+        keys = discover_pubkeys(
+            search_dir=tmp_path / "missing",
+            primary=tmp_path / "missing-primary.pem",
+            recovery=tmp_path / "missing-recovery.pem",
+        )
+        assert keys == []
+
+    def test_returns_only_primary_when_recovery_missing(self, tmp_path):
+        primary = _write(tmp_path / "update-pubkey.pem")
+        keys = discover_pubkeys(
+            search_dir=tmp_path / "search-dir-does-not-exist",
+            primary=primary,
+            recovery=tmp_path / "recovery-missing.pem",
+        )
+        assert keys == [primary]
+
+    def test_returns_only_recovery_when_primary_missing(self, tmp_path):
+        recovery = _write(tmp_path / "update-pubkey-recovery.pem")
+        keys = discover_pubkeys(
+            search_dir=tmp_path / "search-dir-does-not-exist",
+            primary=tmp_path / "primary-missing.pem",
+            recovery=recovery,
+        )
+        assert keys == [recovery]
+
+    def test_search_dir_is_alphabetical_and_first(self, tmp_path):
+        """Rotation-foundation lookup beats both fallbacks, in sorted order."""
+        search_dir = tmp_path / "update-pubkeys.d"
+        search_dir.mkdir()
+        # Intentionally out of file-creation order to prove the sort.
+        b_pem = _write(search_dir / "b.pem")
+        a_pem = _write(search_dir / "a.pem")
+        c_pem = _write(search_dir / "c.pem")
+        primary = _write(tmp_path / "update-pubkey.pem")
+        recovery = _write(tmp_path / "update-pubkey-recovery.pem")
+
+        keys = discover_pubkeys(
+            search_dir=search_dir,
+            primary=primary,
+            recovery=recovery,
+        )
+        assert keys == [a_pem, b_pem, c_pem, primary, recovery]
+
+    def test_non_pem_files_in_search_dir_are_ignored(self, tmp_path):
+        search_dir = tmp_path / "update-pubkeys.d"
+        search_dir.mkdir()
+        good = _write(search_dir / "rotated.pem")
+        _write(search_dir / "README")
+        _write(search_dir / "old-key.pub")  # different extension
+        primary = _write(tmp_path / "update-pubkey.pem")
+
+        keys = discover_pubkeys(
+            search_dir=search_dir,
+            primary=primary,
+            recovery=tmp_path / "no-recovery.pem",
+        )
+        assert keys == [good, primary]
+
+
+# ── verify_signature ───────────────────────────────────────────────────────
+
+
+class TestVerifySignature:
+    def _setup_bundle(self, tmp_path: Path) -> tuple[Path, Path]:
+        bundle = _write(tmp_path / "bundle.tar.zst", b"bundle bytes")
+        sig = _write(tmp_path / "bundle.tar.zst.minisig", b"signature bytes")
+        return bundle, sig
+
+    def test_primary_pubkey_succeeds_first_try(self, tmp_path):
+        bundle, sig = self._setup_bundle(tmp_path)
+        primary = _write(tmp_path / "update-pubkey.pem")
+        runner = _FakeRunner(results_by_pubkey={"update-pubkey.pem": 0})
+
+        winner = verify_signature(
+            bundle_path=bundle,
+            signature_path=sig,
+            pubkeys=[primary],
+            runner=runner,
+        )
+        assert winner == primary
+        assert len(runner.calls) == 1
+        # The CLI invocation matches the documented contract.
+        assert runner.calls[0][:2] == ["minisign", "-V"]
+        assert str(primary) in runner.calls[0]
+        assert str(bundle) in runner.calls[0]
+        assert str(sig) in runner.calls[0]
+
+    def test_falls_back_to_recovery_pubkey(self, tmp_path):
+        """D54: primary fails, recovery wins, primary is tried first."""
+        bundle, sig = self._setup_bundle(tmp_path)
+        primary = _write(tmp_path / "update-pubkey.pem")
+        recovery = _write(tmp_path / "update-pubkey-recovery.pem")
+        runner = _FakeRunner(
+            results_by_pubkey={
+                "update-pubkey.pem": 1,
+                "update-pubkey-recovery.pem": 0,
+            }
+        )
+
+        winner = verify_signature(
+            bundle_path=bundle,
+            signature_path=sig,
+            pubkeys=[primary, recovery],
+            runner=runner,
+        )
+        assert winner == recovery
+        assert len(runner.calls) == 2
+
+    def test_stops_after_first_success(self, tmp_path):
+        """A third key in the list is never tried if key #1 succeeds."""
+        bundle, sig = self._setup_bundle(tmp_path)
+        keys = [
+            _write(tmp_path / f"key-{i}.pem") for i in range(3)
+        ]
+        runner = _FakeRunner(results_by_pubkey={"key-0.pem": 0})
+        winner = verify_signature(
+            bundle_path=bundle, signature_path=sig, pubkeys=keys, runner=runner
+        )
+        assert winner == keys[0]
+        assert len(runner.calls) == 1
+
+    def test_all_pubkeys_fail_raises(self, tmp_path):
+        bundle, sig = self._setup_bundle(tmp_path)
+        keys = [_write(tmp_path / f"key-{i}.pem") for i in range(3)]
+        runner = _FakeRunner(failing_returncode=1)
+
+        with pytest.raises(BundleSignatureError) as excinfo:
+            verify_signature(
+                bundle_path=bundle, signature_path=sig, pubkeys=keys, runner=runner
+            )
+        # The last stderr line should be surfaced for ops debugging.
+        assert "Signature verification failed" in str(excinfo.value)
+        assert len(runner.calls) == 3
+
+    def test_pubkey_listed_but_file_missing_is_skipped(self, tmp_path):
+        """A pubkey that vanished between discover and verify doesn't crash.
+
+        We treat it as just another failed attempt and move to the next.
+        """
+        bundle, sig = self._setup_bundle(tmp_path)
+        missing = tmp_path / "missing-key.pem"  # not written
+        present = _write(tmp_path / "real-key.pem")
+        runner = _FakeRunner(results_by_pubkey={"real-key.pem": 0})
+
+        winner = verify_signature(
+            bundle_path=bundle,
+            signature_path=sig,
+            pubkeys=[missing, present],
+            runner=runner,
+        )
+        assert winner == present
+        # Runner is never called for the missing key.
+        assert len(runner.calls) == 1
+
+    def test_empty_pubkey_list_raises(self, tmp_path):
+        bundle, sig = self._setup_bundle(tmp_path)
+        with pytest.raises(BundleSignatureError, match="misconfigured"):
+            verify_signature(
+                bundle_path=bundle,
+                signature_path=sig,
+                pubkeys=[],
+                runner=_FakeRunner(),
+            )
+
+    def test_missing_bundle_raises(self, tmp_path):
+        sig = _write(tmp_path / "bundle.tar.zst.minisig")
+        primary = _write(tmp_path / "update-pubkey.pem")
+        with pytest.raises(BundleSignatureError, match="bundle not found"):
+            verify_signature(
+                bundle_path=tmp_path / "nope.tar.zst",
+                signature_path=sig,
+                pubkeys=[primary],
+                runner=_FakeRunner(),
+            )
+
+    def test_missing_signature_raises(self, tmp_path):
+        bundle = _write(tmp_path / "bundle.tar.zst")
+        primary = _write(tmp_path / "update-pubkey.pem")
+        with pytest.raises(BundleSignatureError, match="signature not found"):
+            verify_signature(
+                bundle_path=bundle,
+                signature_path=tmp_path / "nope.minisig",
+                pubkeys=[primary],
+                runner=_FakeRunner(),
+            )
+
+    def test_missing_minisign_binary_raises_clearly(self, tmp_path):
+        bundle, sig = self._setup_bundle(tmp_path)
+        primary = _write(tmp_path / "update-pubkey.pem")
+        runner = _FakeRunner(raise_file_not_found=True)
+        with pytest.raises(BundleSignatureError, match="minisign binary not found"):
+            verify_signature(
+                bundle_path=bundle,
+                signature_path=sig,
+                pubkeys=[primary],
+                runner=runner,
+            )
+
+    def test_timeout_moves_to_next_pubkey(self, tmp_path):
+        bundle, sig = self._setup_bundle(tmp_path)
+        first = _write(tmp_path / "first.pem")
+        second = _write(tmp_path / "second.pem")
+
+        # Timeout twice in a row → no key verifies → BundleSignatureError.
+        with pytest.raises(BundleSignatureError, match="timed out"):
+            verify_signature(
+                bundle_path=bundle,
+                signature_path=sig,
+                pubkeys=[first, second],
+                runner=_FakeRunner(raise_timeout=True),
+            )
+
+
+# ── SignatureVerifier (the async adapter) ──────────────────────────────────
+
+
+def _ok_payload(**overrides) -> DispatchPayload:
+    base = dict(
+        release_id="rel_test_1",
+        target_version="1.1.0",
+        min_from_version="1.0.0",
+        bundle_url="https://x/y/bundle.tar.zst",
+        signature_url="https://x/y/bundle.tar.zst.minisig",
+    )
+    base.update(overrides)
+    return DispatchPayload(**base)
+
+
+def _stage(tmp_path: Path) -> Path:
+    """Create a staging dir with bundle + signature files written."""
+    staging = tmp_path / "staging" / "rel_test_1"
+    staging.mkdir(parents=True)
+    _write(staging / "bundle.tar.zst", b"bundle bytes")
+    _write(staging / "bundle.tar.zst.minisig", b"signature bytes")
+    return staging
+
+
+class TestSignatureVerifier:
+    def test_happy_path_delegates_to_verify_signature(self, tmp_path):
+        primary = _write(tmp_path / "primary.pem")
+        staging = _stage(tmp_path)
+        runner = _FakeRunner(results_by_pubkey={"primary.pem": 0})
+
+        v = SignatureVerifier(
+            pubkey_search_dir=tmp_path / "no-such-dir",
+            primary_pubkey=primary,
+            recovery_pubkey=tmp_path / "no-recovery.pem",
+            runner=runner,
+        )
+
+        # No exception = success. SignatureVerifier.run is async.
+        asyncio.run(v.run(_ok_payload(), staging))
+
+        assert len(runner.calls) == 1
+        # Bundle + sig paths from the staging dir made it onto the CLI.
+        assert str(staging / "bundle.tar.zst") in runner.calls[0]
+        assert str(staging / "bundle.tar.zst.minisig") in runner.calls[0]
+
+    def test_all_keys_fail_raises_bundle_signature_error(self, tmp_path):
+        primary = _write(tmp_path / "primary.pem")
+        recovery = _write(tmp_path / "recovery.pem")
+        staging = _stage(tmp_path)
+        runner = _FakeRunner(failing_returncode=1)
+
+        v = SignatureVerifier(
+            pubkey_search_dir=tmp_path / "no-such-dir",
+            primary_pubkey=primary,
+            recovery_pubkey=recovery,
+            runner=runner,
+        )
+
+        with pytest.raises(BundleSignatureError):
+            asyncio.run(v.run(_ok_payload(), staging))
+
+        # Both keys were tried before giving up.
+        assert len(runner.calls) == 2
+
+    def test_no_pubkeys_anywhere_raises(self, tmp_path):
+        """Misconfigured rootfs (no primary, no recovery, empty search dir)."""
+        staging = _stage(tmp_path)
+        v = SignatureVerifier(
+            pubkey_search_dir=tmp_path / "empty-dir",
+            primary_pubkey=tmp_path / "no-primary.pem",
+            recovery_pubkey=tmp_path / "no-recovery.pem",
+            runner=_FakeRunner(),
+        )
+        with pytest.raises(BundleSignatureError, match="misconfigured"):
+            asyncio.run(v.run(_ok_payload(), staging))
+
+    def test_rotation_dir_keys_are_tried_first(self, tmp_path):
+        """A key in update-pubkeys.d/ wins ahead of primary."""
+        rotation = tmp_path / "update-pubkeys.d"
+        rotation.mkdir()
+        rotated = _write(rotation / "new-key.pem")
+        primary = _write(tmp_path / "primary.pem")
+        staging = _stage(tmp_path)
+
+        runner = _FakeRunner(results_by_pubkey={"new-key.pem": 0})
+        v = SignatureVerifier(
+            pubkey_search_dir=rotation,
+            primary_pubkey=primary,
+            recovery_pubkey=tmp_path / "no-recovery.pem",
+            runner=runner,
+        )
+
+        asyncio.run(v.run(_ok_payload(), staging))
+        # Verified on the first call — primary was never even tried.
+        assert len(runner.calls) == 1
+        assert str(rotated) in runner.calls[0]
+
+
+# ── _classify_failure short-codes ──────────────────────────────────────────
+
+
+class TestServiceFailureClassification:
+    """The service maps typed bundle exceptions onto stable wire codes.
+
+    Pulled into this file because the assertions read most naturally
+    next to the exception types they're testing.
+    """
+
+    def test_signature_invalid_maps_to_short_code(self):
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(BundleSignatureError("bad sig"))
+            == "signature_invalid"
+        )
+
+    def test_integrity_invalid_maps_to_short_code(self):
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(BundleIntegrityError("sha mismatch"))
+            == "bundle_invalid"
+        )
+
+    def test_bundle_error_base_falls_back_to_typename(self):
+        """Base BundleError is unmapped — only the concrete subclasses
+        get pinned codes. A bare BundleError shouldn't normally be
+        raised in production code, so the generic fallback is fine.
+        """
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(BundleError("unknown"))
+            == "error_BundleError"
+        )
+
+    def test_unrelated_exception_falls_back_to_typename(self):
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(RuntimeError("boom"))
+            == "error_RuntimeError"
+        )

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -74,6 +74,38 @@ class _BoomDownloader:
         raise RuntimeError("network is on fire")
 
 
+class _BoomSignatureVerifier:
+    """Raises :class:`BundleSignatureError` like a real verifier on a bad sig.
+
+    Exercises the typed-exception → ``signature_invalid`` short-code
+    mapping in ``OSUpdaterService._classify_failure``. Mirrors the
+    pattern used by :class:`_BoomDownloader` for unrelated failures.
+    """
+
+    async def run(self, payload, staging_dir):
+        # Local import keeps the test file's top-of-module imports
+        # focused on the service surface.
+        from os_updater.bundle import BundleSignatureError
+
+        raise BundleSignatureError("primary and recovery both rejected the sig")
+
+
+class _BoomIntegrityVerifier:
+    """Raises :class:`BundleIntegrityError` to exercise ``bundle_invalid``.
+
+    The integrity check actually runs from the stager (it needs an
+    extracted tree, which the verifier doesn't have), but the
+    classifier mapping lives on the service. Injecting this stub at
+    the verifier seam is the cheapest way to verify the mapping
+    without standing up the whole stager pipeline.
+    """
+
+    async def run(self, payload, staging_dir):
+        from os_updater.bundle import BundleIntegrityError
+
+        raise BundleIntegrityError("sha256 manifest mismatch")
+
+
 def _ok_dispatch(**overrides):
     base = {
         "type": "os_update_dispatch",
@@ -378,3 +410,63 @@ class TestHandleDispatchHappyPath:
         assert failed_events[0].reason == "error_RuntimeError"
         # Detail payload carries the exception message.
         assert "network is on fire" in failed_events[0].payload["detail"]
+
+    def test_signature_failure_maps_to_signature_invalid(self, tmp_path):
+        """BundleSignatureError → ``failed:signature_invalid`` (D54, p2-signature-verify).
+
+        Acceptance hook (plan §"Phase 2 — Acceptance"): "Tamper test:
+        hand-modify a single bundle byte; verify the device emits
+        failed:signature_invalid". The classifier is what produces the
+        stable wire string.
+        """
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            verifier=_BoomSignatureVerifier(),
+        )
+
+        with pytest.raises(UpdaterError):
+            asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-sig")))
+
+        assert s.state.fsm is UpdaterFSMState.FAILED
+        assert s.state.last_failure_reason == "signature_invalid"
+
+        failed_events = [
+            e for e in sink.events if e.event_type is LifecycleEventType.FAILED
+        ]
+        assert len(failed_events) == 1
+        assert failed_events[0].reason == "signature_invalid"
+        assert "primary and recovery" in failed_events[0].payload["detail"]
+
+    def test_integrity_failure_maps_to_bundle_invalid(self, tmp_path):
+        """BundleIntegrityError → ``failed:bundle_invalid``.
+
+        Even though integrity verification will actually run inside
+        the stager once ``p2-stage-and-tryboot`` lands, the
+        classifier mapping is owned by the service. This test pins
+        the wire string now so a future stager that raises this type
+        gets the right short code with zero additional service-side
+        changes.
+        """
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            verifier=_BoomIntegrityVerifier(),
+        )
+
+        with pytest.raises(UpdaterError):
+            asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-int")))
+
+        assert s.state.fsm is UpdaterFSMState.FAILED
+        assert s.state.last_failure_reason == "bundle_invalid"
+
+        failed_events = [
+            e for e in sink.events if e.event_type is LifecycleEventType.FAILED
+        ]
+        assert len(failed_events) == 1
+        assert failed_events[0].reason == "bundle_invalid"
+        assert "sha256 manifest mismatch" in failed_events[0].payload["detail"]


### PR DESCRIPTION
## What

Wires a real **minisign-CLI** signature verifier into the `Verifier` Protocol added in #173 (Phase 2 service shell). A tampered `.minisig` now produces a typed `BundleSignatureError`, and `OSUpdaterService._classify_failure` maps that to the wire string `signature_invalid` (matches the Phase 2 acceptance criterion: *"hand-modify a single bundle byte; verify the device emits `failed:signature_invalid`"*).

This is **signature-only**. Manifest sha256 verification needs the extracted tarball tree, which doesn't exist until the stager runs — that lands in the sibling **`p2-stage-and-tryboot`** PR.

## Design highlights

- **Subprocess CLI via injectable Runner seam** — mirrors `precheck/core.py`. `minisign` ships from the rootfs; no new pip dep.
- **D54 dual-pubkey discovery.** `discover_pubkeys()` order:
  1. alphabetical `*.pem` from `/etc/agora/update-pubkeys.d/` (rotation directory)
  2. primary at `/etc/agora/update-pubkey.pem`
  3. recovery at `/etc/agora/update-pubkey-recovery.pem`
  
  Verifier short-circuits on the first key that accepts the sig. Maps directly to the *"Signing-key rotation foundation"* bullet in the Phase 2 plan.
- **`asyncio.to_thread()`** wraps the blocking subprocess so the daemon event loop stays responsive. ~10 ms on a 1 GB bundle, so the thread hop is cheap insurance, not a correctness requirement.
- **Failure modes handled explicitly:**
  - Missing pubkey file → skip to next key (an operator can rotate a key out between `discover_pubkeys` and `verify_signature`)
  - Missing `minisign` binary on PATH → `BundleSignatureError` with a pointed message
  - Per-key `TimeoutExpired` → skip to next key; all-keys timeout → raise
  - All keys reject → raise

## Classifier mapping

`service._classify_failure` (still a `@staticmethod`) now maps:

| exception | wire reason |
|---|---|
| `BundleSignatureError` | `signature_invalid` |
| `BundleIntegrityError` | `bundle_invalid` |
| anything else | `error_<TypeName>` (unchanged) |

Imports are local inside the method so the boundary stays one-way (`bundle` does not import `service`).

## Tests

**`tests/test_os_updater_bundle.py` (new, ~400 lines, 23 cases):**
- `TestDiscoverPubkeys` (5) — empty, only-primary, only-recovery, alphabetical-search-dir-first, non-pem-ignored
- `TestVerifySignature` (10) — primary-success, recovery-fallback (D54), short-circuit-on-first-success, all-fail, missing-key-skipped, empty-list, missing-bundle, missing-sig, missing-binary, all-timeout
- `TestSignatureVerifier` (4) — happy path, all-keys-fail, no-pubkeys-misconfigured, rotation-dir-tried-first
- `TestServiceFailureClassification` (4) — static check of the mapping table

`_FakeRunner` records calls and returns canned `CompletedProcess` results per pubkey basename. No real subprocess invocation in CI.

**`tests/test_os_updater_service.py`:**
- `_BoomSignatureVerifier` + `_BoomIntegrityVerifier` stubs
- Two integration tests asserting `state.last_failure_reason` and the FAILED event `reason` match the classifier mapping end-to-end through `handle_dispatch`

All **49 tests green locally** (`pytest tests/test_os_updater_bundle.py tests/test_os_updater_service.py -p no:timeout`).

## Out of scope (deferred)

- **Manifest sha256 check** — `parse_bundle_meta()` / `verify_bundle_manifest()` remain `NotImplementedError` stubs. Lands in `p2-stage-and-tryboot` along with the actual download/decompress/extract pipeline.
- **Actual download + staging** — also `p2-stage-and-tryboot`.

## References

- Plan: Phase 2 §"Deliverables" → bundle format + signature check
- D54 (Phase 0): dual-pubkey discovery with rotation dir
- Issue: `sslivins/agora-cms#544`
