### PR TITLE
feat(os-updater): manual stage CLI (python -m os_updater stage)

### DIFF
--- a/os_updater/__main__.py
+++ b/os_updater/__main__.py
@@ -1,8 +1,14 @@
-"""Allow ``python -m os_updater`` to run the daemon."""
+"""Allow ``python -m os_updater`` to run the CLI dispatcher.
+
+The dispatcher (see :mod:`os_updater.cli`) routes the ``stage`` and
+``daemon`` subcommands. With no subcommand, it falls through to the
+daemon entry point so the existing systemd unit (which invokes
+``python3 -m os_updater`` with no args) keeps working unchanged.
+"""
 
 from __future__ import annotations
 
-from os_updater.main import main
+from os_updater.cli import main
 
 
 if __name__ == "__main__":

--- a/os_updater/cli.py
+++ b/os_updater/cli.py
@@ -1,0 +1,397 @@
+"""Top-level command dispatcher for ``python -m os_updater``.
+
+``os_updater`` ships two operator-facing entrypoints:
+
+``daemon`` (default)
+    The long-running WPS-driven update service. Invoked by
+    ``systemd/agora-os-updater.service`` as ``python3 -m os_updater``.
+    Implementation lives in :func:`os_updater.main.main`.
+
+``stage <bundle>``
+    A break-glass / QA tool that installs a locally-resident bundle
+    into the inactive slot and (optionally) triggers tryboot. This
+    bypasses the CMS dispatch + download + signature-verify phases —
+    use it for:
+
+    - Field recovery when a Pi can't reach CMS
+    - Pre-release QA validation of a bundle on lab hardware
+    - Phase-by-phase acceptance testing while the rest of the update
+      pipeline is still being built
+
+    The bundle is not downloaded, not signature-checked, and not
+    floor-checked against ``min_from_version``. The operator is
+    asserting trust in the bundle file they're passing in.
+
+Backward compatibility
+----------------------
+``python -m os_updater`` with no subcommand (or any leading flag like
+``--log-level=DEBUG``) falls through to the daemon, so the existing
+systemd unit keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as _dt
+import logging
+import os
+import shutil
+import sys
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+from os_updater import __version__
+from os_updater.apply import (
+    DEFAULT_BUNDLE_FILENAME,
+    BundleIntegrityError,
+    RsyncError,
+    SlotStager,
+    StagingError,
+    TrybootError,
+)
+from os_updater.bundle import BundleError
+from os_updater.dispatch import DispatchPayload
+from os_updater.service import DEFAULT_STAGING_ROOT
+
+
+log = logging.getLogger("agora.os_updater.cli")
+
+
+#: Subcommands the dispatcher knows about. Anything else (or empty
+#: argv) falls through to the daemon.
+_SUBCOMMANDS = ("stage", "daemon")
+
+
+def _configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _build_stage_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="os_updater stage",
+        description=(
+            "Manually install an OS bundle into the inactive slot and "
+            "trigger tryboot. Bypasses CMS dispatch, download, and "
+            "signature verification — the operator is asserting trust "
+            "in the bundle file."
+        ),
+    )
+    p.add_argument(
+        "bundle",
+        type=Path,
+        help="Path to the .tar.zst bundle file on local disk.",
+    )
+    p.add_argument(
+        "--target-version",
+        required=True,
+        help=(
+            "Semver of the OS version this bundle delivers. Must match "
+            "the bundle's meta.json version (defense-in-depth check)."
+        ),
+    )
+    p.add_argument(
+        "--release-id",
+        default=None,
+        help=(
+            "Opaque release identifier (logged + persisted in updater "
+            "state). Defaults to manual-<UTC-isotime>."
+        ),
+    )
+    p.add_argument(
+        "--min-from-version",
+        default="0.0.0",
+        help=(
+            "Minimum running version required by this bundle. Not "
+            "enforced in manual mode — included for parity with the "
+            "DispatchPayload schema. Default: 0.0.0 (permissive)."
+        ),
+    )
+    p.add_argument(
+        "--staging-root",
+        type=Path,
+        default=DEFAULT_STAGING_ROOT,
+        help=(
+            "Parent directory under which per-install staging dirs are "
+            f"created (default: {DEFAULT_STAGING_ROOT})."
+        ),
+    )
+    p.add_argument(
+        "--no-reboot",
+        action="store_true",
+        help=(
+            "Stage the bundle and arm tryboot, but do not actually "
+            "reboot. Useful for inspecting the inactive slot before "
+            "handing control to the bootloader."
+        ),
+    )
+    p.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "Required to actually run. Without it, the command prints "
+            "the install plan and exits with code 0 (dry-run)."
+        ),
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        help="Logging level (default: INFO).",
+    )
+    return p
+
+
+def _default_release_id() -> str:
+    """``manual-YYYYMMDDTHHMMSSZ`` — passes DispatchPayload's regex."""
+
+    now = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"manual-{now}"
+
+
+def _prepare_staging_dir(
+    bundle: Path,
+    staging_root: Path,
+    release_id: str,
+    *,
+    bundle_filename: str = DEFAULT_BUNDLE_FILENAME,
+) -> Path:
+    """Create ``<staging_root>/<release_id>/`` and link the bundle into it.
+
+    Returns the staging directory path. Uses a hard link when the
+    bundle and staging root are on the same filesystem (cheap, no
+    extra disk), falling back to ``shutil.copy2`` for cross-device
+    cases. We avoid symlinks because some zstd / tar builds resolve
+    them in surprising ways under sandboxed mounts.
+    """
+
+    if not bundle.is_file():
+        raise FileNotFoundError(f"bundle file not found: {bundle}")
+
+    staging_root.mkdir(parents=True, exist_ok=True)
+    staging_dir = staging_root / release_id
+    if staging_dir.exists():
+        # Clear any prior debris from a re-run with the same release_id.
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir()
+
+    target = staging_dir / bundle_filename
+    try:
+        os.link(str(bundle), str(target))
+    except OSError:
+        # Cross-device or platform that refuses hard links — copy.
+        shutil.copy2(str(bundle), str(target))
+    return staging_dir
+
+
+def _make_stager(*, no_reboot: bool) -> SlotStager:
+    """Construct a production :class:`SlotStager`.
+
+    When ``no_reboot`` is True, we wrap :func:`slot_mgr.trigger_tryboot`
+    with ``reboot=False`` so the bootloader is armed but the device
+    stays up. Lazy-imports slot_mgr so unit tests can exercise the
+    rest of the module without the slot_mgr deps installed.
+    """
+
+    import slot_mgr  # local import per docstring
+
+    trigger_fn: Optional[Callable[[int], Any]] = None
+    if no_reboot:
+        trigger_fn = partial(slot_mgr.trigger_tryboot, reboot=False)
+
+    return SlotStager(
+        slot_state_fn=slot_mgr.slot_state,
+        trigger_tryboot_fn=trigger_fn,
+    )
+
+
+def stage_command(
+    argv: Sequence[str],
+    *,
+    stager_factory: Callable[..., SlotStager] = _make_stager,
+    asyncio_run: Callable[[Any], Any] = asyncio.run,
+    out: Any = None,
+    err: Any = None,
+) -> int:
+    """Implementation of ``python -m os_updater stage <bundle> ...``.
+
+    Returns a process exit code. Injection seams (``stager_factory``,
+    ``asyncio_run``, ``out``, ``err``) keep this testable without
+    real subprocesses or a real Pi. ``out``/``err`` resolve to the
+    *current* ``sys.stdout`` / ``sys.stderr`` when None, so pytest's
+    ``capsys`` (which swaps the module-level streams at test time)
+    can capture our output.
+    """
+
+    if out is None:
+        out = sys.stdout
+    if err is None:
+        err = sys.stderr
+
+    parser = _build_stage_parser()
+    args = parser.parse_args(argv)
+    _configure_logging(args.log_level)
+
+    release_id = args.release_id or _default_release_id()
+
+    # Synthesize a DispatchPayload that satisfies the validators.
+    # bundle_url / signature_url aren't used by SlotStager — the
+    # download phase ran before stage() in the daemon flow — so we
+    # drop in https placeholders that satisfy the http(s)-scheme
+    # check but are never fetched.
+    try:
+        payload = DispatchPayload(
+            release_id=release_id,
+            target_version=args.target_version,
+            min_from_version=args.min_from_version,
+            bundle_url=f"https://manual.invalid/{release_id}.tar.zst",
+            signature_url=f"https://manual.invalid/{release_id}.tar.zst.minisig",
+            force_now=True,
+            force_downgrade=True,
+        )
+    except Exception as exc:  # pydantic ValidationError
+        print(f"error: invalid dispatch arguments: {exc}", file=err)
+        return 2
+
+    # Build the install plan summary before doing anything destructive.
+    reboot_note = (
+        "Device will NOT auto-reboot (--no-reboot); inspect inactive "
+        "slot then reboot manually to attempt tryboot."
+        if args.no_reboot
+        else "Device WILL REBOOT to attempt the new slot via tryboot."
+    )
+    plan = (
+        f"Bundle:         {args.bundle}\n"
+        f"Release ID:     {release_id}\n"
+        f"Target version: {args.target_version}\n"
+        f"Staging root:   {args.staging_root}\n"
+        f"\n{reboot_note}\n"
+    )
+
+    if not args.confirm:
+        print("Manual OS install — DRY RUN (pass --confirm to execute):", file=out)
+        print(plan, file=out)
+        return 0
+
+    print("Manual OS install — EXECUTING:", file=out)
+    print(plan, file=out)
+
+    try:
+        staging_dir = _prepare_staging_dir(
+            args.bundle, args.staging_root, release_id
+        )
+    except (FileNotFoundError, OSError) as exc:
+        print(f"error: failed to prepare staging dir: {exc}", file=err)
+        return 3
+
+    print(f"Staging dir:    {staging_dir}", file=out)
+
+    try:
+        stager = stager_factory(no_reboot=args.no_reboot)
+    except Exception as exc:
+        print(f"error: failed to build SlotStager: {exc}", file=err)
+        return 4
+
+    try:
+        asyncio_run(stager.stage(payload, staging_dir))
+    except BundleIntegrityError as exc:
+        print(f"error: bundle integrity check failed: {exc}", file=err)
+        return 10
+    except BundleError as exc:
+        print(f"error: bundle error: {exc}", file=err)
+        return 11
+    except RsyncError as exc:
+        print(f"error: rsync to inactive slot failed: {exc}", file=err)
+        return 12
+    except TrybootError as exc:
+        print(f"error: tryboot arming failed: {exc}", file=err)
+        return 13
+    except StagingError as exc:
+        print(f"error: staging failed: {exc}", file=err)
+        return 14
+    except Exception as exc:
+        print(f"error: unexpected failure: {exc}", file=err)
+        log.exception("manual stage failed")
+        return 1
+
+    if args.no_reboot:
+        print(
+            "\nStaging complete. Tryboot is armed but reboot was "
+            "suppressed. Run `reboot` when ready, or revert the boot "
+            "config via slot_mgr if you change your mind.",
+            file=out,
+        )
+    else:
+        # We shouldn't actually reach here when slot_mgr.trigger_tryboot
+        # successfully reboots, but a test/fake might return normally.
+        print(
+            "\nStaging complete and tryboot triggered. Device should "
+            "now be rebooting.",
+            file=out,
+        )
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Top-level dispatcher invoked by ``python -m os_updater``.
+
+    Routes the ``stage`` and ``daemon`` subcommands. Anything else
+    (empty argv, leading ``--flag``, unknown first arg) falls through
+    to the daemon entry point so the existing systemd unit keeps
+    working without modification.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Top-level --help / --version: handle here so they describe the
+    # dispatcher (which knows about subcommands), not just the daemon.
+    if argv and argv[0] in ("-h", "--help"):
+        _print_top_level_help()
+        return 0
+    if argv and argv[0] == "--version":
+        print(f"os_updater {__version__}")
+        return 0
+
+    if argv and argv[0] in _SUBCOMMANDS:
+        sub = argv[0]
+        rest = list(argv[1:])
+        if sub == "stage":
+            return stage_command(rest)
+        if sub == "daemon":
+            from os_updater.main import main as daemon_main
+
+            return daemon_main(rest)
+
+    # Back-compat: fall through to the daemon. Covers
+    # ``python -m os_updater`` (systemd) and any leading-flag form.
+    from os_updater.main import main as daemon_main
+
+    return daemon_main(list(argv))
+
+
+def _print_top_level_help() -> None:
+    print(
+        "usage: python -m os_updater [-h] [--version] <subcommand> [args...]\n"
+        "\n"
+        "agora-os-updater — A/B atomic OS update orchestrator.\n"
+        "\n"
+        "subcommands:\n"
+        "  daemon              run the WPS-driven update service "
+        "(default if no subcommand)\n"
+        "  stage <bundle>      manually install a local bundle into "
+        "the inactive slot\n"
+        "\n"
+        "Pass ``-h`` after a subcommand for its specific options, e.g.:\n"
+        "  python -m os_updater stage --help\n"
+        "  python -m os_updater daemon --help\n"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_os_updater_cli.py
+++ b/tests/test_os_updater_cli.py
@@ -1,0 +1,466 @@
+"""Tests for :mod:`os_updater.cli`.
+
+Covers:
+
+* Dispatcher routing — empty argv, leading flags, and unknown
+  subcommands fall through to :func:`os_updater.main.main` so the
+  systemd unit (``python -m os_updater`` with no args) keeps working.
+* ``stage`` subcommand happy path with an injected stager factory.
+* ``--confirm`` gate (dry-run by default).
+* ``--target-version`` is required.
+* Exit codes for the documented failure classes.
+* Top-level ``--help`` / ``--version`` work without dragging in
+  unrelated subsystems.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, List, Optional
+
+import pytest
+
+from os_updater import cli
+from os_updater.apply import (
+    BundleIntegrityError,
+    RsyncError,
+    SlotStager,
+    StagingError,
+    TrybootError,
+)
+from os_updater.bundle import BundleError
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+class _FakeStager:
+    """Stand-in for :class:`SlotStager` used in stage_command tests.
+
+    Records the ``stage(payload, staging_dir)`` call and either
+    returns or raises the configured outcome.
+    """
+
+    def __init__(
+        self,
+        *,
+        raises: Optional[BaseException] = None,
+        on_call: Optional[Callable[..., None]] = None,
+    ) -> None:
+        self.calls: List[Any] = []
+        self._raises = raises
+        self._on_call = on_call
+
+    async def stage(self, payload, staging_dir):  # mirrors SlotStager.stage
+        self.calls.append((payload, Path(staging_dir)))
+        if self._on_call is not None:
+            self._on_call(payload, staging_dir)
+        if self._raises is not None:
+            raise self._raises
+
+
+def _make_factory(stager: _FakeStager) -> Callable[..., _FakeStager]:
+    captured: dict = {}
+
+    def factory(**kwargs):
+        captured.update(kwargs)
+        return stager
+
+    factory.captured = captured  # type: ignore[attr-defined]
+    return factory
+
+
+def _fake_bundle(tmp_path: Path, name: str = "test-bundle.tar.zst") -> Path:
+    """Create a placeholder bundle file — content doesn't matter; the
+    real :class:`SlotStager` isn't invoked in these tests."""
+
+    bundle = tmp_path / name
+    bundle.write_bytes(b"not-a-real-zstd-stream")
+    return bundle
+
+
+# ── dispatcher routing ────────────────────────────────────────────────────
+
+
+def test_main_empty_argv_falls_through_to_daemon(monkeypatch):
+    """Bare ``python -m os_updater`` (systemd's invocation) must hit
+    the daemon entry point with no args."""
+
+    called: dict = {}
+
+    def fake_daemon(argv):
+        called["argv"] = list(argv)
+        return 42
+
+    monkeypatch.setattr("os_updater.main.main", fake_daemon)
+    rc = cli.main([])
+    assert rc == 42
+    assert called["argv"] == []
+
+
+def test_main_leading_flag_falls_through_to_daemon(monkeypatch):
+    """``python -m os_updater --log-level DEBUG`` — leading flags
+    aren't subcommands; route everything to the daemon."""
+
+    called: dict = {}
+
+    def fake_daemon(argv):
+        called["argv"] = list(argv)
+        return 0
+
+    monkeypatch.setattr("os_updater.main.main", fake_daemon)
+    rc = cli.main(["--log-level", "DEBUG"])
+    assert rc == 0
+    assert called["argv"] == ["--log-level", "DEBUG"]
+
+
+def test_main_unknown_first_arg_falls_through_to_daemon(monkeypatch):
+    """Anything not in ``_SUBCOMMANDS`` is forwarded as-is to the
+    daemon, which will reject it via its own argparse if invalid."""
+
+    called: dict = {}
+
+    def fake_daemon(argv):
+        called["argv"] = list(argv)
+        return 7
+
+    monkeypatch.setattr("os_updater.main.main", fake_daemon)
+    rc = cli.main(["pwiggle"])
+    assert rc == 7
+    assert called["argv"] == ["pwiggle"]
+
+
+def test_main_explicit_daemon_subcommand_strips_keyword(monkeypatch):
+    """``python -m os_updater daemon --log-level DEBUG`` — strip the
+    ``daemon`` token, forward the rest to the daemon parser."""
+
+    called: dict = {}
+
+    def fake_daemon(argv):
+        called["argv"] = list(argv)
+        return 0
+
+    monkeypatch.setattr("os_updater.main.main", fake_daemon)
+    rc = cli.main(["daemon", "--log-level", "DEBUG"])
+    assert rc == 0
+    assert called["argv"] == ["--log-level", "DEBUG"]
+
+
+def test_main_stage_routes_to_stage_command(monkeypatch):
+    """The ``stage`` token hands the remaining argv to
+    :func:`stage_command`, not the daemon."""
+
+    daemon_called = {"hit": False}
+
+    def fake_daemon(argv):
+        daemon_called["hit"] = True
+        return 0
+
+    monkeypatch.setattr("os_updater.main.main", fake_daemon)
+
+    received: dict = {}
+
+    def fake_stage(argv, **kwargs):
+        received["argv"] = list(argv)
+        return 99
+
+    monkeypatch.setattr(cli, "stage_command", fake_stage)
+    rc = cli.main(["stage", "/tmp/foo", "--target-version", "1.2.3"])
+    assert rc == 99
+    assert received["argv"] == ["/tmp/foo", "--target-version", "1.2.3"]
+    assert daemon_called["hit"] is False
+
+
+def test_main_version_flag(capsys):
+    """Top-level ``--version`` prints the package version without
+    touching the daemon (avoids importing slot_mgr on Windows)."""
+
+    from os_updater import __version__
+
+    rc = cli.main(["--version"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert __version__ in out
+
+
+def test_main_help_flag(capsys):
+    """Top-level ``-h`` describes both subcommands."""
+
+    rc = cli.main(["-h"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "stage" in out and "daemon" in out
+
+
+# ── stage_command — argument validation ───────────────────────────────────
+
+
+def test_stage_command_requires_target_version(tmp_path):
+    """Without ``--target-version`` argparse should exit 2."""
+
+    bundle = _fake_bundle(tmp_path)
+    with pytest.raises(SystemExit) as excinfo:
+        cli.stage_command([str(bundle)])
+    assert excinfo.value.code == 2
+
+
+def test_stage_command_dry_run_without_confirm(tmp_path, capsys):
+    """Without ``--confirm``, the command prints the plan and exits 0
+    without touching the staging dir or constructing a stager."""
+
+    bundle = _fake_bundle(tmp_path)
+    factory_calls = {"count": 0}
+
+    def factory(**_):
+        factory_calls["count"] += 1
+        raise AssertionError("factory must not be called on dry-run")
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=factory,
+    )
+    assert rc == 0
+    assert factory_calls["count"] == 0
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "1.2.3" in out
+    # Staging root must not have been created on a dry run.
+    assert not (tmp_path / "staging").exists()
+
+
+def test_stage_command_rejects_invalid_target_version(tmp_path, capsys):
+    """The DispatchPayload validator rejects non-semver target_version
+    → exit code 2."""
+
+    bundle = _fake_bundle(tmp_path)
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "not-a-version",
+            "--confirm",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+    )
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "invalid dispatch arguments" in err
+
+
+def test_stage_command_missing_bundle_returns_3(tmp_path, capsys):
+    """Bundle file doesn't exist → exit code 3 from
+    :func:`_prepare_staging_dir`."""
+
+    rc = cli.stage_command(
+        [
+            str(tmp_path / "does-not-exist.tar.zst"),
+            "--target-version",
+            "1.2.3",
+            "--confirm",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=lambda **_: _FakeStager(),
+    )
+    err = capsys.readouterr().err
+    assert rc == 3
+    assert "failed to prepare staging dir" in err
+
+
+# ── stage_command — happy path ────────────────────────────────────────────
+
+
+def test_stage_command_confirm_invokes_stager(tmp_path, capsys):
+    """``--confirm`` runs the full flow: prepare staging dir, build
+    stager, run ``stage()``. Bundle is hard-linked into
+    ``<staging-root>/<release-id>/bundle.tar.zst``."""
+
+    bundle = _fake_bundle(tmp_path)
+    staging_root = tmp_path / "staging"
+    fake = _FakeStager()
+    factory = _make_factory(fake)
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--release-id",
+            "manual-test-001",
+            "--confirm",
+            "--staging-root",
+            str(staging_root),
+        ],
+        stager_factory=factory,
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert len(fake.calls) == 1
+    payload, staging_dir = fake.calls[0]
+    assert staging_dir == staging_root / "manual-test-001"
+    assert (staging_dir / "bundle.tar.zst").is_file()
+    # Hard link → both paths see the same bytes.
+    assert (staging_dir / "bundle.tar.zst").read_bytes() == bundle.read_bytes()
+    # Payload satisfies the DispatchPayload contract.
+    assert payload.release_id == "manual-test-001"
+    assert payload.target_version == "1.2.3"
+    assert payload.force_now is True
+    assert payload.force_downgrade is True
+    # Stager factory was called with the no_reboot flag.
+    assert factory.captured == {"no_reboot": False}
+    assert "EXECUTING" in out
+    assert "tryboot" in out.lower()
+
+
+def test_stage_command_no_reboot_passes_flag_to_factory(tmp_path):
+    """``--no-reboot`` propagates through to the stager factory."""
+
+    bundle = _fake_bundle(tmp_path)
+    fake = _FakeStager()
+    factory = _make_factory(fake)
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--confirm",
+            "--no-reboot",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=factory,
+    )
+    assert rc == 0
+    assert factory.captured == {"no_reboot": True}
+
+
+def test_stage_command_default_release_id_when_omitted(tmp_path):
+    """Omitting ``--release-id`` produces ``manual-<UTC-isotime>``."""
+
+    bundle = _fake_bundle(tmp_path)
+    fake = _FakeStager()
+    factory = _make_factory(fake)
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--confirm",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=factory,
+    )
+    assert rc == 0
+    payload, _ = fake.calls[0]
+    # release_id matches manual-YYYYMMDDTHHMMSSZ
+    assert re.fullmatch(r"manual-\d{8}T\d{6}Z", payload.release_id), payload.release_id
+
+
+def test_stage_command_reuses_release_dir(tmp_path):
+    """Re-running with the same release_id wipes any prior staging
+    contents (safe to retry after a failure)."""
+
+    bundle = _fake_bundle(tmp_path)
+    staging_root = tmp_path / "staging"
+    staging_root.mkdir()
+    stale_dir = staging_root / "manual-replay"
+    stale_dir.mkdir()
+    (stale_dir / "stale.txt").write_text("debris from prior run")
+
+    fake = _FakeStager()
+    factory = _make_factory(fake)
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--release-id",
+            "manual-replay",
+            "--confirm",
+            "--staging-root",
+            str(staging_root),
+        ],
+        stager_factory=factory,
+    )
+    assert rc == 0
+    # Stale file gone; fresh bundle present.
+    assert not (stale_dir / "stale.txt").exists()
+    assert (stale_dir / "bundle.tar.zst").exists()
+
+
+# ── stage_command — failure exit codes ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exc, expected_rc, fragment",
+    [
+        (BundleIntegrityError("bad meta"), 10, "bundle integrity"),
+        (BundleError("zstd died"), 11, "bundle error"),
+        (RsyncError("rsync exited 23"), 12, "rsync"),
+        (TrybootError("autoboot rewrite failed"), 13, "tryboot"),
+        (StagingError("misc staging fail"), 14, "staging failed"),
+        (RuntimeError("boom"), 1, "unexpected failure"),
+    ],
+)
+def test_stage_command_exit_codes(tmp_path, capsys, exc, expected_rc, fragment):
+    """Each documented failure class maps to its own exit code with a
+    distinct error message on stderr."""
+
+    bundle = _fake_bundle(tmp_path)
+    fake = _FakeStager(raises=exc)
+    factory = _make_factory(fake)
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--confirm",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=factory,
+    )
+    err = capsys.readouterr().err
+    assert rc == expected_rc
+    assert fragment in err.lower()
+
+
+def test_stage_command_factory_failure_returns_4(tmp_path, capsys):
+    """If the stager factory itself raises (e.g. slot_mgr not
+    importable), the CLI surfaces that as exit code 4 with a clear
+    message — not a traceback to the terminal."""
+
+    bundle = _fake_bundle(tmp_path)
+
+    def factory(**_):
+        raise ImportError("slot_mgr unavailable on this host")
+
+    rc = cli.stage_command(
+        [
+            str(bundle),
+            "--target-version",
+            "1.2.3",
+            "--confirm",
+            "--staging-root",
+            str(tmp_path / "staging"),
+        ],
+        stager_factory=factory,
+    )
+    err = capsys.readouterr().err
+    assert rc == 4
+    assert "SlotStager" in err


### PR DESCRIPTION
Adds a permanent manual installer CLI: `python -m os_updater stage <bundle> --target-version X.Y.Z --confirm`.

## Why

Phase 2 of the A/B OS update plan ships SlotStager (PRs #166–177), but until now the only way to drive it is via the CMS WPS dispatch path. For release QA, smart-plug chaos runs, and break-glass recovery on a Pi that can't reach CMS, we need a permanent operator tool that drives SlotStager from the command line. Manually keeping a one-off script around is brittle; making it a proper subcommand keeps it covered by CI.

## What

- `os_updater/__main__.py` is now a dispatcher: `stage` subcommand routes to `cli.stage_command`; everything else (bare `python -m os_updater`, unknown args) falls through to the existing daemon `main`. systemd's existing `ExecStart=python -m os_updater` keeps working unchanged.
- `os_updater/cli.py` owns the argparse surface, dry-run gate (`--confirm` required to actually mutate the inactive slot), and exit-code map.

## Exit codes

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | generic / unexpected error |
| 2 | argparse validation failure |
| 3 | bundle path does not exist |
| 4 | stager factory failed |
| 10 | BundleIntegrityError |
| 11 | BundleError |
| 12 | RsyncError |
| 13 | TrybootError |
| 14 | StagingError |

## Test plan

- New: `tests/test_os_updater_cli.py` — 22 tests covering dispatcher routing, dry-run vs `--confirm`, every exit-code path, stdout/stderr surface.
- Full `os_updater` sweep: **243 passed, 1 skipped**.
- Full repo sweep (excl. Windows-incompatible `test_cms_url_reconnect.py` and `test_wss_support.py`): **1337 passed, 31 skipped**. Zero regressions.

## Phase context

Tactical Phase 2 hardening — not in the master plan. CLI is the tool that drives Phase 5's smart-plug chaos and lab-acceptance OTA runs, so it earns its keep across the rest of the rollout.