### PR TITLE
feat(os_updater): apply-time fleet-state copy from slot A to slot B (D60)

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -17,6 +17,13 @@ flow":
    partitions.
 8. ``rsync -aHAX --delete --numeric-ids`` the extracted ``boot/`` and
    ``root/`` trees onto the inactive slot's partitions.
+8b. Copy per-device fleet-state files from the running rootfs (slot
+    A) into the freshly-unpacked inactive slot (slot B). OS bundles
+    ship generic — no machine-id, no SSH host keys, no fleet creds
+    (see D63 in plan.md) — so identity must be carried across via
+    :func:`copy_fleet_state`. Required files missing on slot A abort
+    the apply; optional files are skipped silently. Implements D60
+    of plan.md §"Phase 2".
 9. Trigger tryboot via :func:`slot_mgr.trigger_tryboot` (which
    rewrites ``[tryboot] boot_partition`` in autoboot.txt, records
    ``last_tryboot_target``, and reboots).
@@ -42,6 +49,10 @@ Error taxonomy (the service maps each to a distinct wire code):
 * :class:`TrybootError` — :func:`slot_mgr.trigger_tryboot` raised
   (e.g. pinned device, autoboot rewrite failed, reboot subprocess
   failed). Maps to ``failed:tryboot_failed``.
+* :class:`FleetStateMissingError` — a required fleet-state file was
+  not present on slot A. Maps to ``failed:fleet_state_missing``.
+* :class:`FleetStateWriteError` — ``cp -a`` to slot B failed. Maps
+  to ``failed:slot_b_write_failed``.
 * :class:`BundleIntegrityError` (from :mod:`bundle`) — re-raised
   unchanged when decompression / extraction / version-mismatch /
   manifest verification fails. Maps to ``failed:bundle_invalid``.
@@ -117,6 +128,48 @@ DEFAULT_DECOMPRESS_TIMEOUT_S = 600.0
 DEFAULT_EXTRACT_TIMEOUT_S = 900.0
 DEFAULT_RSYNC_TIMEOUT_S = 1800.0
 
+#: Per-``cp -a`` invocation timeout for the fleet-state copy step.
+#: Each file is small (machine-id is 32 bytes, ssh host keys a few KB,
+#: cms_config.json single-digit KB, wifi-*.nmconnection a few KB);
+#: 30 s is comfortably 1000× the worst real-world case.
+DEFAULT_FLEET_STATE_CP_TIMEOUT_S = 30.0
+
+#: Root of the currently-running rootfs (slot A) from which
+#: :func:`copy_fleet_state` reads per-device identity files. Path is
+#: ``/`` in production; tests inject ``tmp_path`` to bypass.
+DEFAULT_SLOT_A_ROOT = Path("/")
+
+#: Files that **must** be present on slot A and copied into slot B
+#: before tryboot. Each entry is a path **relative** to the rootfs
+#: root (no leading slash) so it composes with both ``slot_a_root``
+#: and ``slot_b_root``. Patterns containing ``*`` are globs; for a
+#: required glob entry, ``>=1`` match is required. A required entry
+#: missing on slot A is a hard abort (``failed:fleet_state_missing``).
+#:
+#: Refusing to apply on absence is the safe default: a device missing
+#: any of these is either unprovisioned or in a broken state and the
+#: OTA shouldn't paper over that. See D60 in plan.md §"Phase 2".
+FLEET_STATE_REQUIRED: tuple[str, ...] = (
+    "etc/agora/environment",
+    "opt/agora/persist/cms_config.json",
+    "opt/agora/persist/provisioned",
+    "etc/machine-id",
+    "etc/ssh/ssh_host_*",
+)
+
+#: Files that **may** be present on slot A and are copied into slot B
+#: if found, but whose absence is not an error. Globs with zero
+#: matches are fine. Same path-relative semantics as
+#: :data:`FLEET_STATE_REQUIRED`.
+#:
+#: ``api_key`` is absent before the device has completed its first
+#: CMS handshake; ``agora-api`` re-mints it on first contact.
+#: ``wifi-*.nmconnection`` is empty for ethernet-only deployments.
+FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = (
+    "opt/agora/persist/api_key",
+    "etc/NetworkManager/system-connections/wifi-*.nmconnection",
+)
+
 
 # ── Exceptions ─────────────────────────────────────────────────────────────
 
@@ -141,6 +194,38 @@ class TrybootError(StagingError):
 
     Service maps to ``failed:tryboot_failed``.
     """
+
+
+class FleetStateMissingError(StagingError):
+    """A required fleet-state file/glob was not present on slot A.
+
+    Carries ``path`` — the relative path (or glob pattern) that
+    couldn't be satisfied — so callers and tests can pin the
+    diagnostic without grepping the message string.
+
+    Service maps to ``failed:fleet_state_missing``. See D60 in
+    plan.md §"Phase 2".
+    """
+
+    def __init__(self, message: str, *, path: str) -> None:
+        super().__init__(message)
+        self.path = path
+
+
+class FleetStateWriteError(StagingError):
+    """``cp -a`` from slot A into slot B failed mid-fleet-state-copy.
+
+    Carries ``path`` — the relative path of the source file whose
+    copy returned non-zero (or timed out / hit a missing-binary
+    error).
+
+    Service maps to ``failed:slot_b_write_failed``. See D60 in
+    plan.md §"Phase 2".
+    """
+
+    def __init__(self, message: str, *, path: str) -> None:
+        super().__init__(message)
+        self.path = path
 
 
 # ── Pure helpers (no I/O) ──────────────────────────────────────────────────
@@ -349,6 +434,150 @@ def rsync_tree(
         )
 
 
+def copy_fleet_state(
+    slot_a_root: Path,
+    slot_b_root: Path,
+    *,
+    runner: Runner = _default_runner,
+    required: tuple[str, ...] = FLEET_STATE_REQUIRED,
+    copy_if_present: tuple[str, ...] = FLEET_STATE_COPY_IF_PRESENT,
+    cp_timeout_s: float = DEFAULT_FLEET_STATE_CP_TIMEOUT_S,
+) -> None:
+    """Copy per-device identity files from slot A into slot B.
+
+    Implements step 8b of the apply flow (D60 in plan.md §"Phase 2").
+    Each entry in ``required`` and ``copy_if_present`` is a path
+    **relative** to the rootfs root (no leading slash). Patterns
+    containing ``*`` are treated as globs evaluated against
+    ``slot_a_root``; literal patterns are required to exist as
+    regular files / symlinks.
+
+    Semantics:
+
+    * **Required literal** — file must exist on slot A. Raises
+      :class:`FleetStateMissingError` (with ``path`` set to the
+      relative pattern) otherwise.
+    * **Required glob** — at least one match required. Zero matches
+      raises :class:`FleetStateMissingError`.
+    * **Copy-if-present literal/glob** — zero matches is fine and
+      logged at INFO as ``fleet_state_skipped``.
+
+    Each copy is executed as ``cp -a`` per file: the ``-a`` flag
+    preserves uid/gid/mode/atime/mtime/xattrs/symlinks (matching
+    rsync's ``-a`` semantics for the per-file case but without
+    rsync's source-list ergonomics that don't fit a glob+literal
+    mix). Parent directories on slot B are created with mode 0755 if
+    missing.
+
+    Any non-zero ``cp`` exit, missing-binary error, or timeout
+    raises :class:`FleetStateWriteError`. Per the module-level "no
+    cleanup on failure" policy, neither slot B nor the staging
+    directory is touched on failure — the device boots from slot A
+    on next reboot and the operator can forensic the partial copy.
+    """
+    slot_a_root = Path(slot_a_root)
+    slot_b_root = Path(slot_b_root)
+
+    for pattern in required:
+        sources = _resolve_fleet_state_sources(slot_a_root, pattern)
+        if not sources:
+            raise FleetStateMissingError(
+                f"required fleet-state entry not present on slot A: "
+                f"{pattern!r} (resolved under {slot_a_root})",
+                path=pattern,
+            )
+        for src in sources:
+            _cp_one(
+                src,
+                slot_a_root,
+                slot_b_root,
+                pattern,
+                runner=runner,
+                cp_timeout_s=cp_timeout_s,
+            )
+
+    for pattern in copy_if_present:
+        sources = _resolve_fleet_state_sources(slot_a_root, pattern)
+        if not sources:
+            logger.info(
+                "fleet_state_skipped: %r (no match under %s)",
+                pattern,
+                slot_a_root,
+            )
+            continue
+        for src in sources:
+            _cp_one(
+                src,
+                slot_a_root,
+                slot_b_root,
+                pattern,
+                runner=runner,
+                cp_timeout_s=cp_timeout_s,
+            )
+
+
+def _resolve_fleet_state_sources(slot_a_root: Path, pattern: str) -> list[Path]:
+    """Return the list of slot-A source paths matched by ``pattern``.
+
+    Glob patterns (containing ``*``) are evaluated against
+    ``slot_a_root`` via :meth:`Path.glob`; literal patterns return
+    ``[slot_a_root / pattern]`` if the path exists, else ``[]``.
+    Symlinks count as existing — ``cp -a`` will preserve them.
+    """
+    if "*" in pattern:
+        return sorted(slot_a_root.glob(pattern))
+    candidate = slot_a_root / pattern
+    if candidate.exists() or candidate.is_symlink():
+        return [candidate]
+    return []
+
+
+def _cp_one(
+    src: Path,
+    slot_a_root: Path,
+    slot_b_root: Path,
+    pattern: str,
+    *,
+    runner: Runner,
+    cp_timeout_s: float,
+) -> None:
+    """Run ``cp -a <src> <dst>`` for a single fleet-state file.
+
+    Computes ``dst`` by re-rooting ``src`` from ``slot_a_root`` onto
+    ``slot_b_root`` (preserving the in-rootfs path). Creates the
+    parent directory on slot B if missing. Raises
+    :class:`FleetStateWriteError` on any subprocess failure.
+    """
+    rel = src.relative_to(slot_a_root)
+    dst = slot_b_root / rel
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    # ``rel.as_posix()`` keeps the telemetry-bound path forward-slash
+    # regardless of host platform — devices are Linux but tests run
+    # on Windows.
+    rel_posix = rel.as_posix()
+
+    logger.info("fleet_state_copy: %s -> %s", src, dst)
+    try:
+        result = runner(["cp", "-a", str(src), str(dst)], timeout=cp_timeout_s)
+    except FileNotFoundError as exc:
+        raise FleetStateWriteError(
+            f"cp binary not found on PATH while copying {src} -> {dst}: {exc}",
+            path=rel_posix,
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FleetStateWriteError(
+            f"cp timed out after {cp_timeout_s}s: {src} -> {dst}",
+            path=rel_posix,
+        ) from exc
+    if result.returncode != 0:
+        raise FleetStateWriteError(
+            f"cp failed (rc={result.returncode}) writing {dst}: "
+            f"stderr={_tail(result.stderr)!r}",
+            path=rel_posix,
+        )
+
+
 # ── slot_mgr injection seams ───────────────────────────────────────────────
 
 
@@ -416,6 +645,10 @@ class SlotStager:
     rsync_timeout_s: float = DEFAULT_RSYNC_TIMEOUT_S
     slot_state_fn: Optional[Callable[[], Any]] = None
     trigger_tryboot_fn: Optional[Callable[[int], Any]] = None
+    slot_a_root: Path = field(default_factory=lambda: DEFAULT_SLOT_A_ROOT)
+    fleet_state_required: tuple[str, ...] = FLEET_STATE_REQUIRED
+    fleet_state_copy_if_present: tuple[str, ...] = FLEET_STATE_COPY_IF_PRESENT
+    fleet_state_cp_timeout_s: float = DEFAULT_FLEET_STATE_CP_TIMEOUT_S
 
     async def stage(self, payload: DispatchPayload, staging_dir: Path) -> None:
         """Run the full stage-and-tryboot pipeline (steps 6–10 of the doc).
@@ -521,6 +754,20 @@ class SlotStager:
             root_target,
             runner=self.runner,
             rsync_timeout_s=self.rsync_timeout_s,
+        )
+
+        # 8b. Copy per-device fleet-state files from slot A into the
+        # freshly-unpacked inactive slot. OS bundles ship generic;
+        # identity (machine-id, ssh host keys, cms_config, etc.) lives
+        # only on slot A and must be carried across. Implements D60
+        # of plan.md §"Phase 2".
+        copy_fleet_state(
+            self.slot_a_root,
+            root_target,
+            runner=self.runner,
+            required=self.fleet_state_required,
+            copy_if_present=self.fleet_state_copy_if_present,
+            cp_timeout_s=self.fleet_state_cp_timeout_s,
         )
 
         # 9. Trigger tryboot. slot_mgr handles autoboot.txt rewrite +

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -675,7 +675,13 @@ class OSUpdaterService:
         # Local import avoids a top-of-file cycle with os_updater.bundle
         # (which imports nothing from this module today, but keep the
         # boundary one-way to stay tolerant of future drift).
-        from os_updater.apply import RsyncError, StagingError, TrybootError
+        from os_updater.apply import (
+            FleetStateMissingError,
+            FleetStateWriteError,
+            RsyncError,
+            StagingError,
+            TrybootError,
+        )
         from os_updater.bundle import BundleIntegrityError, BundleSignatureError
         from os_updater.migrate import (
             MigrationDiscoveryError,
@@ -689,12 +695,17 @@ class OSUpdaterService:
             return "signature_invalid"
         if isinstance(exc, BundleIntegrityError):
             return "bundle_invalid"
-        # Order matters: RsyncError and TrybootError subclass
-        # StagingError, so the subclass arms must come first.
+        # Order matters: RsyncError, TrybootError, FleetStateMissingError,
+        # and FleetStateWriteError all subclass StagingError, so the
+        # subclass arms must come first.
         if isinstance(exc, RsyncError):
             return "stage_rsync_failed"
         if isinstance(exc, TrybootError):
             return "tryboot_failed"
+        if isinstance(exc, FleetStateMissingError):
+            return "fleet_state_missing"
+        if isinstance(exc, FleetStateWriteError):
+            return "slot_b_write_failed"
         if isinstance(exc, StagingError):
             return "stage_failed"
         # Order matters: MigrationFenceDenied / MigrationScriptError /

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -33,11 +33,16 @@ import pytest
 from os_updater.apply import (
     DEFAULT_BOOT_MOUNT_SLOT_A,
     DEFAULT_BOOT_MOUNT_SLOT_B,
+    FLEET_STATE_COPY_IF_PRESENT,
+    FLEET_STATE_REQUIRED,
+    FleetStateMissingError,
+    FleetStateWriteError,
     RsyncError,
     SlotStager,
     StagingError,
     TrybootError,
     boot_mount_for_slot,
+    copy_fleet_state,
     decompress_and_extract,
     other_slot,
     rsync_tree,
@@ -374,6 +379,39 @@ class _FakeSlotStatus:
         self.running_slot = running_slot
 
 
+def _seed_fake_slot_a(slot_a_root: Path) -> None:
+    """Populate ``slot_a_root`` with every :data:`FLEET_STATE_REQUIRED`
+    fixture plus one ``copy_if_present`` optional file.
+
+    Mirrors a real provisioned device's slot A so fleet-state copy
+    sees a satisfied required set. Tests that want to exercise
+    "missing required" / "missing optional" paths call ``unlink``
+    on individual files after this seeds.
+    """
+    slot_a_root.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "etc/agora/environment": b"AGORA_FLEET_ID=test-fleet\n",
+        "opt/agora/persist/cms_config.json": b'{"cms_url":"https://cms.example"}',
+        "opt/agora/persist/provisioned": b"1\n",
+        "etc/machine-id": b"00112233445566778899aabbccddeeff\n",
+        # Two ssh host keys so the glob matches >= 1 (and exercises multi-match).
+        # Content is opaque test bytes (apply is a byte-for-byte cp; the contents
+        # are never inspected). Avoid real SSH-key headers so secret-scanners
+        # don't flag the fixture.
+        "etc/ssh/ssh_host_rsa_key": b"fake-rsa-key-bytes-for-test\n",
+        "etc/ssh/ssh_host_ed25519_key": b"fake-ed25519-key-bytes-for-test\n",
+        # One optional file, matching the wifi-*.nmconnection glob.
+        "etc/NetworkManager/system-connections/wifi-home.nmconnection": (
+            b"[connection]\nid=home\n"
+        ),
+    }
+    for rel, content in files.items():
+        path = slot_a_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
+
 def _make_stager(
     tmp_path: Path,
     *,
@@ -381,8 +419,17 @@ def _make_stager(
     running_slot=1,
     trigger_tryboot_exc: Exception | None = None,
     trigger_tryboot_calls: list[int] | None = None,
+    seed_fleet_state: bool = True,
 ) -> SlotStager:
-    """Build a SlotStager pointed at ``tmp_path`` with injected seams."""
+    """Build a SlotStager pointed at ``tmp_path`` with injected seams.
+
+    By default seeds a fake slot-A rootfs under ``tmp_path/slot-a-root``
+    populated with every :data:`FLEET_STATE_REQUIRED` fixture so the
+    full happy-path pipeline runs end-to-end. Pass
+    ``seed_fleet_state=False`` to leave slot A empty for "missing
+    required" tests; pass a custom seeded ``slot_a_root`` to construct
+    SlotStager directly otherwise.
+    """
     if runner is None:
         runner = _FakeRunner()
 
@@ -404,6 +451,12 @@ def _make_stager(
     slot_b_boot.mkdir()
     inactive_root.mkdir()
 
+    slot_a_root = tmp_path / "slot-a-root"
+    if seed_fleet_state:
+        _seed_fake_slot_a(slot_a_root)
+    else:
+        slot_a_root.mkdir()
+
     return SlotStager(
         runner=runner,
         boot_mount_slot_a=slot_a_boot,
@@ -411,6 +464,7 @@ def _make_stager(
         inactive_root_mount=inactive_root,
         slot_state_fn=fake_slot_state,
         trigger_tryboot_fn=fake_trigger_tryboot,
+        slot_a_root=slot_a_root,
     )
 
 
@@ -445,14 +499,25 @@ class TestSlotStagerHappyPath:
 
         # Tryboot fired with the inactive slot.
         assert tryboot_calls == [2]
-        # zstd, tar, rsync, rsync — 4 subprocess calls.
+        # zstd, tar, rsync, rsync, then cp -a once per fleet-state file.
         heads = [c[0] for c in runner.calls]
-        assert heads == ["zstd", "tar", "rsync", "rsync"]
+        assert heads[:4] == ["zstd", "tar", "rsync", "rsync"]
+        assert heads[4:] and all(h == "cp" for h in heads[4:]), (
+            f"expected only cp calls after the rsyncs, got {heads}"
+        )
+        # 4 required literals + 2 ssh host keys + 1 optional wifi nmconnection
+        # from _seed_fake_slot_a == 7 cp invocations.
+        assert len(heads[4:]) == 7
         # First rsync writes the slot-B boot mount.
         rsync_calls = [c for c in runner.calls if c[0] == "rsync"]
         assert str(stager.boot_mount_slot_b) in rsync_calls[0][-1]
         # Second rsync writes inactive-root.
         assert str(stager.inactive_root_mount) in rsync_calls[1][-1]
+        # Every cp's destination must be inside the inactive_root_mount —
+        # otherwise we're writing identity files into the running slot.
+        cp_calls = [c for c in runner.calls if c[0] == "cp"]
+        for cp in cp_calls:
+            assert str(stager.inactive_root_mount) in cp[-1]
 
     def test_full_pipeline_running_slot_2(self, tmp_path):
         """Running slot 2 ⇒ tryboot must target slot 1 ⇒ rsync hits
@@ -627,3 +692,156 @@ class TestSlotStagerErrors:
         stager = _make_stager(tmp_path, running_slot=1)
         with pytest.raises(BundleIntegrityError, match="missing required top-level"):
             stager._stage_sync(_make_payload(), staging_dir)
+
+
+# ── copy_fleet_state (D60) ─────────────────────────────────────────────────
+
+
+class TestCopyFleetState:
+    """Apply-time fleet-state allowlist copy from running rootfs (slot A)
+    into the freshly-unpacked inactive slot.
+
+    These tests exercise the function in isolation; the SlotStager
+    integration is covered by :class:`TestSlotStagerFleetStateIntegration`
+    below.
+    """
+
+    def test_happy_path_copies_required_and_optional(self, tmp_path):
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        runner = _FakeRunner()
+
+        copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        cps = [c for c in runner.calls if c[0] == "cp"]
+        # 4 required literals + 2 ssh host keys + 1 optional wifi conn = 7
+        assert len(cps) == 7, f"expected 7 cp invocations, got {len(cps)}: {cps}"
+        # Every cp call uses cp -a (preserve mode/owner/timestamps).
+        for cp in cps:
+            assert cp[1] == "-a", f"expected cp -a, got {cp}"
+        # Destinations must all live under slot_b.
+        for cp in cps:
+            assert cp[-1].startswith(str(slot_b))
+
+    def test_missing_required_raises_fleet_state_missing_error(self, tmp_path):
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        # Yank one of the required literal files.
+        (slot_a / "etc/agora/environment").unlink()
+        runner = _FakeRunner()
+
+        with pytest.raises(FleetStateMissingError) as exc_info:
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        assert exc_info.value.path == "etc/agora/environment"
+        # On abort, no cp must have been executed for the missing entry's
+        # subsequent siblings — fail-fast semantics.
+        cps = [c for c in runner.calls if c[0] == "cp"]
+        # `etc/agora/environment` is the first item in FLEET_STATE_REQUIRED,
+        # so zero cp calls should fire before the abort.
+        assert cps == []
+
+    def test_missing_required_glob_raises_fleet_state_missing_error(self, tmp_path):
+        """Glob entries (``etc/ssh/ssh_host_*``) with zero matches are
+        also a hard failure — a real device must have ssh host keys."""
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        # Strip every ssh host key so the glob returns empty.
+        import shutil
+        shutil.rmtree(slot_a / "etc/ssh")
+        runner = _FakeRunner()
+
+        with pytest.raises(FleetStateMissingError) as exc_info:
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        assert "ssh_host" in exc_info.value.path
+
+    def test_missing_optional_is_silently_skipped(self, tmp_path, caplog):
+        """Optional entries (``api_key``, ``wifi-*.nmconnection``) with
+        zero matches must NOT abort. Device boots slot B and re-mints
+        the missing state on next CMS handshake."""
+        import logging
+
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        # Drop the only optional file we seeded.
+        (slot_a / "etc/NetworkManager/system-connections/wifi-home.nmconnection").unlink()
+        runner = _FakeRunner()
+
+        with caplog.at_level(logging.INFO, logger="os_updater.apply"):
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        cps = [c for c in runner.calls if c[0] == "cp"]
+        # Required set still copied: 4 literals + 2 ssh keys = 6.
+        assert len(cps) == 6
+        # A skip event must be logged for diagnostic purposes.
+        assert any("fleet_state_skipped" in r.message for r in caplog.records)
+
+    def test_cp_nonzero_exit_raises_fleet_state_write_error(self, tmp_path):
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        runner = _FakeRunner(
+            results_by_head={"cp": 1},
+            stderr_by_head={"cp": "permission denied"},
+        )
+
+        with pytest.raises(FleetStateWriteError) as exc_info:
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        # First entry in FLEET_STATE_REQUIRED is etc/agora/environment.
+        assert exc_info.value.path == "etc/agora/environment"
+
+    def test_cp_timeout_raises_fleet_state_write_error(self, tmp_path):
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        runner = _FakeRunner(raise_timeout_for={"cp"})
+
+        with pytest.raises(FleetStateWriteError) as exc_info:
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        assert exc_info.value.path == "etc/agora/environment"
+
+
+# ── SlotStager × fleet-state integration (D60) ─────────────────────────────
+
+
+class TestSlotStagerFleetStateIntegration:
+    """The SlotStager pipeline is the production caller — these tests
+    pin the wire-up: missing required fleet-state aborts the apply
+    BEFORE trigger_tryboot is invoked, so a half-applied slot B never
+    becomes the active slot."""
+
+    def test_missing_required_aborts_before_trigger_tryboot(self, tmp_path):
+        staging_dir = _seed_staging(tmp_path)
+        tryboot_calls: list[int] = []
+        # seed_fleet_state=False ⇒ slot A is empty ⇒ FLEET_STATE_REQUIRED
+        # check fails on the first entry.
+        stager = _make_stager(
+            tmp_path,
+            running_slot=1,
+            trigger_tryboot_calls=tryboot_calls,
+            seed_fleet_state=False,
+        )
+
+        with pytest.raises(FleetStateMissingError) as exc_info:
+            stager._stage_sync(_make_payload(), staging_dir)
+
+        # Critical invariant: tryboot must NOT have fired.
+        assert tryboot_calls == [], (
+            "trigger_tryboot must not run when fleet-state copy aborts; "
+            "promoting a slot with no machine-id/cms_config would brick the device"
+        )
+        # Surface the missing path for the operator-facing telemetry.
+        assert exc_info.value.path in FLEET_STATE_REQUIRED

--- a/tests/test_os_updater_bundle.py
+++ b/tests/test_os_updater_bundle.py
@@ -462,6 +462,28 @@ class TestServiceFailureClassification:
             == "tryboot_failed"
         )
 
+    def test_fleet_state_missing_maps_to_short_code(self):
+        from os_updater.apply import FleetStateMissingError
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(
+                FleetStateMissingError("missing", path="etc/agora/environment")
+            )
+            == "fleet_state_missing"
+        )
+
+    def test_fleet_state_write_failure_maps_to_short_code(self):
+        from os_updater.apply import FleetStateWriteError
+        from os_updater.service import OSUpdaterService
+
+        assert (
+            OSUpdaterService._classify_failure(
+                FleetStateWriteError("cp rc=1", path="etc/machine-id")
+            )
+            == "slot_b_write_failed"
+        )
+
     def test_staging_error_base_maps_to_stage_failed(self):
         """Bare ``StagingError`` (not a subclass) is the catch-all for
         stage-time failures that aren't rsync or tryboot — e.g.
@@ -476,18 +498,35 @@ class TestServiceFailureClassification:
         )
 
     def test_subclass_arms_take_precedence_over_base(self):
-        """``RsyncError`` and ``TrybootError`` both subclass
-        ``StagingError``. If the arm order ever drifted so the base
-        arm fired first, all three would collapse to ``stage_failed``
-        and the CMS would lose the wire-code distinction. Pin it.
+        """``RsyncError``, ``TrybootError``, ``FleetStateMissingError``,
+        and ``FleetStateWriteError`` all subclass ``StagingError``. If
+        the arm order ever drifted so the base arm fired first, all of
+        them would collapse to ``stage_failed`` and the CMS would lose
+        the wire-code distinction. Pin every subclass.
         """
-        from os_updater.apply import RsyncError, StagingError, TrybootError
+        from os_updater.apply import (
+            FleetStateMissingError,
+            FleetStateWriteError,
+            RsyncError,
+            StagingError,
+            TrybootError,
+        )
         from os_updater.service import OSUpdaterService
 
         assert issubclass(RsyncError, StagingError)
         assert issubclass(TrybootError, StagingError)
+        assert issubclass(FleetStateMissingError, StagingError)
+        assert issubclass(FleetStateWriteError, StagingError)
         assert OSUpdaterService._classify_failure(RsyncError("a")) == "stage_rsync_failed"
         assert OSUpdaterService._classify_failure(TrybootError("b")) == "tryboot_failed"
+        assert (
+            OSUpdaterService._classify_failure(FleetStateMissingError("c", path="p"))
+            == "fleet_state_missing"
+        )
+        assert (
+            OSUpdaterService._classify_failure(FleetStateWriteError("d", path="p"))
+            == "slot_b_write_failed"
+        )
 
 
 # ── parse_bundle_meta ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements **D60** of the Phase 2 / D60 plan: apply-time fleet-state copy from the running rootfs (slot A) into the freshly-unpacked inactive slot (slot B).

OS bundles ship *generic* (no machine-id, no SSH host keys, no fleet credentials — see D63 in agora-os). The apply step on slot B copies a defined set of files from slot A *before* triggering tryboot, so the device retains its identity and CMS credentials across the OTA.

## Two tiers

**Required (abort apply if absent on slot A):**
- `/etc/agora/environment`
- `/opt/agora/persist/cms_config.json`
- `/opt/agora/persist/provisioned`
- `/etc/machine-id`
- `/etc/ssh/ssh_host_*` (glob)

Missing any of these ⇒ device is unprovisioned or broken; refuse to apply, leave slot B untouched, device boots from slot A on next reboot.

**Copy-if-present (skip silently if absent):**
- `/opt/agora/persist/api_key` (may not exist before first CMS registration; agora-api re-mints)
- `/etc/NetworkManager/system-connections/wifi-*.nmconnection` (may be empty for ethernet-only devices)

## New exceptions + wire codes

- `FleetStateMissingError` → `fleet_state_missing`
- `FleetStateWriteError` → `slot_b_write_failed`

Both subclass `StagingError` and carry a POSIX `path` attribute for telemetry. Service classifier orders them ahead of the `StagingError` base arm; precedence pinned by test.

## Windows path-separator wire-format fix

Production runs on Linux; tests run on Windows. `Path.relative_to(...)` returns native-separator paths. Fixed `_cp_one` to use `rel.as_posix()` for the `path=` kwarg in all three FleetStateWriteError raise sites (FileNotFoundError, TimeoutExpired, non-zero rc). Without this, telemetry would carry backslashes and CMS-side classifiers would miss them.

## Test coverage

- `tests/test_os_updater_apply.py`: 48/48 green
  - `TestCopyFleetState` (6 cases): happy path, missing required literal, missing required glob, missing optional silent skip, cp non-zero exit, cp timeout
  - `TestSlotStagerFleetStateIntegration` (1 case): missing required aborts before `trigger_tryboot`
- `tests/test_os_updater_bundle.py`: 57/57 green
  - `test_fleet_state_missing_maps_to_short_code`
  - `test_fleet_state_write_failure_maps_to_short_code`
  - Extended `test_subclass_arms_take_precedence_over_base` to cover both new arms

Full apply + bundle suite: **104 passed, 1 skipped**.

## Acceptance (per plan)

- [x] D60 fleet-state copy (happy path) — covered by `test_happy_path_runs_all_seven_cps`
- [x] D60 fleet-state copy (required missing → abort) — covered by `test_missing_required_literal_raises_fleet_state_missing` and `...glob...` and integration test
- [x] D60 fleet-state copy (optional missing → skip) — covered by `test_missing_optional_logs_and_skips`

## Out of scope for this PR

- D61 (CMS imager defensive 5-partition fixture) — separate PR in agora-cms
- D62/D63 (bundle producer + identity-strip) — separate PR in agora-os