### PR TITLE
packaging: add agora-os-updater CLI wrapper

### DIFF
--- a/packaging/cli-wrappers/agora-os-updater
+++ b/packaging/cli-wrappers/agora-os-updater
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# /usr/local/sbin/agora-os-updater - thin shell wrapper around `python3 -m os_updater`.
+#
+# Installed by packaging/build-deb.sh so operators can run
+# `agora-os-updater stage <bundle> --target-version <ver> --confirm` directly
+# without having to know the PYTHONPATH dance. Mirrors agora-slot-mgr.
+#
+# Note: this is the *operator-facing* CLI. The systemd daemon
+# (agora-os-updater.service) invokes `python3 -m os_updater` directly with its
+# own EnvironmentFile, so this wrapper does not affect the daemon path.
+set -euo pipefail
+exec env \
+  PYTHONPATH=/opt/agora/src \
+  AGORA_BASE=/opt/agora \
+  python3 -m os_updater "$@"


### PR DESCRIPTION
Adds a thin shell wrapper at `/usr/local/sbin/agora-os-updater` that mirrors the existing `agora-slot-mgr` pattern, so operators can run the updater without typing the PYTHONPATH dance:

``
agora-os-updater stage /path/to/bundle.tar.zst \\
    --target-version v0.0.2-test --confirm
``

Quality-of-life only — no behavior change. The systemd daemon (`agora-os-updater.service`) still invokes `python3 -m os_updater` directly with its own `EnvironmentFile`, so this wrapper does not affect the daemon path.

`build-deb.sh` auto-discovers anything in `packaging/cli-wrappers/`, so no other wiring is needed (verified against the existing slot-mgr wrapper install loop at lines 85-88).

### Why now
First end-to-end manual update test is about to begin (flash agora-os v0.0.2-test image, SCP bundle, install). Having the wrapper makes the operator command shorter and more discoverable.

### Test
- Unit/CI: existing tests cover the os_updater module; the wrapper is a 7-line bash exec — exercised on first invocation in the manual test.