### PR TITLE
fix(systemd): agora-player must not Requires= nonexistent mount unit

### DIFF
--- a/systemd/agora-player.service
+++ b/systemd/agora-player.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Agora Media Player
-After=opt-agora-state.mount agora-provision.service
-Requires=opt-agora-state.mount
+After=data.mount agora-provision.service
+RequiresMountsFor=/opt/agora/state /opt/agora/persist /data
 ConditionPathExists=/opt/agora/persist/provisioned
 DefaultDependencies=no
 


### PR DESCRIPTION
## What

3-line fix to systemd/agora-player.service:
- Drop `Requires=opt-agora-state.mount` (the unit doesn't exist; silently disables the service at boot).
- Change `After=opt-agora-state.mount agora-provision.service` to `After=data.mount agora-provision.service`.
- Add `RequiresMountsFor=/opt/agora/state /opt/agora/persist /data` for path-based dependency tracking that works on both pre-v0.0.3 (plain dirs) and v0.0.3+ (bind mounts) images.

## Why

On Pi5 192.168.1.100 flashed with `agora-os` `v0.0.2-test`, `agora-player.service` did not come up on HDMI after boot. The journal was completely silent for the unit. Manual `systemctl start agora-player` surfaced:

```
Failed to start agora-player.service: Unit opt-agora-state.mount not found.
```

Root cause: the unit Requires a `.mount` unit that no agora-os release has ever shipped. systemd's behaviour with `DefaultDependencies=no` plus a missing Requires-target is to silently refuse to start with no journal entry.

A drop-in override (`/etc/systemd/system/agora-player.service.d/00-unbreak.conf` with `Requires=` reset to empty) did **not** work — that's a known quirk of units with `DefaultDependencies=no`. The fix has to land in the shipped unit file.

## Compatibility

- **Pre-v0.0.3 OS images** (`/opt/agora/state` is a plain dir): `RequiresMountsFor=` is a no-op for paths that aren't mount points. `After=data.mount` still resolves because `data.mount` is fstab-generated by `PARTLABEL=data`.
- **v0.0.3+ OS images** (`/opt/agora/state` bound from `/data/agora/state`): `RequiresMountsFor=` correctly waits for the bind mount; `After=data.mount` covers the underlying ext4.

## Verified

Manually edited the shipped unit on .100, started `agora-player` cleanly, watched it survive `systemctl daemon-reexec`. Backup of the unmodified unit kept at `.bak` for reproducibility.

## Related

Part of the v0.0.3-test bug sweep documented in the OTA rollout plan. Companion PR in `sslivins/agora-os` covers the other three bugs (state on rootfs, firstboot mkfs race, watchdog contention).