### PR TITLE
fix(os_updater): parse /etc/agora/version as multi-line key=value

### DIFF
--- a/os_updater/main.py
+++ b/os_updater/main.py
@@ -49,25 +49,58 @@ from os_updater.state import DEFAULT_STATE_PATH
 log = logging.getLogger("agora.os_updater")
 
 
-#: Path to the baked-in current-version file. Phase 0 writes the OS image
-#: version into ``/etc/agora/version`` (plan §"Phase 0 — Deliverables"
-#: re: ``/etc/agora/version``). One-line plain text, semver-shaped.
+#: Path to the baked-in current-version file. agora-os writes this at
+#: image-build time (assemble.sh) and at OTA-bundle-build time
+#: (build-bundle.sh). It's a multi-line key=value file:
+#:
+#:     # comment
+#:     agora_os_version=0.0.4-test
+#:     agora_app_floor=1.11.0
+#:
+#: We consume only ``agora_os_version`` here (per Decision #2 the
+#: ``agora_app_floor`` is the agora-app channel's contract, not the OS
+#: updater's). Naive .strip() of the whole file would return the entire
+#: multi-line blob as the "version" string and torpedo every floor check.
 DEFAULT_CURRENT_VERSION_FILE = Path("/etc/agora/version")
 
 
 def _read_current_version(path: Path) -> str:
-    """Read ``/etc/agora/version`` and strip whitespace.
+    """Parse ``/etc/agora/version`` and return ``agora_os_version``.
 
-    Raises if the file is missing or empty — better to fail loud at daemon
-    startup than to ship an empty string into the floor check and either
-    accept every dispatch (string comparison) or reject every dispatch
-    (semver parse).
+    File format: ``# comment`` lines and blank lines are skipped; every
+    other line must be ``key=value``. The ``agora_os_version`` value is
+    returned (whitespace-stripped). Other keys (e.g. ``agora_app_floor``)
+    are tolerated so this parser doesn't have to be lockstepped with every
+    future field added by agora-os.
+
+    Raises ``RuntimeError`` if the file is missing the
+    ``agora_os_version`` key, contains a malformed line, or has an empty
+    value for ``agora_os_version`` — better to fail loud at daemon startup
+    than to ship an empty string into the floor check.
     """
 
-    raw = path.read_text(encoding="utf-8").strip()
-    if not raw:
-        raise RuntimeError(f"{path} is empty; cannot determine current version")
-    return raw
+    raw = path.read_text(encoding="utf-8")
+    version: str | None = None
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        if not sep:
+            raise RuntimeError(
+                f"{path}:{lineno}: malformed line (expected key=value): {line!r}"
+            )
+        if key.strip() == "agora_os_version":
+            version = value.strip()
+    if version is None:
+        raise RuntimeError(
+            f"{path} did not contain an 'agora_os_version=...' line"
+        )
+    if not version:
+        raise RuntimeError(
+            f"{path}: 'agora_os_version' has an empty value; cannot determine current version"
+        )
+    return version
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/test_os_updater_main.py
+++ b/tests/test_os_updater_main.py
@@ -1,0 +1,96 @@
+"""Tests for the ``/etc/agora/version`` parser in :mod:`os_updater.main`.
+
+agora-os ships ``/etc/agora/version`` as a multi-line key=value file
+(``agora_os_version=...``, ``agora_app_floor=...``). The original
+implementation did a naive ``.strip()`` of the entire file and treated
+the result as the version string, which broke every floor check. These
+tests pin the new parser's contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from os_updater.main import _read_current_version
+
+
+def _write(tmp_path, content: str):
+    p = tmp_path / "version"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestReadCurrentVersion:
+    def test_returns_agora_os_version_value(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "# header\nagora_os_version=0.0.4-test\nagora_app_floor=1.11.0\n",
+        )
+        assert _read_current_version(p) == "0.0.4-test"
+
+    def test_skips_comments_and_blank_lines(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "\n# comment line\n\nagora_os_version=1.2.3\n\n# trailing comment\n",
+        )
+        assert _read_current_version(p) == "1.2.3"
+
+    def test_tolerates_unknown_keys(self, tmp_path):
+        # agora-os may grow new keys without coordinating with this
+        # parser; only the missing agora_os_version line is fatal.
+        p = _write(
+            tmp_path,
+            "agora_os_version=2.0.0\nagora_app_floor=1.11.0\nfuture_field=hello\n",
+        )
+        assert _read_current_version(p) == "2.0.0"
+
+    def test_strips_surrounding_whitespace_in_value(self, tmp_path):
+        p = _write(tmp_path, "agora_os_version =   1.2.3   \n")
+        assert _read_current_version(p) == "1.2.3"
+
+    def test_missing_agora_os_version_raises(self, tmp_path):
+        p = _write(tmp_path, "agora_app_floor=1.11.0\nfuture_field=hello\n")
+        with pytest.raises(RuntimeError, match="agora_os_version"):
+            _read_current_version(p)
+
+    def test_empty_value_raises(self, tmp_path):
+        p = _write(tmp_path, "agora_os_version=\n")
+        with pytest.raises(RuntimeError, match="empty value"):
+            _read_current_version(p)
+
+    def test_empty_file_raises(self, tmp_path):
+        p = _write(tmp_path, "")
+        with pytest.raises(RuntimeError, match="agora_os_version"):
+            _read_current_version(p)
+
+    def test_comment_only_file_raises(self, tmp_path):
+        p = _write(tmp_path, "# only comments\n# nothing useful\n")
+        with pytest.raises(RuntimeError, match="agora_os_version"):
+            _read_current_version(p)
+
+    def test_malformed_line_without_equals_raises(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "agora_os_version=1.0.0\nthis-line-has-no-equals\n",
+        )
+        with pytest.raises(RuntimeError, match="malformed line"):
+            _read_current_version(p)
+
+    def test_literal_todo_placeholder_passes_through(self, tmp_path):
+        # Regression: pre-fix v0.0.4 images shipped with literal "TODO"
+        # as the value. The parser shouldn't blow up on it — the floor
+        # check downstream is responsible for noticing "TODO" isn't
+        # semver-shaped. This test pins that we return the literal
+        # string rather than swallowing it as "missing".
+        p = _write(tmp_path, "agora_os_version=TODO\nagora_app_floor=TODO\n")
+        assert _read_current_version(p) == "TODO"
+
+    def test_multiple_agora_os_version_lines_last_wins(self, tmp_path):
+        # Not a documented format feature, but the parser walks the
+        # whole file; pin "last write wins" so a future bug that adds
+        # duplicate lines is at least deterministic.
+        p = _write(
+            tmp_path,
+            "agora_os_version=1.0.0\nagora_os_version=2.0.0\n",
+        )
+        assert _read_current_version(p) == "2.0.0"


### PR DESCRIPTION
## Summary

The on-Pi parser for `/etc/agora/version` was treating the multi-line key=value file as a single version string. Found while validating Pi 192.168.1.100 — the file shape per `agora-os/image-build/assemble.sh` is:

```
# Generated by assemble.sh at image-build time. Do not hand-edit.
agora_os_version=0.0.4-test
agora_app_floor=1.11.0
```

per Decision #2 / F17 in the A/B OS update plan — `agora_app_floor` is the contract for the parallel forward-only agora-app OTA channel, separate from `agora_os_version`.

## Bug

`_read_current_version()` did `raw = path.read_text().strip()` and returned the entire multi-line blob as the version string. The floor check (`min_from_version` comparison) was then comparing semver strings against `"agora_os_version=...\nagora_app_floor=..."` — silent-fail mode, every OTA dispatch refused or accepted on whichever way the broken string compare landed.

## Fix

Rewrote the parser to walk the file line-by-line:
- Skip blank lines and `#` comments
- Every other line must be `key=value` (raise on malformed — fail loud at daemon startup)
- Return the value of `agora_os_version` (whitespace-stripped)
- Tolerate unknown keys (so the parser doesn't have to lockstep with every future agora-os field)
- Raise if `agora_os_version` is missing or empty

Caller still gets a `str`, so no downstream changes.

## Tests

New `tests/test_os_updater_main.py` with 11 cases:
- happy path
- comments + blanks skipped
- unknown keys tolerated
- whitespace stripping
- missing key raises
- empty value raises
- empty file raises
- comment-only file raises
- malformed line raises
- literal `TODO` value passes through (so the downstream semver parse is what complains, not us — regression check for the bug that motivated this PR)
- last-wins on duplicate keys (pinned for determinism, not a documented feature)

All 11 green locally: `python -m pytest tests/test_os_updater_main.py -v -p no:timeout`.

## Paired PR

Companion fix on the agora-os side: sslivins/agora-os#TBD — that PR makes the image-build pipeline actually substitute the values instead of shipping literal `TODO` placeholders.
