### PR TITLE
fix(os-updater): preserve perms and ownership during bundle extract (#187)

### DIFF
--- a/docs/bundle-format.md
+++ b/docs/bundle-format.md
@@ -191,10 +191,10 @@ This is the contract `agora-os-updater` honors. Each step's failure produces a s
 3. **Download** the `.tar.zst` to `/data/.update/staging/<release_id>/bundle.tar.zst` with resumable HTTP (`Range:` requests on retry). On unrecoverable HTTP error, emit `failed:download` and clean the staging dir.
 4. **Download** the `.minisig` (small, single shot). Same failure path as step 3.
 5. **Verify signature** over the on-disk `.tar.zst` bytes using the multi-key directory lookup above. Failure: emit `failed:signature_invalid`, delete staging dir immediately. Do NOT decompress on signature failure — the tarball might be malicious.
-6. **Decompress + extract** into `/data/.update/staging/<release_id>/unpacked/`. Stream-decompress with the bundled zstd; pipe through GNU tar with `--no-same-owner --no-same-permissions=root` (the device-side rsync stage will fix ownership). Failure: `failed:bundle_invalid`.
+6. **Extract `meta.json`** from the bundle to `/data/.update/staging/<release_id>/unpacked/meta.json` (stream-decompress with the bundled zstd, then tar-extract just the single `meta.json` member). Failure: `failed:bundle_invalid`.
 7. **Read `meta.json`.** Reject if `version` mismatches the dispatch's `target_version` (defense in depth — the CMS should never dispatch a mismatched bundle, but we don't trust the network). Failure: `failed:bundle_invalid`.
-8. **Verify manifest.** Walk `boot/` and `root/`; for every regular file confirm it appears in `sha256_manifest` AND the on-disk content sha256 matches. Reject on missing entries, extra files, or hash mismatch. Failure: `failed:bundle_invalid`, delete staging.
-9. **Stage to inactive slot.** Rsync `boot/` → `/boot/firmware-<inactive>/`, `root/` → `/mnt/inactive-root/`. (Implemented in p2-stage-and-tryboot.)
+8. **Stream `boot/` and `root/` subtrees directly into the inactive slot.** Two passes of `zstd -dc | tar -x --strip-components=1 -C <target>`, once with `<target>` = the inactive slot's mounted boot partition and once with `<target>` = its root partition. Tar is invoked **without** `--no-same-owner` / `--no-same-permissions` so that, running as root, it restores numeric uid/gid and setuid/setgid/sticky bits from the archive. (The original 2-step design extracted to staging and then rsync'd into the slot, with those defensive flags compensating for the running uid; the streaming refactor eliminated the rsync stage, so those flags are not safe here — see agora#187.) Failure: `failed:bundle_invalid`.
+9. **Verify manifest** against the bytes that landed on the inactive slot. Walk `boot/` and `root/`; for every regular file confirm it appears in `sha256_manifest` AND the on-disk content sha256 matches. Reject on missing entries, extra files, or hash mismatch. Failure: `failed:bundle_invalid`, delete staging.
 10. **Hand off to slot-mgr.** Invoke `agora-slot-mgr trigger-tryboot` to flip the next-boot pointer. This is the last device-side step before reboot; after reboot, Phase 1's slot-confirm logic takes over.
 11. **`/data` migrations run POST-PROMOTE ONLY** (see [bundle-migration.md](./bundle-migration.md)). They are NOT part of the staging step — they fire after slot-confirm flips `agora-firstboot.service`'s migration-allowed sentinel.
 
@@ -207,21 +207,20 @@ This is the contract `agora-os-updater` honors. Each step's failure produces a s
   <release_id>/
     bundle.tar.zst        # the downloaded asset
     bundle.tar.zst.minisig
-    unpacked/             # populated by step 6 above
-      boot/
-      root/
-      meta.json
+    unpacked/             # populated by step 6 above (meta.json only;
+      meta.json           # boot/ and root/ stream straight into the
+                          # inactive slot in step 8, never to staging)
 ```
 
 Each dispatch's `release_id` namespaces its own subdirectory. Cleanup happens at:
 
 - **Step 5 failure** (signature) — delete `<release_id>/` immediately. Belt-and-braces: untrusted bytes never sit on disk for more than seconds.
-- **Step 6–8 failure** (decompress / manifest) — delete `<release_id>/` immediately.
+- **Step 6–9 failure** (extract / version / manifest) — delete `<release_id>/` immediately; if step 8 had begun writing to the inactive slot, leave the slot for forensics — slot-confirm will refuse to promote it and the next successful apply overwrites it.
 - **Step 10 success** — keep `<release_id>/` until reboot. After reboot, slot-confirm's success path deletes it; slot-confirm's rollback path leaves it for forensics (the rollback diagnostics in Phase 1 already collect it).
 - **`agora-os-updater.service` start** — sweep `/data/.update/staging/*/` and delete any directory whose `mtime` is more than 24h old OR whose `meta.json` is missing/unparseable (TTL + sanity). This handles the case where the device rebooted unexpectedly mid-stage. (Decision #20.)
 
 ## Future-compat notes
 
-- **Delta updates.** A future bundle format could replace `root/` with a casync `castr/` + index file. The minisign + `meta.json` envelope stays identical; only steps 6–9 of the verify flow change. The `builder` and `version` fields are forward-compatible.
+- **Delta updates.** A future bundle format could replace `root/` with a casync `castr/` + index file. The minisign + `meta.json` envelope stays identical; only steps 6–9 of the verify flow change (the extract pipeline gains an index-resolution step, but the streaming-into-inactive-slot shape is unchanged). The `builder` and `version` fields are forward-compatible.
 - **A separate manifest file.** If `meta.json` grows large enough to be annoying to embed (e.g. >100k sha256 entries), splitting into `meta.json` + `manifest.json` is a one-version flag day. The signature scheme doesn't care; the device-side parser does, hence flagging here.
 - **Cosign / sigstore.** Out of scope for v1. Minisign was chosen for being self-contained and not requiring a transparency log we'd then have to operate.

--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -643,14 +643,22 @@ def stream_extract_subtree(
     dst_dir.mkdir(parents=True, exist_ok=True)
 
     zstd_argv = ["zstd", "-dc", f"--long={zstd_long}", "-f", str(bundle_path)]
+    # GNU tar's defaults are correct here when this code runs as root
+    # (which the stager always does, via sudo): --same-owner restores
+    # numeric uid/gid from the archive, and --same-permissions restores
+    # full mode bits including setuid/setgid/sticky. The previous
+    # two-step staging flow rsync'd from staging into the slot and
+    # could afford --no-same-owner / --no-same-permissions; the
+    # streaming flow extracts directly into the inactive slot's
+    # rootfs, so those flags would silently strip setuid bits
+    # (sudo, su, mount, passwd, ping, ...) and reset every file's
+    # ownership to the running uid. See sslivins/agora#187.
     tar_argv = [
         "tar",
         "-x",
         "--strip-components=1",
         "-C",
         str(dst_dir),
-        "--no-same-owner",
-        "--no-same-permissions",
         subpath,
     ]
 

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -512,6 +512,47 @@ class TestStreamExtractSubtree:
         assert str(dst) in tar_argv
         assert tar_argv[-1] == "root"
 
+    def test_tar_argv_preserves_perms_and_ownership(self, tmp_path):
+        """Regression guard for sslivins/agora#187.
+
+        The streaming extract runs as root and writes directly into
+        the inactive slot's rootfs. It MUST NOT pass
+        ``--no-same-owner`` or ``--no-same-permissions``: those flags
+        strip setuid/setgid bits and reset every extracted file's
+        uid/gid to the running user, which on the device meant slot
+        B came up with non-functional ``sudo``, ``su``, ``passwd``,
+        etc. and ``/home/agora`` owned by root.
+
+        GNU tar's defaults already do the right thing when invoked as
+        root (the stager always is), so the correct fix was simply
+        to remove the flags. This test pins that decision."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.write_bytes(b"x")
+        dst = tmp_path / "dst"
+        captured: list[Sequence[str]] = []
+
+        def capturing_pipeline(zstd_argv, tar_argv, *, tar_stdout_path=None, timeout_s):
+            captured.append(list(tar_argv))
+            return (0, "", 0, "")
+
+        stream_extract_subtree(
+            bundle, "root", dst, pipeline_runner=capturing_pipeline
+        )
+
+        tar_argv = captured[0]
+        assert "--no-same-owner" not in tar_argv, (
+            "tar must NOT be invoked with --no-same-owner: it would "
+            "reset every extracted file's uid/gid to the running user, "
+            "breaking the inactive-slot rootfs (see agora#187)"
+        )
+        assert "--no-same-permissions" not in tar_argv, (
+            "tar must NOT be invoked with --no-same-permissions: it "
+            "applies umask and strips setuid/setgid/sticky bits, "
+            "leaving sudo/su/passwd/etc. non-functional on the "
+            "inactive slot (see agora#187)"
+        )
+
+
     def test_zstd_failure_raises_bundle_integrity_error(self, tmp_path):
         bundle = tmp_path / "bundle.tar.zst"
         bundle.write_bytes(b"corrupted")


### PR DESCRIPTION
Fixes #187.

## What was broken

The OTA stager's streaming extract (`os_updater/apply.py:stream_extract_subtree`) invoked GNU tar with `--no-same-owner` and `--no-same-permissions`. The stager runs as root via sudo, so under those flags:

- every extracted file's uid/gid was reset to the running user (effectively root, with the archive's numeric uid/gid metadata silently discarded), and
- the running process's umask was applied to mode bits — stripping `setuid`/`setgid`/`sticky`.

The smoking-gun observed during the v0.0.9-test OTA on Pi100:

| Path | Expected | Observed on slot B |
|---|---|---|
| `/usr/bin/sudo` | `4755 root:root` | `0755 root:root` |
| `/bin/su`, `/usr/bin/passwd`, `/usr/bin/ping`, `/bin/mount` | `4755` | `0755` |
| `/home/agora` | `agora:agora` | `root:root` |

Cascading consequences: kernel auto-remounted `/` read-only after boot-time perm errors; `/data` failed to mount; `agora-slot-mgr.service` never ran (so the intentional revert path never fired — only the user power-cycling Pi5 brought it back to slot A).

## Why these flags shipped

The flags are a fossil from the **previous** two-step apply pipeline: the original design extracted into `unpacked/boot/` + `unpacked/root/` staging dirs and then rsync'd those into the slot. In that design `--no-same-owner` / `--no-same-permissions` were *defensive* — the rsync step was the one that restored ownership and perm bits.

The streaming refactor collapsed the rsync step (`tar | extract-direct-into-slot`) but left the now-anti-defensive flags in place. Classic rotation bug: doc still mentioned the rsync stage, code no longer did rsync, no test pinned the extracted permissions.

## The fix

Remove the two flags from `tar_argv`. GNU tar's defaults when running as root are correct here:

- `--same-owner` (default for root) restores numeric uid/gid from the archive
- `--same-permissions` (default for root) restores full mode bits including setuid/setgid/sticky

Added a multi-line comment above the `tar_argv` block explaining the historical context so the next refactor doesn't reintroduce the flags.

## Test added

`tests/test_os_updater_apply.py::TestStreamExtractSubtree::test_tar_argv_preserves_perms_and_ownership` captures the `tar_argv` the pipeline is invoked with and asserts neither flag is present. Pins the decision so any future regression fails CI loudly.

## Doc cleanup

`docs/bundle-format.md` had two stale passages referencing the dead rsync-fixup stage. Rewrote the apply-flow steps to describe the actual current behaviour (stream `boot/` + `root/` straight into the inactive slot's mounts) and added a forward-pointing note to #187 explaining why the bad flags are *not* present.

## Tests

```
$ python -m pytest tests/test_os_updater_apply.py -v -p no:timeout
============================= 82 passed in 1.29s =============================
```

## Out of scope (filed separately)

- Slot B's `agora-slot-mgr.service` being `inactive (dead)` after tryboot landed — never observed services, never fired revert. Tracked in plan as Phase E2. Filing as a separate issue once this lands and v0.0.10 OTA validates that healthy slot B behaviour is what unblocks slot-mgr.
- Stage CLI dry-run default (#185).
- Bundle verifier "bad signature" diagnostic context (#186).

## Validation plan (post-merge)

1. Cut `v0.0.10-test` on the new `main`.
2. Pi100 is already on v0.0.8-test (clean baseline). SFTP the v0.0.10 bundle.
3. Re-run stage CLI. Expected: slot B comes up healthy, `sudo` works, `agora-slot-mgr` observes the 4 services and promotes via `autoboot.txt` rewrite.
