### PR TITLE
fix(postinst): enable agora-slot-mgr + agora-os-updater; fix StartLimit* placement

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -255,7 +255,7 @@ fi
 
 # ── Enable and restart services ──
 systemctl daemon-reload
-systemctl enable agora-watchdog agora-player agora-api agora-cms-client agora-provision agora-fleet-provision
+systemctl enable agora-watchdog agora-player agora-api agora-cms-client agora-provision agora-fleet-provision agora-slot-mgr agora-os-updater
 
 # ── Ensure dnsmasq does not start by default (managed by provision service) ──
 systemctl disable dnsmasq 2>/dev/null || true

--- a/systemd/agora-slot-mgr.service
+++ b/systemd/agora-slot-mgr.service
@@ -11,6 +11,14 @@ After=agora-cms-client.service
 After=agora-player.service
 After=agora-watchdog.service
 DefaultDependencies=yes
+# StartLimit* must live in [Unit], NOT [Service]. systemd interprets
+# Restart=/RestartSec= per-unit instance, but the StartLimit* knobs that
+# bound the total restart budget belong to the unit's lifecycle. When
+# they were misplaced in [Service] (pre-#193) systemd silently ignored
+# them and emitted a warning at unit-load time. Move here to actually
+# enforce the bounded retry budget the comment in [Service] promised.
+StartLimitBurst=10
+StartLimitIntervalSec=600
 
 [Service]
 # `oneshot` so the unit runs once after boot and exits; the gate's job
@@ -30,8 +38,6 @@ Environment=AGORA_BASE=/opt/agora
 # recorded.
 Restart=on-failure
 RestartSec=30
-StartLimitBurst=10
-StartLimitIntervalSec=600
 
 # Both `--auto` exit codes that mean "ran to completion" are 0 or 1,
 # and we already filter exit 1 via `--auto` (which always exits 0 or 2).


### PR DESCRIPTION
Two service-management bugs surfaced by the v0.0.11-test smoke OTA on slot B (Pi100, 2026-05-15). Fixes #193 + #194 together since they're both small and both gate the same v0.0.12-test cut.

## Bug 1 — `agora-slot-mgr` + `agora-os-updater` never enabled (#194, P0)

`packaging/debian/postinst:258` enables `agora-watchdog agora-player agora-api agora-cms-client agora-provision agora-fleet-provision` — but skips `agora-slot-mgr` and `agora-os-updater`. Both units ship in this repo under `systemd/` and are critical to the OTA loop:

- `agora-slot-mgr.service` runs `slot_confirm --auto` post-tryboot to either promote the new slot (write `[all] boot_partition=N` in `autoboot.txt`) or strike. Without it being enabled, the slot-mgr daemon never runs, slot-confirm never fires, and the only reason v0.0.11-test slot B reverted to slot A on power-cycle was the **tryboot one-shot semantics** (the `[tryboot]` section is only honoured once by the bootloader) — not the intentional revert path. This means we have zero coverage of the promote-or-strike logic from the real OTA path.
- `agora-os-updater.service` is the WPS-pushed dispatch endpoint that subscribes to `os_update_dispatch` messages and runs the download → verify → stage → tryboot flow. Without it enabled, dispatches go to the floor and the only way to stage a bundle is to SSH in and invoke `python3 -m os_updater stage ...` by hand — which is what we've been doing for every test run since v0.0.6-test.

**Fix:** append both unit names to the existing `systemctl enable` invocation.

## Bug 2 — `StartLimit*` in wrong section of `agora-slot-mgr.service` (#193, P2)

`systemd/agora-slot-mgr.service` had `StartLimitBurst=10` and `StartLimitIntervalSec=600` in `[Service]`. These are unit-level knobs, not instance-level — they belong in `[Unit]`. systemd silently ignores them when placed in `[Service]` (a warning is emitted at unit-load time, lost in noise unless you `journalctl --grep StartLimit`). The end-effect is that the comment in `[Service]` claiming "bounded retry budget" is a lie: `Restart=on-failure` + `RestartSec=30` was the only mechanism actually in force, with no upper bound on the retry budget.

**Fix:** move both lines to `[Unit]` immediately after `DefaultDependencies=yes`. Added a comment explaining why placement matters so this doesn't recur.

## Together these unblock v0.0.12-test

With both fixes shipped + `agora-os#18` (merged: /data mkdir + cmdline-B install) on agora-os main, the v0.0.12-test cut will produce a bundle whose slot-B boots cleanly, has slot-mgr enabled out of the gate, and runs slot-confirm against the four-service health gate the way the Phase 1 design intended. v0.0.11-test produced a tryboot that worked end-to-end *up to* the slot-confirm step and then black-holed because slot-mgr was inactive.

## Verification plan

After merge:

1. Cut v0.0.12-test on agora-os main (commits: agora-os #18 + agora HEAD with this PR).
2. Wait for the agora-os release build to attach `agora-bundle-v0.0.12-test.tar.zst` to the GH Release.
3. Re-flash Pi100 to v0.0.8 baseline.
4. SFTP v0.0.12 bundle to Pi100, invoke stage CLI with `--confirm`.
5. **Expected:** tryboot → slot B kernel up → systemd brings `agora-slot-mgr.service` to active (enabled out of the box this time) → `slot_confirm --auto` runs, observes 4 services active for ≥5 min, writes `[all] boot_partition=3` in `autoboot.txt`, exits 0. Promote complete.
6. Reboot Pi100 — verify `cmdline.txt` shows `root=PARTLABEL=root-B` and stays there. v0.0.12 is now slot A from the bootloader's POV, original slot A is now the "next OTA target".

## Files changed

- `packaging/debian/postinst` (+1 -1): one-line addition to systemctl enable list
- `systemd/agora-slot-mgr.service` (+8 -2): move StartLimit* + add explanatory comment