### PR TITLE
fix(slot-confirm): use systemd monotonic clock for service-uptime gate (#197)

### DIFF
--- a/slot_confirm/core.py
+++ b/slot_confirm/core.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -120,6 +121,7 @@ class ConfirmStatus:
 
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 NowFn = Callable[[], datetime]
+MonotonicNowFn = Callable[[], float]
 FrameOpener = Callable[[str], Any]
 ProbeWriter = Callable[[str, bytes], None]
 StatusReader = Callable[[str], str]
@@ -145,6 +147,39 @@ def _default_runner(
 
 def _default_now() -> datetime:
     return datetime.now(tz=timezone.utc)
+
+
+def _default_monotonic_now() -> float:
+    """Default source for the monotonic "now" used by the service-age math.
+
+    Returns ``time.monotonic()`` (CLOCK_MONOTONIC on Linux), which is
+    immune to NTP step corrections. Pi 5 has no battery-backed RTC, so
+    on a fresh boot the wallclock can jump forward by minutes-to-hours
+    once ``systemd-timesyncd`` syncs — making
+    ``datetime.now() - systemd_ActiveEnterTimestamp`` produce a
+    negative age and a spurious slot-confirm strike. See bug #197.
+    """
+    return time.monotonic()
+
+
+def _parse_systemd_monotonic_us(raw: str) -> Optional[int]:
+    """Parse a systemd ``ActiveEnterTimestampMonotonic`` value.
+
+    systemd emits the property as an integer microsecond count since
+    the kernel started (i.e. against ``CLOCK_MONOTONIC``). Returns
+    ``None`` for empty / ``"0"`` / unparseable values — ``0`` is the
+    sentinel emitted by systemd before a unit has ever activated.
+    """
+    raw = (raw or "").strip()
+    if not raw or raw == "0":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    if value <= 0:
+        return None
+    return value
 
 
 # ── 1. agora services active for ≥5 min ────────────────────────────────────
@@ -187,12 +222,24 @@ def check_agora_services_active(
     min_active_seconds: int = DEFAULT_MIN_ACTIVE_SECONDS,
     runner: Optional[Runner] = None,
     now_fn: Optional[NowFn] = None,
+    monotonic_now_fn: Optional[MonotonicNowFn] = None,
 ) -> CheckResult:
     """Verify every ``services`` entry is Active and has been so for ≥ ``min_active_seconds``.
 
     Returns ``ok=False`` on the first service that is not active or has
     been active for less than the threshold. The reason and offending
     service are recorded in ``detail`` and ``measurement``.
+
+    Age math prefers ``ActiveEnterTimestampMonotonic`` (CLOCK_MONOTONIC)
+    over the wallclock ``ActiveEnterTimestamp``. Pi 5 has no
+    battery-backed RTC, so on a fresh boot the wallclock can jump
+    forward by minutes-to-hours once ``systemd-timesyncd`` syncs,
+    yielding negative wallclock-derived ages and spurious strikes.
+    See bug #197. The wallclock path remains as a fallback when systemd
+    reports ``ActiveEnterTimestampMonotonic=0`` (the sentinel for
+    "never activated"); a negative age from either source is treated as
+    a failure (with ``measurement.reason="negative_age"``) since both
+    inputs must be monotonic w.r.t. their own clock.
     """
     if min_active_seconds < 0:
         raise SlotConfirmError(
@@ -203,6 +250,7 @@ def check_agora_services_active(
 
     run = runner or _default_runner
     now = (now_fn or _default_now)()
+    monotonic_now_s = (monotonic_now_fn or _default_monotonic_now)()
 
     per_service: dict[str, dict[str, Any]] = {}
     for unit in services:
@@ -214,6 +262,7 @@ def check_agora_services_active(
                     unit,
                     "--property=ActiveState",
                     "--property=ActiveEnterTimestamp",
+                    "--property=ActiveEnterTimestampMonotonic",
                 ],
                 check=False,
                 capture_output=True,
@@ -237,6 +286,7 @@ def check_agora_services_active(
 
         active_state: Optional[str] = None
         enter_raw: str = ""
+        enter_monotonic_raw: str = ""
         for line in (cp.stdout or "").splitlines():
             if "=" not in line:
                 continue
@@ -245,6 +295,8 @@ def check_agora_services_active(
                 active_state = value.strip()
             elif key == "ActiveEnterTimestamp":
                 enter_raw = value.strip()
+            elif key == "ActiveEnterTimestampMonotonic":
+                enter_monotonic_raw = value.strip()
 
         if active_state != "active":
             return CheckResult(
@@ -270,11 +322,47 @@ def check_agora_services_active(
                 },
             )
 
-        age = (now - entered).total_seconds()
+        entered_monotonic_us = _parse_systemd_monotonic_us(enter_monotonic_raw)
+        if entered_monotonic_us is not None:
+            # Preferred path: monotonic clock; immune to NTP step.
+            age = monotonic_now_s - (entered_monotonic_us / 1_000_000.0)
+            clock_source = "monotonic"
+        else:
+            # Fallback: wallclock — only triggers if systemd reports
+            # ``ActiveEnterTimestampMonotonic=0`` (unit never activated)
+            # which would already have tripped the ``active_state`` gate.
+            age = (now - entered).total_seconds()
+            clock_source = "wallclock"
+
         per_service[unit] = {
             "active_for_seconds": age,
             "entered_at": entered.isoformat(),
+            "clock_source": clock_source,
         }
+
+        if age < 0:
+            # Both clock sources are supposed to be monotonic w.r.t.
+            # themselves; a negative delta means the systemd property
+            # disagrees with our "now" (clock jumped backwards, or unit
+            # entered ``ActiveEnterTimestampMonotonic`` after the
+            # daemon read its own clock — neither can be reasoned about).
+            return CheckResult(
+                name="agora_services_active",
+                ok=False,
+                detail=(
+                    f"{unit} has negative active-for age ({age:.1f}s) "
+                    f"via {clock_source} clock"
+                ),
+                measurement={
+                    "service": unit,
+                    "active_for_seconds": age,
+                    "min_active_seconds": min_active_seconds,
+                    "entered_at": entered.isoformat(),
+                    "clock_source": clock_source,
+                    "reason": "negative_age",
+                },
+            )
+
         if age < min_active_seconds:
             return CheckResult(
                 name="agora_services_active",
@@ -288,6 +376,7 @@ def check_agora_services_active(
                     "active_for_seconds": age,
                     "min_active_seconds": min_active_seconds,
                     "entered_at": entered.isoformat(),
+                    "clock_source": clock_source,
                 },
             )
 

--- a/systemd/agora-slot-mgr.service
+++ b/systemd/agora-slot-mgr.service
@@ -10,6 +10,13 @@ After=agora-api.service
 After=agora-cms-client.service
 After=agora-player.service
 After=agora-watchdog.service
+# Belt-and-suspenders for bug #197: don't run the service-age check
+# until NTP has had a chance to sync the wallclock. The clock-source
+# fix in ``check_agora_services_active`` uses CLOCK_MONOTONIC and is
+# immune to NTP step on its own; this just removes one more variable
+# from the diagnostic ("did we even sync before deciding?").
+After=time-sync.target
+Wants=time-sync.target
 DefaultDependencies=yes
 # StartLimit* must live in [Unit], NOT [Service]. systemd interprets
 # Restart=/RestartSec= per-unit instance, but the StartLimit* knobs that

--- a/tests/test_slot_confirm.py
+++ b/tests/test_slot_confirm.py
@@ -49,14 +49,29 @@ def _fixed_now(seconds_ago: int = 0) -> datetime:
     return base + timedelta(seconds=seconds_ago)
 
 
-def _show_output(active_state: str, entered_at: str = "") -> str:
-    return f"ActiveState={active_state}\nActiveEnterTimestamp={entered_at}\n"
+def _show_output(
+    active_state: str,
+    entered_at: str = "",
+    monotonic_us: str = "0",
+) -> str:
+    return (
+        f"ActiveState={active_state}\n"
+        f"ActiveEnterTimestamp={entered_at}\n"
+        f"ActiveEnterTimestampMonotonic={monotonic_us}\n"
+    )
 
 
-def _systemctl_runner(per_service: dict[str, tuple[str, str]]) -> scc.Runner:
+def _systemctl_runner(
+    per_service: dict[str, tuple[str, ...]],
+) -> scc.Runner:
     """Build a runner that returns canned ``systemctl show`` output per service.
 
-    ``per_service`` is ``{unit: (active_state, entered_raw)}``.
+    ``per_service`` is ``{unit: (active_state, entered_raw)}`` or
+    ``{unit: (active_state, entered_raw, monotonic_us)}``. The 2-tuple
+    form is preserved for backward compatibility with the existing
+    wallclock-only tests; missing monotonic defaults to ``"0"`` (the
+    systemd sentinel for "never activated" — handled as wallclock
+    fallback by :func:`check_agora_services_active`).
     """
 
     def runner(
@@ -68,11 +83,14 @@ def _systemctl_runner(per_service: dict[str, tuple[str, str]]) -> scc.Runner:
         timeout: float | None = None,
     ) -> subprocess.CompletedProcess[str]:
         unit = args[2]
-        active, entered = per_service.get(unit, ("inactive", ""))
+        triple = per_service.get(unit, ("inactive", "", "0"))
+        active = triple[0]
+        entered = triple[1] if len(triple) > 1 else ""
+        monotonic = triple[2] if len(triple) > 2 else "0"
         return subprocess.CompletedProcess(
             args=list(args),
             returncode=0,
-            stdout=_show_output(active, entered),
+            stdout=_show_output(active, entered, monotonic),
             stderr="",
         )
 
@@ -212,6 +230,151 @@ class TestCheckAgoraServicesActive:
         )
         assert result.ok is False  # because we returned "inactive"
         assert captured["args"][0][0] == "systemctl"
+
+    # ── monotonic clock path (bug #197) ────────────────────────────────────
+
+    def test_uses_monotonic_clock_when_available(self) -> None:
+        """Happy path: systemd reports ``ActiveEnterTimestampMonotonic``,
+        clock-source is recorded as ``monotonic``, age math uses the
+        injected monotonic-now-fn rather than the wallclock now-fn."""
+        wall_now = _fixed_now(0)
+        # 600s elapsed in monotonic clock; wallclock irrelevant.
+        monotonic_now_s = 3600.0
+        entered_monotonic_us = (3600.0 - 600.0) * 1_000_000
+        entered_at = (wall_now - timedelta(seconds=600)).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        runner = _systemctl_runner(
+            {
+                svc: ("active", entered_at, str(int(entered_monotonic_us)))
+                for svc in DEFAULT_AGORA_SERVICES
+            }
+        )
+        result = check_agora_services_active(
+            runner=runner,
+            now_fn=lambda: wall_now,
+            monotonic_now_fn=lambda: monotonic_now_s,
+        )
+        assert result.ok is True
+        per_service = result.measurement["per_service"]
+        for svc in DEFAULT_AGORA_SERVICES:
+            assert per_service[svc]["clock_source"] == "monotonic"
+            assert per_service[svc]["active_for_seconds"] == pytest.approx(600.0)
+
+    def test_clock_skew_immunity_via_monotonic(self) -> None:
+        """The bug #197 repro: wallclock-derived age is negative because
+        NTP stepped the clock forward after the service registered its
+        ``ActiveEnterTimestamp``. With the monotonic property populated,
+        the gate must ignore the corrupt wallclock and report passing."""
+        wall_now = _fixed_now(0)
+        # The corrupt wallclock entered_at is 1h *ahead* of now, which
+        # would yield active_for_seconds=-3600 on the wallclock path
+        # (exactly the symptom we saw on Pi100 v0.0.13).
+        bad_entered_at = (wall_now + timedelta(seconds=3600)).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        # Monotonic clock — independently — says 600s of uptime, which
+        # is a clean pass against the 300s default threshold.
+        monotonic_now_s = 1200.0
+        entered_monotonic_us = 600 * 1_000_000
+        runner = _systemctl_runner(
+            {
+                svc: ("active", bad_entered_at, str(entered_monotonic_us))
+                for svc in DEFAULT_AGORA_SERVICES
+            }
+        )
+        result = check_agora_services_active(
+            runner=runner,
+            now_fn=lambda: wall_now,
+            monotonic_now_fn=lambda: monotonic_now_s,
+        )
+        assert result.ok is True, (
+            f"monotonic path must mask wallclock skew, got {result}"
+        )
+        per_service = result.measurement["per_service"]
+        for svc in DEFAULT_AGORA_SERVICES:
+            assert per_service[svc]["clock_source"] == "monotonic"
+            assert per_service[svc]["active_for_seconds"] == pytest.approx(600.0)
+
+    def test_falls_back_to_wallclock_when_monotonic_zero(self) -> None:
+        """systemd reports ``ActiveEnterTimestampMonotonic=0`` for units
+        that have never activated (or for transient bugs we shouldn't
+        amplify). The gate must fall back to the wallclock path and
+        report ``clock_source="wallclock"`` so the caller can audit."""
+        wall_now = _fixed_now(0)
+        entered_at = (wall_now - timedelta(seconds=600)).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        runner = _systemctl_runner(
+            {
+                svc: ("active", entered_at, "0")
+                for svc in DEFAULT_AGORA_SERVICES
+            }
+        )
+        result = check_agora_services_active(
+            runner=runner,
+            now_fn=lambda: wall_now,
+            monotonic_now_fn=lambda: 9999.0,  # ignored
+        )
+        assert result.ok is True
+        per_service = result.measurement["per_service"]
+        for svc in DEFAULT_AGORA_SERVICES:
+            assert per_service[svc]["clock_source"] == "wallclock"
+            assert per_service[svc]["active_for_seconds"] == pytest.approx(600.0)
+
+    def test_negative_age_treated_as_failure(self) -> None:
+        """If the monotonic clock disagrees with the property (e.g. the
+        property was sampled *after* the now-fn returned), the gate
+        must not silently pass — it must report failure with
+        ``measurement.reason='negative_age'``. This is the safety net
+        in case there's an unanticipated clock-source ordering bug."""
+        wall_now = _fixed_now(0)
+        entered_at = (wall_now - timedelta(seconds=600)).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        # Monotonic now < monotonic entered: -100s age.
+        runner = _systemctl_runner(
+            {
+                svc: ("active", entered_at, str(1000 * 1_000_000))
+                for svc in DEFAULT_AGORA_SERVICES
+            }
+        )
+        result = check_agora_services_active(
+            runner=runner,
+            now_fn=lambda: wall_now,
+            monotonic_now_fn=lambda: 900.0,
+        )
+        assert result.ok is False
+        assert result.measurement["reason"] == "negative_age"
+        assert result.measurement["clock_source"] == "monotonic"
+        assert result.measurement["active_for_seconds"] < 0
+
+
+# ── _parse_systemd_monotonic_us ────────────────────────────────────────────
+
+
+class TestParseSystemdMonotonicUs:
+    def test_zero_returns_none(self) -> None:
+        assert scc._parse_systemd_monotonic_us("0") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert scc._parse_systemd_monotonic_us("") is None
+
+    def test_whitespace_returns_none(self) -> None:
+        assert scc._parse_systemd_monotonic_us("   ") is None
+
+    def test_non_integer_returns_none(self) -> None:
+        assert scc._parse_systemd_monotonic_us("not-a-number") is None
+
+    def test_negative_returns_none(self) -> None:
+        assert scc._parse_systemd_monotonic_us("-1") is None
+
+    def test_positive_returns_int(self) -> None:
+        # 10s after boot expressed as microseconds.
+        assert scc._parse_systemd_monotonic_us("10000000") == 10_000_000
+
+    def test_strips_whitespace(self) -> None:
+        assert scc._parse_systemd_monotonic_us("  12345  ") == 12345
 
 
 # ── check_framebuffer ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`slot_confirm`'s `agora_services_active` check computes service-uptime by subtracting two **wallclock** readings. On Pi 5 (no battery-backed RTC), the wallclock can jump arbitrarily during boot when ``systemd-timesyncd`` syncs to NTP — and ``ActiveEnterTimestamp`` from systemd is the *pre-correction* wallclock while ``datetime.now()`` is the *post-correction* wallclock. The difference is garbage (often negative). Slot-confirm fails the time-gate even though agora-api has been up for plenty of real time, slot-mgr strikes the slot, no promote happens.

## Repro (real, on Pi5 192.168.1.100, 2026-05-15)

OTA v0.0.12-test -> v0.0.13-test. Tryboot landed on slot B, agora-api came up clean. ``agora-slot-mgr`` ran, emitted:

```json
{
  "name": "agora_services_active",
  "ok": false,
  "detail": "agora-api.service has been active for -3594s, need >=300s",
  "measurement": {
    "service": "agora-api.service",
    "active_for_seconds": -3593.877835,
    "min_active_seconds": 300,
    "entered_at": "2026-05-15T00:41:41+00:00"
  }
}
```

``active_for_seconds = -3594`` — i.e. ~1h *in the future*. Three other checks (framebuffer/data_writable/wps_connected) passed. ``next_action: strike``. Strike counter advanced, slot stayed tentative, autoboot.txt ``[all]`` not rewritten. On next reboot the device reverts to slot A v0.0.12 because tryboot is one-shot.

## Root cause

``slot_confirm/core.py:184-300`` ``check_agora_services_active``:

```python
now = (now_fn or _default_now)()                  # datetime.now(tz=UTC) -> wallclock
...
"--property=ActiveEnterTimestamp"                 # wallclock from systemd
...
entered = _parse_systemd_timestamp(enter_raw)     # wallclock
age = (now - entered).total_seconds()             # delta of two wallclocks
if age < min_active_seconds:                      # fails if either reading drifted
```

Both readings are wallclock. **If NTP jumps the wallclock between the two readings, the math breaks.** Pi 5 is a 100% repro because there's no RTC: kernel boots with whatever timestamp was on the last block-device write, agora-api gets ``ActiveEnterTimestamp`` recorded against that initial clock, ``systemd-timesyncd`` later jumps the clock to real UTC, slot-confirm runs against the corrected clock.

Sign of the drift depends on whether the kernel-boot clock was ahead of or behind real UTC. In our repro the pre-NTP clock was ~1h *ahead* of real UTC, so the correction was backwards, giving negative age. The reverse (pre-NTP behind real UTC) would give an implausibly large positive age, which would pass the gate but on a lie.

## Why slot-mgr's oneshot model amplifies this

``agora-slot-mgr.service`` is a oneshot triggered at boot. It runs once, scores the slot, exits. No retry. A transient clock skew at boot is therefore *fatal* — three of these unlucky boots in a row (the strike counter is per-slot) and slot-mgr pins the device to last-known-good. With this bug, EVERY first boot of a fresh slot strikes, so every OTA accumulates strikes monotonically.

## Fix

Use the **monotonic** boot clock for the age math. systemd already exposes ``ActiveEnterTimestampMonotonic`` (microseconds since boot, CLOCK_MONOTONIC), and Python's ``time.monotonic()`` is CLOCK_MONOTONIC on Linux. Both are immune to ``settimeofday()`` calls.

Keep the wallclock ``ActiveEnterTimestamp`` in the ``measurement`` payload for human-readable telemetry (and for log correlation), but compute ``age`` from the monotonic values.

**Diff sketch:**

```python
# Query both timestamps from systemctl
"--property=ActiveState",
"--property=ActiveEnterTimestamp",
"--property=ActiveEnterTimestampMonotonic",   # NEW

# Parse the monotonic value (microseconds since boot, int)
entered_monotonic_us = int(monotonic_raw)
now_monotonic_s = time.monotonic()
age = now_monotonic_s - (entered_monotonic_us / 1_000_000)

# Keep wallclock entered_at in measurement for telemetry, but don't use it for the gate
```

Also add a belt-and-suspenders guard to the service unit:

```
# slot_confirm/data/agora-slot-mgr.service
[Unit]
After=time-sync.target network-online.target agora-api.service
Wants=time-sync.target
```

This won't fix the bug on its own (``ActiveEnterTimestamp`` is still wallclock), but ensures the wallclock is at least one-NTP-sync-corrected by the time slot-mgr runs, which makes telemetry more useful and protects any other wallclock-sensitive code we add later.

## Tests

In ``tests/test_slot_confirm.py``:

1. **Existing behaviour preserved (wallclock case):** stub ``runner`` to emit consistent wallclock and monotonic values, ``min_active_seconds=300``, monotonic_us = 400e6 -> ok=True.
2. **Clock-skew immunity (the failing real-world case):** stub ``runner`` to emit wallclock ``entered_at = now+1h`` (NTP-correction-backward) but ``ActiveEnterTimestampMonotonic`` = 400e6 (i.e. 400s real uptime). With ``now_monotonic_fn`` returning 600.0, age = 200s -> ok=False on threshold, ok=True at 300s. Critically, the gate decision is driven by monotonic, NOT wallclock — the negative-wallclock-delta case is no longer fatal.
3. **Missing monotonic field (graceful degradation):** if ``ActiveEnterTimestampMonotonic`` is missing from systemctl output (older systemd?), fall back to wallclock with a logged warning and a measurement field ``"clock_source": "wallclock"``.
4. **Negative monotonic age (sanity guard):** if computed monotonic age is negative (shouldn't happen, but defense in depth), treat as ok=False with detail ``"clock source inconsistent"`` and a distinct ``measurement.reason`` so this case is auditable from telemetry.

## Workaround until fixed

Manually promote the slot by editing ``/boot/firmware/autoboot.txt`` (``[all] boot_partition=3`` for slot B). Bypasses slot-mgr entirely. Or: reboot the device 3+ times before the strike counter triggers a pin — by the third boot ``systemd-timesyncd`` has typically established a steady time and the bug may not fire. Neither is acceptable for production.

## Related

- agora#196 (separate dispatch crash that forced us to use the manual ``stage`` CLI for this OTA test)
- Phase 1 D44 ("watchdog wiring + slot mechanics") in agora-cms#544 plan — this is a Phase 1 oversight; the spec calls for ``agora-api active for >=5 min`` but didn't specify a clock source
- F20 ("Pi 5 may ship without RTC battery") in agora-cms#544 plan — flagged the clock-at-boot risk for ``agora-firstboot``, but the same risk applies to anything reading wallclock during boot
