### PR TITLE
fix(os-updater): copy /home/agora/.ssh in fleet-state COPY_IF_PRESENT (#198)

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -88,6 +88,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -216,9 +217,14 @@ FLEET_STATE_REQUIRED: tuple[str, ...] = (
 #: ``api_key`` is absent before the device has completed its first
 #: CMS handshake; ``agora-api`` re-mints it on first contact.
 #: ``wifi-*.nmconnection`` is empty for ethernet-only deployments.
+#: ``home/agora/.ssh`` is absent on production-deployed Pis that have
+#: no operator SSH access — copied as a directory entry so ``cp -a``
+#: carries the 0700 perms + ``agora:agora`` ownership that ``sshd``
+#: enforces on ``authorized_keys`` (see agora#198).
 FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = (
     "opt/agora/persist/api_key",
     "etc/NetworkManager/system-connections/wifi-*.nmconnection",
+    "home/agora/.ssh",
 )
 
 #: Relative path inside the inactive slot's root where the bundle ships
@@ -1034,6 +1040,15 @@ def _cp_one(
     rel = src.relative_to(slot_a_root)
     dst = slot_b_root / rel
     dst.parent.mkdir(parents=True, exist_ok=True)
+
+    # If ``src`` is a directory (e.g. ``home/agora/.ssh``) and ``dst``
+    # already exists on slot B from a prior partial apply, remove it
+    # first so ``cp -a`` writes AT ``dst`` rather than INTO ``dst`` —
+    # i.e. avoids creating ``slot_b/home/agora/.ssh/.ssh``. Safe
+    # because copy_fleet_state is the sole source of truth for the
+    # fleet-state entries on slot B.
+    if src.is_dir() and dst.exists():
+        shutil.rmtree(dst)
 
     # ``rel.as_posix()`` keeps the telemetry-bound path forward-slash
     # regardless of host platform — devices are Linux but tests run

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -927,6 +927,14 @@ def _seed_fake_slot_a(slot_a_root: Path) -> None:
         "etc/NetworkManager/system-connections/wifi-home.nmconnection": (
             b"[connection]\nid=home\n"
         ),
+        # Optional operator SSH state — D60 gap fix (agora#198). The
+        # ``home/agora/.ssh`` entry in FLEET_STATE_COPY_IF_PRESENT is a
+        # directory; seeding ``authorized_keys`` here causes the parent
+        # ``.ssh`` dir to exist on slot A, which is what
+        # ``_resolve_fleet_state_sources`` returns for that literal.
+        "home/agora/.ssh/authorized_keys": (
+            b"ssh-ed25519 AAAAfake-key-for-test operator@workstation\n"
+        ),
     }
     for rel, content in files.items():
         path = slot_a_root / rel
@@ -1104,8 +1112,8 @@ class TestSlotStagerHappyPath:
             f"expected only cp calls in runner, got {heads}"
         )
         # 4 required literals + 2 ssh host keys + 1 optional wifi nmconnection
-        # from _seed_fake_slot_a == 7 cp invocations.
-        assert len(heads) == 7
+        # + 1 home/agora/.ssh dir from _seed_fake_slot_a == 8 cp invocations.
+        assert len(heads) == 8
 
         # Boot was streamed into slot-B boot mount.
         boot_call = next(c for c in pipeline.calls if c[0] == "boot")
@@ -1409,8 +1417,9 @@ class TestCopyFleetState:
         copy_fleet_state(slot_a, slot_b, runner=runner)
 
         cps = [c for c in runner.calls if c[0] == "cp"]
-        # 4 required literals + 2 ssh host keys + 1 optional wifi conn = 7
-        assert len(cps) == 7, f"expected 7 cp invocations, got {len(cps)}: {cps}"
+        # 4 required literals + 2 ssh host keys + 1 optional wifi conn
+        # + 1 home/agora/.ssh dir = 8
+        assert len(cps) == 8, f"expected 8 cp invocations, got {len(cps)}: {cps}"
         # Every cp call uses cp -a (preserve mode/owner/timestamps).
         for cp in cps:
             assert cp[1] == "-a", f"expected cp -a, got {cp}"
@@ -1473,8 +1482,9 @@ class TestCopyFleetState:
             copy_fleet_state(slot_a, slot_b, runner=runner)
 
         cps = [c for c in runner.calls if c[0] == "cp"]
-        # Required set still copied: 4 literals + 2 ssh keys = 6.
-        assert len(cps) == 6
+        # Required set still copied: 4 literals + 2 ssh keys = 6, plus
+        # the still-present home/agora/.ssh optional dir = 7.
+        assert len(cps) == 7
         # A skip event must be logged for diagnostic purposes.
         assert any("fleet_state_skipped" in r.message for r in caplog.records)
 
@@ -1505,6 +1515,109 @@ class TestCopyFleetState:
             copy_fleet_state(slot_a, slot_b, runner=runner)
 
         assert exc_info.value.path == "etc/agora/environment"
+
+    # ── home/agora/.ssh — D60 gap fix (agora#198) ──────────────────────────
+
+    def test_ssh_dir_copied_when_present(self, tmp_path):
+        """``home/agora/.ssh`` is a directory entry in COPY_IF_PRESENT.
+        When the directory exists on slot A, ``copy_fleet_state`` issues
+        a single ``cp -a`` for the directory itself (not one per child),
+        so ``cp -a`` preserves the 0700 perms + ``agora:agora`` ownership
+        that ``sshd`` enforces on ``authorized_keys`` (see agora#198).
+        """
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        runner = _FakeRunner()
+
+        copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        cps = [c for c in runner.calls if c[0] == "cp"]
+        ssh_cps = [
+            c for c in cps
+            if c[-2].endswith(str(Path("home/agora/.ssh")))
+            or c[-2].endswith(str(Path("home") / "agora" / ".ssh"))
+        ]
+        assert len(ssh_cps) == 1, (
+            f"expected exactly one cp -a for home/agora/.ssh as a directory, "
+            f"got: {ssh_cps}"
+        )
+        # cp -a was used (preserves perms/owner).
+        assert ssh_cps[0][1] == "-a"
+        # Source is the slot-A .ssh dir; destination is under slot-B.
+        assert str(slot_a / "home" / "agora" / ".ssh") == ssh_cps[0][-2]
+        assert str(slot_b / "home" / "agora" / ".ssh") == ssh_cps[0][-1]
+
+    def test_ssh_dir_absent_skips_silently(self, tmp_path, caplog):
+        """A production-deployed Pi may have no operator SSH access.
+        Absence of ``home/agora/.ssh`` must NOT abort the apply — it's
+        ``COPY_IF_PRESENT``, not ``REQUIRED``.
+        """
+        import logging
+        import shutil as _shutil
+
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        # Drop the seeded .ssh dir.
+        _shutil.rmtree(slot_a / "home" / "agora" / ".ssh")
+        runner = _FakeRunner()
+
+        with caplog.at_level(logging.INFO, logger="os_updater.apply"):
+            copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        cps = [c for c in runner.calls if c[0] == "cp"]
+        # 4 required literals + 2 ssh host keys + 1 wifi optional = 7.
+        assert len(cps) == 7
+        # The skip event must mention the .ssh path so operator-facing
+        # telemetry can distinguish "missing wifi" from "missing .ssh".
+        skip_records = [
+            r for r in caplog.records
+            if "fleet_state_skipped" in r.message and "home/agora/.ssh" in r.message
+        ]
+        assert skip_records, (
+            f"expected a fleet_state_skipped log for home/agora/.ssh, "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_ssh_dir_idempotent_replaces_stale_dst(self, tmp_path):
+        """If slot B already has a ``home/agora/.ssh`` from a prior
+        partial-apply recovery, ``_cp_one`` must ``rmtree`` it before
+        ``cp -a`` so the source ends up AT dst, not nested as
+        ``slot_b/home/agora/.ssh/.ssh``.
+        """
+        slot_a = tmp_path / "slot-a"
+        slot_b = tmp_path / "slot-b"
+        slot_b.mkdir()
+        _seed_fake_slot_a(slot_a)
+        # Simulate a stale .ssh directory left over from a prior
+        # partial apply (e.g. apply aborted after rsync but before
+        # tryboot triggered).
+        stale_ssh = slot_b / "home" / "agora" / ".ssh"
+        stale_ssh.mkdir(parents=True)
+        stale_marker = stale_ssh / "stale_authorized_keys"
+        stale_marker.write_bytes(b"this should be removed before cp -a runs\n")
+        assert stale_marker.exists()
+
+        runner = _FakeRunner()
+        copy_fleet_state(slot_a, slot_b, runner=runner)
+
+        # The stale destination must have been removed by ``_cp_one``'s
+        # rmtree guard. Because ``_FakeRunner`` does NOT execute ``cp``,
+        # the dst directory should now not exist at all (rmtree removed
+        # it; the mocked cp left nothing).
+        assert not stale_marker.exists(), (
+            "stale slot-B .ssh content survived: rmtree guard in _cp_one did not fire"
+        )
+        assert not stale_ssh.exists(), (
+            "expected slot_b/home/agora/.ssh to be removed by _cp_one's rmtree guard "
+            "(mocked cp does not recreate it)"
+        )
+        # And the parent home/agora dir must still exist (mkdir was called
+        # before the rmtree, on the parent — that's the structural invariant).
+        assert (slot_b / "home" / "agora").exists()
 
 
 # ── SlotStager × fleet-state integration (D60) ─────────────────────────────


### PR DESCRIPTION
## Summary

``copy_fleet_state`` (D60, ``os_updater/apply.py``) copies machine-id, SSH **host** keys, wifi connection files, CMS config, and the per-device API key from slot A to slot B at apply-time — but does NOT carry ``/home/agora/.ssh/``. Every fresh slot is therefore SSH-passwordless-broken: ``authorized_keys`` is gone, so the only way back in is the ``agora`` UNIX password (and any operator that pushed keys-only to ``authorized_keys`` is locked out of the freshly-promoted slot).

## Repro (real, on Pi5 192.168.1.100, 2026-05-15)

OTA v0.0.12-test -> v0.0.13-test. Tryboot to slot B succeeded; all 4 agora services up; sudo setuid intact; /home/agora ownership ``agora:agora`` (the v0.0.10 tar-flags fix from PR #188 held). Tried to SSH in with the operator key (``id_pi_agora``); got password prompt instead of key-auth. ``cat /home/agora/.ssh/authorized_keys`` over a password session showed the file did not exist on slot B. Same file is present on slot A (block 1 boot p1).

## Root cause

``os_updater/apply.py:203-222``:

```python
FLEET_STATE_REQUIRED: tuple[str, ...] = (
    "etc/agora/environment",
    "opt/agora/persist/cms_config.json",
    "opt/agora/persist/provisioned",
    "etc/machine-id",
    "etc/ssh/ssh_host_*",
)

FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = (
    "opt/agora/persist/api_key",
    "etc/NetworkManager/system-connections/wifi-*.nmconnection",
)
```

D60 enumerated identity files but missed operator SSH state. The bundle producer correctly strips ``/etc/ssh/ssh_host_*`` and ``/etc/machine-id`` (D63 in agora-cms#544 plan) so the bundle is generic; ``copy_fleet_state`` repopulates them on slot B. Same treatment needs to apply to ``/home/agora/.ssh/``: pi-gen does not create it (the agora user is unprivileged-by-default), so the directory simply doesn't exist on a freshly-unpacked slot B.

## Wrinkle: directory perms

Just adding ``home/agora/.ssh/authorized_keys`` (the file) to ``FLEET_STATE_COPY_IF_PRESENT`` is wrong. ``_cp_one`` calls ``dst.parent.mkdir(parents=True, exist_ok=True)`` which uses the running umask under root, giving mode 0755 root:root. SSH then refuses to use ``authorized_keys`` because ``.ssh/`` has bad ownership/perms:

```
Authentication refused: bad ownership or modes for directory /home/agora/.ssh
```

The right answer is to copy the **directory** ``home/agora/.ssh`` so ``cp -a`` carries the dir's own 0700 perms + ``agora:agora`` ownership. Pi-gen's user creation already makes ``/home/agora/`` owned by ``agora:agora``, so the destination *parent* is fine; only the .ssh subdir needs to exist with correct perms.

## Fix

```python
FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = (
    "opt/agora/persist/api_key",
    "etc/NetworkManager/system-connections/wifi-*.nmconnection",
    "home/agora/.ssh",                                              # NEW
)
```

This is the first directory entry in ``FLEET_STATE_*`` so ``_cp_one`` needs to handle the dir case. Today it works *almost* by accident because ``cp -a`` does the right thing when the destination doesn't exist:

```sh
$ cp -a /home/agora/.ssh /slot_b_root/home/agora/.ssh
# creates dst as a clone of src, preserving perms/owner
```

But if dst happens to exist (re-run apply, partial-failure recovery), ``cp -a`` would create ``/slot_b_root/home/agora/.ssh/.ssh`` — the source ends up nested. To be safe, ``_cp_one`` should pre-remove a directory dst before the copy:

```python
def _cp_one(src, slot_a_root, slot_b_root, pattern, *, runner, cp_timeout_s):
    rel = src.relative_to(slot_a_root)
    dst = slot_b_root / rel
    dst.parent.mkdir(parents=True, exist_ok=True)

    # If src is a directory and dst already exists, remove dst first so
    # ``cp -a`` writes src AT dst (not INTO dst).
    if src.is_dir() and dst.exists():
        shutil.rmtree(dst)

    result = runner(["cp", "-a", str(src), str(dst)], timeout=cp_timeout_s)
    ...
```

Idempotent. Single-purpose. ``shutil.rmtree`` is safe here because ``_cp_one`` only writes under ``slot_b_root`` and ``copy_fleet_state`` is the source of truth for /home/agora/.ssh on slot B.

## Why COPY_IF_PRESENT, not REQUIRED

A production-deployed venue Pi may legitimately have no operator SSH access — the cms-managed device doesn't need it for normal operation. Adding ``home/agora/.ssh`` to ``FLEET_STATE_REQUIRED`` would abort OTA on every such device. COPY_IF_PRESENT degrades gracefully: copy if exists, skip silently otherwise.

## Tests

In ``tests/test_apply_fleet_state.py``:

1. **.ssh dir present -> copied with perms preserved.** ``slot_a/home/agora/.ssh`` mode 0700 owner agora:agora containing ``authorized_keys``. Run ``copy_fleet_state``. Assert ``slot_b/home/agora/.ssh`` is mode 0700 owner agora:agora, contains ``authorized_keys`` byte-identical, structural perms preserved.
2. **.ssh dir absent -> skipped without error.** ``slot_a/home/agora/`` exists but ``.ssh/`` does not. Run ``copy_fleet_state``. Assert telemetry shows ``fleet_state_skipped: home/agora/.ssh`` and no slot B dir was created.
3. **.ssh dir present on slot A, dst already exists on slot B (idempotent re-run).** Pre-populate ``slot_b/home/agora/.ssh/.stale`` to simulate a partial earlier copy. Run ``copy_fleet_state``. Assert the stale file is gone, slot B .ssh is a faithful clone of slot A.
4. **Existing fields unchanged.** Re-run the existing happy-path test from ``test_apply_fleet_state.py`` to confirm the new entry doesn't perturb machine-id/host-keys/wifi/cms_config behaviour.

## Workaround until fixed

After every promote, the operator must one-time ``scp`` (or sudo-edit) their key into ``/home/agora/.ssh/authorized_keys`` on the newly-promoted slot. Painful for any field validation flow and a hard nope for production.

## Related

- D60 ("Fleet state copy-at-apply allowlist") in agora-cms#544 plan — this issue is a D60 gap, not a new design
- D63 ("Identity-file stripping in build-bundle.sh") — same logic applies: ``.ssh/`` is per-device identity that must be stripped from the generic bundle and re-applied per-device
- agora#188 (the tar-flags fix from #187) — that fix proved fleet_state_copy is the right design pattern for everything we strip from the bundle
