### PR TITLE
chore: disable auto-trigger on Build Pi Image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -13,17 +13,16 @@ on:
           - zero2w
           - pi4
           - pi5
-  # Auto-build all boards when a stable release is published. The image is
-  # fully tenant-agnostic — no CMS URL, no WiFi creds, no fleet identity
-  # baked in. The CMS imager stamps /boot/firmware/agora-fleet.env at
-  # imaging time with deployment-specific values, and
-  # agora-fleet-provision.sh (in the firmware) consumes it at first boot.
+  # NOTE: auto-trigger on release-prereleased was disabled in favour of
+  # the agora-os bundle path. Pi5 fresh-flash images are now produced by
+  # sslivins/agora-os's release.yml (A/B GPT layout, OTA-capable). This
+  # workflow is kept for manual builds of zero2w / pi4 images, which
+  # agora-os doesn't yet support. Re-enable by uncommenting the block
+  # below (the job's `if:` and matrix expressions still understand the
+  # `release` event_name).
   #
-  # We trigger on `prereleased` (not `released`) because create-release.yml
-  # publishes new releases as pre-releases. The publish-catalog job below
-  # promotes to a normal release at the end of a successful build.
-  release:
-    types: [prereleased]
+  # release:
+  #   types: [prereleased]
 
 permissions:
   contents: write


### PR DESCRIPTION
# chore: disable auto-trigger on Build Pi Image

## What

Comment out the `release: types: [prereleased]` trigger on
`.github/workflows/build-image.yml`, so new agora releases no longer
fan out to a 3-board pi-gen build automatically.

The workflow remains fully functional via `workflow_dispatch` (manual
runs still pick board, still produce the same artifacts).

## Why

`sslivins/agora-os`'s `release.yml` now produces pi5 fresh-flash
images using the new A/B GPT layout — the architecture we're moving
the fleet to (D52/D55). Each agora-release auto-build was burning
~3×60 min of CI time on every PR-merge to produce single-partition
pi5 images we no longer ship.

zero2w and pi4 are not yet covered by agora-os (single-board matrix
TODO). Keeping this workflow + manual dispatch means we can still
build those when needed — e.g. a fleet adds new pi4 hardware — without
running it on every release.

## Re-enabling

Uncomment the 2-line `release:` block in `on:`. The job's `if:` and
matrix expressions already understand `event_name == 'release'`; no
other changes required. The `publish-catalog` job (also gated on
`event_name == 'release'`) will start firing again automatically.

## Risk

Low. Only the trigger is removed. No artifact contract changes.
The `publish-catalog` job becomes effectively dead code (it's still
gated on `event_name == 'release'` which can no longer fire), but
keeping it in-tree preserves the re-enable contract.

## Test plan

- [x] Diff is comment-and-trigger-only (verified: 11 lines changed, all in `on:`)
- [ ] CI gate (secrets-scan, lint) green on PR
- [ ] After merge: confirm next agora release tag does NOT trigger
      Build Pi Image (only Build & Release + pages-build-and-deployment)
- [ ] Confirm `gh workflow run "Build Pi Image" --repo sslivins/agora -f board=pi4`
      still successfully kicks off a manual build
