### PR TITLE
os_updater: emit STAGE_PROGRESS lifecycle events from stager (#202)

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -186,6 +186,44 @@ DEFAULT_RSYNC_TIMEOUT_S = 1800.0
 #: 30 s is comfortably 1000× the worst real-world case.
 DEFAULT_FLEET_STATE_CP_TIMEOUT_S = 30.0
 
+#: Closed enumeration of phase names emitted by :meth:`SlotStager._stage_sync`
+#: via the optional ``progress_callback``. The CMS-side parser switches
+#: on these strings (carried in ``LifecycleEvent.payload["phase"]``) to
+#: render an upgrade-progress UI, so any addition is a coordinated
+#: change. Order matches the actual emission order during a happy-path
+#: stage. Tracked as ``sslivins/agora#202``.
+STAGE_PROGRESS_PHASES: tuple[str, ...] = (
+    "extracting_meta",
+    "mounting_inactive",
+    "extracting_boot",
+    "extracting_rootfs",
+    "verifying_manifest",
+    "copying_fleet_state",
+    "finalizing",
+)
+
+
+def _safe_emit_progress(
+    progress_callback: Optional[Callable[[str], None]], phase: str
+) -> None:
+    """Best-effort invocation of a stage progress callback.
+
+    The callback is wired by the service to ``emit_event(STAGE_PROGRESS, ...)``
+    which can fail (full disk on ``/data``, sink down, etc.). A buggy
+    callback or a sink failure must NOT brick an OTA mid-stage — the
+    progress signal is purely advisory. Swallow + log on failure;
+    :meth:`_stage_sync` keeps running.
+    """
+
+    if progress_callback is None:
+        return
+    try:
+        progress_callback(phase)
+    except Exception:  # noqa: BLE001 — intentional firewall around advisory callback
+        logger.exception(
+            "progress_callback raised on phase=%s; continuing stage", phase
+        )
+
 #: Root of the currently-running rootfs (slot A) from which
 #: :func:`copy_fleet_state` reads per-device identity files. Path is
 #: ``/`` in production; tests inject ``tmp_path`` to bypass.
@@ -1168,16 +1206,38 @@ class SlotStager:
     #: device node. Tests inject a tmp path.
     partlabel_base: Path = field(default_factory=lambda: DEFAULT_PARTLABEL_BASE)
 
-    async def stage(self, payload: DispatchPayload, staging_dir: Path) -> None:
+    async def stage(
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
         """Run the full stage-and-tryboot pipeline (10-step streaming orchestration).
 
         Async entrypoint matching the :class:`Stager` protocol. The
         synchronous body lives in :meth:`_stage_sync` for ease of
         testing without an event loop.
-        """
-        await asyncio.to_thread(self._stage_sync, payload, staging_dir)
 
-    def _stage_sync(self, payload: DispatchPayload, staging_dir: Path) -> None:
+        ``progress_callback``, if provided, is invoked with each phase
+        name from :data:`STAGE_PROGRESS_PHASES` at that phase's
+        boundary (before the phase's work begins). Callback exceptions
+        are caught and logged — they do not interrupt the stage.
+        """
+        await asyncio.to_thread(
+            self._stage_sync,
+            payload,
+            staging_dir,
+            progress_callback=progress_callback,
+        )
+
+    def _stage_sync(
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
         staging_dir = Path(staging_dir)
         bundle_path = staging_dir / self.bundle_filename
         meta_path = staging_dir / self.meta_filename
@@ -1193,6 +1253,7 @@ class SlotStager:
 
         # 1. Meta-only extract — cheapest target_version reject before
         # we touch the inactive partitions. ~30s zstd pass with tar -O.
+        _safe_emit_progress(progress_callback, "extracting_meta")
         extract_meta_only(
             bundle_path,
             meta_path,
@@ -1242,6 +1303,7 @@ class SlotStager:
         # ``ensure_partition_mounted`` is idempotent — if a systemd
         # unit already mounted the partition (the agora-os 0.0.8+
         # path), this is a no-op.
+        _safe_emit_progress(progress_callback, "mounting_inactive")
         boot_target = boot_mount_for_slot(
             inactive,
             slot_a_mount=self.boot_mount_slot_a,
@@ -1272,6 +1334,7 @@ class SlotStager:
         # 6. Stream boot/ subtree straight onto the inactive boot partition.
         # --strip-components=1 turns "boot/foo" into "<boot_target>/foo" and
         # naturally filters anything not under boot/.
+        _safe_emit_progress(progress_callback, "extracting_boot")
         stream_extract_subtree(
             bundle_path,
             self.boot_subdir,
@@ -1282,6 +1345,7 @@ class SlotStager:
         )
 
         # 7. Stream root/ subtree straight onto the inactive root partition.
+        _safe_emit_progress(progress_callback, "extracting_rootfs")
         stream_extract_subtree(
             bundle_path,
             self.root_subdir,
@@ -1293,6 +1357,7 @@ class SlotStager:
 
         # 8. Manifest sha256 verification — hash the bytes that actually
         # landed on the partitions.
+        _safe_emit_progress(progress_callback, "verifying_manifest")
         verify_bundle_manifest(
             {self.boot_subdir: boot_target, self.root_subdir: root_target},
             meta,
@@ -1306,6 +1371,7 @@ class SlotStager:
         # 9. Copy per-device fleet-state files from slot A into slot B.
         # Done AFTER manifest verify so the manifest check doesn't see
         # files added by us. Implements D60 of plan.md §"Phase 2".
+        _safe_emit_progress(progress_callback, "copying_fleet_state")
         copy_fleet_state(
             self.slot_a_root,
             root_target,
@@ -1320,6 +1386,7 @@ class SlotStager:
         # was deleted by build-bundle.sh. We render it for the inactive
         # slot here. Per plan.md §"v0.0.4-test bug list", this is critical
         # to avoid bricking the device on tryboot.
+        _safe_emit_progress(progress_callback, "finalizing")
         substitute_fstab(root_target, inactive)
 
         # 10b. Rewrite cmdline.txt for the target slot — bundles ship per-

--- a/os_updater/events.py
+++ b/os_updater/events.py
@@ -57,6 +57,16 @@ class LifecycleEventType(str, enum.Enum):
     DOWNLOAD_STARTED = "download_started"
     SIGNATURE_VERIFIED = "signature_verified"
     STAGED = "staged"
+    #: Sub-phase milestone emitted from within :meth:`SlotStager.stage`
+    #: so the operator (and a future CMS upgrade-progress UI) can see
+    #: which phase of the multi-minute staging pipeline is in flight.
+    #: Carries ``payload = {"phase": <one of STAGE_PROGRESS_PHASES>}``.
+    #: This is in-addition-to the existing ``STAGED`` bookends emitted
+    #: by the service before stage starts and the ``TRYBOOT_INITIATED``
+    #: emitted after stage ends, so dropping STAGE_PROGRESS events
+    #: never desynchronizes the CMS-side state machine. Tracked as
+    #: ``sslivins/agora#202``.
+    STAGE_PROGRESS = "stage_progress"
     TRYBOOT_INITIATED = "tryboot_initiated"
     SLOT_CONFIRMED = "slot_confirmed"
     PROMOTED = "promoted"

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -168,7 +168,11 @@ class Stager(Protocol):
     """Owns rsync-to-inactive-slot + agora-slot-mgr trigger-tryboot (p2-stage-and-tryboot)."""
 
     async def stage(
-        self, payload: DispatchPayload, staging_dir: Path
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[str], None]] = None,
     ) -> None:  # pragma: no cover - protocol
         ...
 
@@ -230,7 +234,13 @@ class _DefaultVerifier:
 
 @dataclass
 class _DefaultStager:
-    async def stage(self, payload: DispatchPayload, staging_dir: Path) -> None:
+    async def stage(
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ) -> None:
         raise NotImplementedError("stager not wired; see p2-stage-and-tryboot")
 
 
@@ -426,7 +436,30 @@ class OSUpdaterService:
 
             transition(self.state, UpdaterFSMState.TRYBOOT_PENDING)
             save_state(self.state, path=self.state_path)
-            await self.stager.stage(payload, staging_dir)
+
+            def _on_stage_progress(phase: str) -> None:
+                """Wired into :meth:`Stager.stage` so each phase boundary
+                emits a STAGE_PROGRESS lifecycle event (agora#202).
+
+                Bound here so the closure captures ``self.state`` /
+                ``self.event_sink`` / ``self.state_path`` at the moment
+                this dispatch is in flight, not at stager-construction
+                time. ``emit_event`` already swallows sink failures, and
+                the stager wraps this callback in its own safe-invoke,
+                so any failure here is logged-and-ignored — STAGE_PROGRESS
+                is advisory.
+                """
+                emit_event(
+                    self.state,
+                    LifecycleEventType.STAGE_PROGRESS,
+                    self.event_sink,
+                    payload={"phase": phase},
+                    state_path=self.state_path,
+                )
+
+            await self.stager.stage(
+                payload, staging_dir, progress_callback=_on_stage_progress
+            )
 
             transition(self.state, UpdaterFSMState.TRYBOOT_RUNNING)
             save_state(self.state, path=self.state_path)

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -40,6 +40,7 @@ from os_updater.apply import (
     DEFAULT_ROOT_MOUNT_OPTS,
     FLEET_STATE_COPY_IF_PRESENT,
     FLEET_STATE_REQUIRED,
+    STAGE_PROGRESS_PHASES,
     CmdlineError,
     FleetStateMissingError,
     FleetStateWriteError,
@@ -1738,3 +1739,74 @@ class TestSlotStagerMountIntegration:
             f"mountpoints; got {mount_calls!r}"
         )
 
+
+
+# -- SlotStager: progress_callback (agora#202) ----------------------------
+
+
+class TestSlotStagerProgressCallback:
+    """The optional ``progress_callback`` kwarg fires once per phase boundary.
+
+    Wired by the service to ``emit_event(STAGE_PROGRESS, ...)``; tests
+    here pin the contract that (a) all 7 phases fire in declared order,
+    (b) a missing kwarg keeps the legacy code path silent, (c) a
+    raising callback does NOT brick the stage. The exhaustive phase
+    list lives in :data:`STAGE_PROGRESS_PHASES`.
+    """
+
+    def test_phases_emitted_in_declared_order(self, tmp_path):
+        """Happy-path stage with a list-collector callback gets all
+        7 phase names in :data:`STAGE_PROGRESS_PHASES` order."""
+        phases: list[str] = []
+        staging_dir, stager, _pipeline = _setup_stager_with_bundle(
+            tmp_path, running_slot=1,
+        )
+        stager._stage_sync(
+            _make_payload(), staging_dir, progress_callback=phases.append,
+        )
+        assert tuple(phases) == STAGE_PROGRESS_PHASES
+
+    def test_default_no_callback_keeps_legacy_behavior(self, tmp_path):
+        """Omitting the kwarg matches pre-#202 behavior — regression guard."""
+        tryboot_calls: list[int] = []
+        staging_dir, stager, _pipeline = _setup_stager_with_bundle(
+            tmp_path, running_slot=1, trigger_tryboot_calls=tryboot_calls,
+        )
+        stager._stage_sync(_make_payload(), staging_dir)
+        assert tryboot_calls == [2]
+
+    def test_raising_callback_does_not_break_stage(self, tmp_path):
+        """A buggy callback that throws on every phase must NOT brick
+        an in-flight OTA — STAGE_PROGRESS is advisory. Tryboot still
+        fires; cmdline + fstab still rewritten on slot B."""
+        tryboot_calls: list[int] = []
+        staging_dir, stager, _pipeline = _setup_stager_with_bundle(
+            tmp_path, running_slot=1, trigger_tryboot_calls=tryboot_calls,
+        )
+
+        def boom(phase: str) -> None:
+            raise RuntimeError(f"crash on phase {phase!r}")
+
+        stager._stage_sync(
+            _make_payload(), staging_dir, progress_callback=boom,
+        )
+
+        assert tryboot_calls == [2]
+        cmdline = (stager.boot_mount_slot_b / "cmdline.txt").read_text()
+        assert "root=PARTLABEL=root-B" in cmdline
+
+    def test_async_entrypoint_forwards_callback(self, tmp_path):
+        """``SlotStager.stage`` is the async wrapper around ``_stage_sync``;
+        the new kwarg must pass through both layers."""
+        import asyncio
+
+        phases: list[str] = []
+        staging_dir, stager, _pipeline = _setup_stager_with_bundle(
+            tmp_path, running_slot=1,
+        )
+        asyncio.run(
+            stager.stage(
+                _make_payload(), staging_dir, progress_callback=phases.append,
+            )
+        )
+        assert tuple(phases) == STAGE_PROGRESS_PHASES

--- a/tests/test_os_updater_events.py
+++ b/tests/test_os_updater_events.py
@@ -272,3 +272,35 @@ class TestOutboxEventSink:
         )
         assert (outbox / "2026-05-07.jsonl").exists()
         assert (outbox / "2026-05-08.jsonl").exists()
+
+
+
+class TestStageProgressEnum:
+    """Pins the public contract that the STAGE_PROGRESS enum value
+    is stable (agora#202). CMS dispatches lifecycle-event handlers off
+    this string; renaming it without coordinating the CMS change would
+    silently lose progress events."""
+
+    def test_enum_value_is_stable_wire_format(self):
+        assert LifecycleEventType.STAGE_PROGRESS.value == "stage_progress"
+
+    def test_event_round_trips_through_sink_with_phase_payload(self, tmp_path):
+        """emit_event must accept payload={'phase': ...} and the sink
+        must receive a LifecycleEvent whose payload preserves it. This
+        is the exact shape the service-side closure produces."""
+        state_path = tmp_path / "state.json"
+        s = UpdaterState(release_id="rel-1", target_version="1.0.0")
+        sink = _ListSink()
+
+        event = emit_event(
+            s,
+            LifecycleEventType.STAGE_PROGRESS,
+            sink,
+            payload={"phase": "extracting_rootfs"},
+            state_path=state_path,
+            now_fn=_FixedNow(),
+        )
+
+        assert event.event_type is LifecycleEventType.STAGE_PROGRESS
+        assert event.payload == {"phase": "extracting_rootfs"}
+        assert sink.events == [event]

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -638,3 +638,104 @@ class TestContinueAfterPromote:
         assert s.state.fsm is UpdaterFSMState.IDLE
         assert migrator.calls == 0
         assert sink.events == []
+
+
+
+# -- handle_dispatch wires STAGE_PROGRESS (agora#202) ----------------------
+
+
+class _ProgressEmittingStager:
+    """Fake stager that captures the ``progress_callback`` kwarg and
+    invokes it once during ``stage()``. Used to verify the service
+    closure emits a STAGE_PROGRESS lifecycle event with the right
+    phase payload."""
+
+    def __init__(self, phase: str = "extracting_rootfs") -> None:
+        self.phase = phase
+        self.calls: list[tuple] = []
+        self.captured_callback = None
+
+    async def stage(self, payload, staging_dir, *, progress_callback=None):
+        self.calls.append(("stage", payload, staging_dir))
+        self.captured_callback = progress_callback
+        if progress_callback is not None:
+            progress_callback(self.phase)
+
+
+class TestHandleDispatchStageProgress:
+    """The service-side ``_on_stage_progress`` closure forwards each
+    phase the stager announces into a STAGE_PROGRESS lifecycle event
+    on the outbox (agora#202)."""
+
+    def test_stager_callback_emits_stage_progress_event(self, tmp_path):
+        sink = _ListSink()
+        stager = _ProgressEmittingStager(phase="extracting_rootfs")
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            stager=stager,
+        )
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-progress")))
+
+        # Service handed the stager a non-None callback.
+        assert stager.captured_callback is not None
+
+        # Exactly one STAGE_PROGRESS event with the right payload.
+        progress_events = [
+            e for e in sink.events
+            if e.event_type is LifecycleEventType.STAGE_PROGRESS
+        ]
+        assert len(progress_events) == 1
+        assert progress_events[0].payload == {"phase": "extracting_rootfs"}
+        assert progress_events[0].release_id == "rel-progress"
+        assert progress_events[0].target_version == "1.1.0"
+
+    def test_stage_progress_lands_between_staged_and_tryboot_initiated(self, tmp_path):
+        """Progress is mid-stage, so its event_id must sit after STAGED
+        and before TRYBOOT_INITIATED in the outbox stream. Pinning the
+        ordering keeps CMS-side rollups sane."""
+        sink = _ListSink()
+        stager = _ProgressEmittingStager(phase="finalizing")
+        s = _build_service(tmp_path, current_version="1.0.0", sink=sink, stager=stager)
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-order")))
+
+        kinds = [e.event_type for e in sink.events]
+        assert LifecycleEventType.STAGE_PROGRESS in kinds
+
+        progress_idx = kinds.index(LifecycleEventType.STAGE_PROGRESS)
+        # The service emits SIGNATURE_VERIFIED + STAGED *before* it
+        # calls stager.stage(progress_callback=...), then emits
+        # TRYBOOT_INITIATED once stage() resolves. The progress
+        # callback fires *inside* stage(), so the progress event
+        # lands between STAGED and TRYBOOT_INITIATED in event_id
+        # order. Pinning this ordering keeps CMS-side rollups sane.
+        staged_idx = kinds.index(LifecycleEventType.STAGED)
+        tryboot_idx = kinds.index(LifecycleEventType.TRYBOOT_INITIATED)
+        assert staged_idx < progress_idx < tryboot_idx
+
+        # Monotonic event_id matches ordering.
+        ids = [e.event_id for e in sink.events]
+        assert ids == sorted(ids)
+
+    def test_no_progress_event_when_stager_never_invokes_callback(self, tmp_path):
+        """If a stager doesn't call its progress_callback (e.g. legacy
+        stager from before #202, or one that fails before any phase
+        boundary), the outbox simply has no STAGE_PROGRESS events.
+        Regression guard against accidentally emitting an empty/None
+        event from the closure."""
+        sink = _ListSink()
+        # _OkStub.stage just appends to .calls and returns — never calls back.
+        s = _build_service(
+            tmp_path, current_version="1.0.0", sink=sink, stager=_OkStub(),
+        )
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-silent")))
+
+        progress_events = [
+            e for e in sink.events
+            if e.event_type is LifecycleEventType.STAGE_PROGRESS
+        ]
+        assert progress_events == []


### PR DESCRIPTION
Plumbs a `STAGE_PROGRESS` lifecycle event through the OTA stager so a future CMS upgrade-progress UI can show which of 7 phases the multi-minute `_stage_sync` pipeline is currently in.

**Closes #202.**

## Contract (frozen)

- New lifecycle event: `LifecycleEventType.STAGE_PROGRESS` (slots between `STAGED` and `TRYBOOT_INITIATED` in the enum).
- Payload: `{"phase": str}` where phase ∈ `apply.STAGE_PROGRESS_PHASES`. The tuple is the public contract; any future renames are an API break.
- Phases, in emission order:
  1. `extracting_meta`
  2. `mounting_inactive`
  3. `extracting_boot`
  4. `extracting_rootfs`
  5. `verifying_manifest`
  6. `copying_fleet_state`
  7. `finalizing`
- Ordering invariant: a `STAGE_PROGRESS` event always lands **between `STAGED` and `TRYBOOT_INITIATED`** in `event_id` order on a single dispatch (covered by `test_stage_progress_lands_between_staged_and_tryboot_initiated`).

## Implementation

- **`os_updater/events.py`** — `STAGE_PROGRESS = "stage_progress"` enum value.
- **`os_updater/apply.py`** — `STAGE_PROGRESS_PHASES` tuple; `_safe_emit_progress()` wrapper that swallows callback exceptions (`logger.exception` + continue, catches `Exception` not `BaseException` so `KeyboardInterrupt` / `SystemExit` still propagate). `Stager.stage()` and `_stage_sync()` gain an optional `progress_callback: Optional[Callable[[str], None]]` kwarg; 7 emissions at the step boundaries above.
- **`os_updater/service.py`** — `Stager` Protocol widened. `_DefaultStager.stage()` forwards the kwarg. `handle_dispatch` defines a `_on_stage_progress(phase)` closure that synthesizes a `STAGE_PROGRESS` lifecycle event with `payload={"phase": phase}` and pushes it onto the same event sink as the surrounding `STAGED` / `TRYBOOT_INITIATED` events.

## Plumbing-only

Nothing on the CMS consumes this yet. This PR is the firmware half — the CMS work to expose a "phase X of 7" indicator on the device detail page can land at any cadence afterward.

## Tests

137/137 green locally (`pytest tests/test_os_updater_events.py tests/test_os_updater_apply.py tests/test_os_updater_service.py`):

- `test_os_updater_apply.py::TestSlotStagerProgressCallback` (4): callback invocation, phase ordering, callback-raises swallowed, `None` callback is no-op.
- `test_os_updater_events.py::TestStageProgressEnum` (2): enum value present, position between STAGED and TRYBOOT_INITIATED.
- `test_os_updater_service.py::TestHandleDispatchStageProgress` (3): `_ProgressEmittingStager` fake captures the kwarg and invokes it; verifies payload shape, event_id ordering between STAGED and TRYBOOT_INITIATED, and that a silent stager produces zero progress events (back-compat guarantee).

Full local sweep: 1424 passed (the unrelated `test_wss_support.py` collection-time errors and `test_cms_url_reconnect.py` websockets-import errors are pre-existing).

## Notes

- `STAGE_PROGRESS_PHASES` is a frozen public contract. Future stager refactors that split or rename a phase need to either keep the tuple stable or coordinate with whatever consumes it.
- `_safe_emit_progress` guarantees the stager itself can never be broken by a buggy callback. Callbacks are best-effort.
- v0.0.15-test (currently on Pi100 slot B) does not include this; ships in the next bundle cut.