### PR TITLE
chore: add PR template with vendored-copy refresh checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What
+
+<!-- 1-2 sentence summary of the change -->
+
+## Why
+
+<!-- Why this change is needed; link to issue if applicable -->
+
+## Testing
+
+<!-- How you validated the change -->
+
+## Checklist
+
+- [ ] **If you touched `os_updater/dispatch.py`:** open a follow-up PR in [`sslivins/agora-cms`](https://github.com/sslivins/agora-cms) to bump the vendored copy at `tests/contract/device_dispatch_validator.py` (header SHA + body). CMS mirrors `DispatchPayload` for wire-compat tests; the vendored copy must track upstream or `agora-cms` CI will fail loudly on a drift detector.


### PR DESCRIPTION
## What

Add a `.github/PULL_REQUEST_TEMPLATE.md` with What/Why/Testing sections and a single checklist item reminding contributors who touch `os_updater/dispatch.py` to refresh the vendored copy in `sslivins/agora-cms`.

## Why

`agora-cms` vendors `DispatchPayload` from `os_updater/dispatch.py` at `tests/contract/device_dispatch_validator.py` to roundtrip CMS-side `OSUpdateDispatchMessage` JSON through the actual device-side validator (cross-repo wire-compat). The file header pins a source commit SHA; if upstream changes and the vendored copy drifts, the CMS drift detector test fails loudly. This checkbox surfaces that maintenance contract at PR time so nobody is surprised.

Cross-references `sslivins/agora-cms#563` (M3 ships the vendored copy).

## Testing

Not a code change — template only renders on PR creation. Visual confirmation post-merge by opening any new PR.