### PR TITLE
m4(device): shared /etc/agora/version parser + os_version in register

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -663,6 +663,7 @@ class CMSClient:
                 "device_id": self.device_id,
                 "auth_token": auth_token,
                 "firmware_version": self._get_version(),
+                "os_version": self._get_os_version(),
                 "device_name": self.settings.device_name,
                 "device_name_custom": name_is_custom,
                 "device_type": _get_device_type(),
@@ -716,6 +717,14 @@ class CMSClient:
                         await self._handle_wipe_assets(msg, ws)
                     elif msg_type == "request_logs":
                         await self._handle_request_logs(msg, ws)
+                    elif msg_type == "os_update_dispatch":
+                        # Routed independently by agora-os-updater.service,
+                        # which opens its own WPS connection. We see it on
+                        # this connection because WPS broadcasts to all
+                        # subscribers on the device's channel; explicitly
+                        # ignore it here so it doesn't trip the catch-all
+                        # warning below once CMS starts dispatching.
+                        pass
                     elif "error" in msg:
                         error_text = msg["error"]
                         logger.error("CMS error: %s", error_text)
@@ -2390,6 +2399,29 @@ class CMSClient:
             return __version__
         except ImportError:
             return "unknown"
+
+    def _get_os_version(self) -> str | None:
+        """Best-effort read of ``agora_os_version`` from ``/etc/agora/version``.
+
+        Used to populate the ``os_version`` field of the register
+        message so CMS can show the running rootfs version alongside
+        the agora-app version. Returns ``None`` rather than raising
+        when the file is missing (off-device workstation checkouts) or
+        malformed — the field is informational and must not block
+        registration.
+        """
+        try:
+            from shared.version_file import parse_version_file
+            return parse_version_file()["agora_os_version"]
+        except FileNotFoundError:
+            return None
+        except Exception:  # pragma: no cover - parser raised on malformed file
+            logger.warning(
+                "Could not parse /etc/agora/version for os_version; "
+                "omitting from register message",
+                exc_info=True,
+            )
+            return None
 
     def _read_schedule_cache(self) -> dict | None:
         try:

--- a/os_updater/main.py
+++ b/os_updater/main.py
@@ -59,48 +59,27 @@ log = logging.getLogger("agora.os_updater")
 #:
 #: We consume only ``agora_os_version`` here (per Decision #2 the
 #: ``agora_app_floor`` is the agora-app channel's contract, not the OS
-#: updater's). Naive .strip() of the whole file would return the entire
-#: multi-line blob as the "version" string and torpedo every floor check.
+#: updater's). The shared :mod:`shared.version_file` parser handles the
+#: actual line-by-line parsing — both this daemon and ``cms_client``
+#: (which reads the file to populate ``os_version`` in its register
+#: message, per the M4 phase of the CMS-migration plan) go through that
+#: single parser so any future regex change stays in lockstep.
 DEFAULT_CURRENT_VERSION_FILE = Path("/etc/agora/version")
 
 
 def _read_current_version(path: Path) -> str:
-    """Parse ``/etc/agora/version`` and return ``agora_os_version``.
+    """Thin back-compat wrapper around the shared parser.
 
-    File format: ``# comment`` lines and blank lines are skipped; every
-    other line must be ``key=value``. The ``agora_os_version`` value is
-    returned (whitespace-stripped). Other keys (e.g. ``agora_app_floor``)
-    are tolerated so this parser doesn't have to be lockstepped with every
-    future field added by agora-os.
-
-    Raises ``RuntimeError`` if the file is missing the
-    ``agora_os_version`` key, contains a malformed line, or has an empty
-    value for ``agora_os_version`` — better to fail loud at daemon startup
-    than to ship an empty string into the floor check.
+    The actual parser lives in :func:`shared.version_file.read_os_version_strict`
+    so ``cms_client`` can use the same logic for its register-message
+    construction. This wrapper exists so the daemon's call sites and
+    its long-standing test suite (which imports this symbol directly)
+    don't have to know about the shared module.
     """
 
-    raw = path.read_text(encoding="utf-8")
-    version: str | None = None
-    for lineno, line in enumerate(raw.splitlines(), start=1):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        key, sep, value = stripped.partition("=")
-        if not sep:
-            raise RuntimeError(
-                f"{path}:{lineno}: malformed line (expected key=value): {line!r}"
-            )
-        if key.strip() == "agora_os_version":
-            version = value.strip()
-    if version is None:
-        raise RuntimeError(
-            f"{path} did not contain an 'agora_os_version=...' line"
-        )
-    if not version:
-        raise RuntimeError(
-            f"{path}: 'agora_os_version' has an empty value; cannot determine current version"
-        )
-    return version
+    from shared.version_file import read_os_version_strict
+
+    return read_os_version_strict(path)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/shared/version_file.py
+++ b/shared/version_file.py
@@ -1,0 +1,121 @@
+"""Shared parser for ``/etc/agora/version``.
+
+Both ``os_updater`` (for the floor check on incoming OS update dispatches)
+and ``cms_client`` (for reporting ``os_version`` in the register message)
+need to read this file. Keeping the parser in one place means a future
+regex tightening or key addition only changes one module — no risk of
+the two sites drifting and disagreeing about what counts as a valid
+version line.
+
+File format::
+
+    # comment lines and blank lines are skipped
+    agora_os_version=1.2.3-test
+    agora_app_floor=1.11.0
+
+Every non-comment line must be ``key=value``. Whitespace around keys and
+values is stripped. Unknown keys are tolerated so this parser doesn't
+have to be lockstep with every future field added by agora-os.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+DEFAULT_VERSION_FILE = Path("/etc/agora/version")
+
+
+def parse_version_file(
+    path: Path = DEFAULT_VERSION_FILE,
+) -> Dict[str, Optional[str]]:
+    """Parse ``/etc/agora/version`` and return a dict of well-known keys.
+
+    Returns a dict with these keys (both may be ``None`` if absent or
+    empty in the file):
+
+    * ``agora_os_version`` — the rootfs's baked-in OS version (e.g.
+      ``"0.0.16-test"``). Set by the image-build pipeline.
+    * ``agora_app_floor`` — the minimum agora-app version this rootfs
+      will accept (e.g. ``"1.11.0"``). Set by the image-build pipeline.
+
+    Missing keys are returned as ``None`` rather than raised — callers
+    that need a strict floor check (e.g. ``os_updater``) should use
+    :func:`read_os_version_strict` instead, which raises if
+    ``agora_os_version`` is missing or empty.
+
+    Raises:
+        FileNotFoundError: if ``path`` doesn't exist. Callers that want
+            to tolerate a missing file (e.g. ``cms_client`` running on a
+            dev workstation outside an agora-os device) should catch
+            this and fall back to ``None``.
+        RuntimeError: if a non-comment, non-blank line is malformed
+            (i.e. doesn't contain ``=``).
+    """
+
+    result: Dict[str, Optional[str]] = {
+        "agora_os_version": None,
+        "agora_app_floor": None,
+    }
+
+    raw = path.read_text(encoding="utf-8")
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        if not sep:
+            raise RuntimeError(
+                f"{path}:{lineno}: malformed line (expected key=value): {line!r}"
+            )
+        key = key.strip()
+        value = value.strip()
+        if key in result:
+            result[key] = value or None
+
+    return result
+
+
+def read_os_version_strict(path: Path = DEFAULT_VERSION_FILE) -> str:
+    """Read ``agora_os_version`` from ``path``, raising if missing/empty.
+
+    Use this where a missing OS version must be a fatal startup error
+    (e.g. ``os_updater`` during the version-floor gate check). For
+    best-effort reads (e.g. populating an ``os_version`` field in the
+    register payload, where ``None`` is an acceptable fallback), use
+    :func:`parse_version_file` directly and handle ``None``.
+
+    Distinguishes "key absent" from "empty value" so error messages are
+    actionable when a malformed file is the culprit.
+
+    Raises:
+        FileNotFoundError: if ``path`` doesn't exist.
+        RuntimeError: if the file is malformed, missing the
+            ``agora_os_version`` key, or has an empty value for it.
+    """
+
+    raw = path.read_text(encoding="utf-8")
+    saw_key = False
+    found_value: Optional[str] = None
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        if not sep:
+            raise RuntimeError(
+                f"{path}:{lineno}: malformed line (expected key=value): {line!r}"
+            )
+        if key.strip() == "agora_os_version":
+            saw_key = True
+            found_value = value.strip()
+
+    if not saw_key:
+        raise RuntimeError(
+            f"{path} did not contain an 'agora_os_version=...' line"
+        )
+    if not found_value:
+        raise RuntimeError(
+            f"{path} had an empty value for 'agora_os_version'"
+        )
+    return found_value

--- a/tests/test_version_file.py
+++ b/tests/test_version_file.py
@@ -1,0 +1,144 @@
+"""Tests for the shared ``/etc/agora/version`` parser in
+:mod:`shared.version_file`.
+
+The strict variant (:func:`read_os_version_strict`) is exercised
+indirectly by :mod:`tests.test_os_updater_main` (which still imports
+``os_updater.main._read_current_version`` — that's a thin wrapper over
+the strict parser). These tests focus on the lenient
+:func:`parse_version_file` path that ``cms_client`` will use to populate
+the ``os_version`` field in its register message (per the M4 phase of
+the CMS-migration sub-plan), where missing keys must not raise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.version_file import (
+    parse_version_file,
+    read_os_version_strict,
+)
+
+
+def _write(tmp_path, content: str):
+    p = tmp_path / "version"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestParseVersionFile:
+    """Lenient parser: missing keys return None, malformed lines raise."""
+
+    def test_returns_both_well_known_keys(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "# header\nagora_os_version=0.0.4-test\nagora_app_floor=1.11.0\n",
+        )
+        assert parse_version_file(p) == {
+            "agora_os_version": "0.0.4-test",
+            "agora_app_floor": "1.11.0",
+        }
+
+    def test_missing_keys_return_none(self, tmp_path):
+        # cms_client needs to be able to register from a workstation
+        # checkout where /etc/agora/version may have only one of the
+        # two keys (or unrelated keys) — None must not raise.
+        p = _write(tmp_path, "agora_os_version=1.2.3\n")
+        assert parse_version_file(p) == {
+            "agora_os_version": "1.2.3",
+            "agora_app_floor": None,
+        }
+
+    def test_empty_value_returns_none(self, tmp_path):
+        # An empty value is semantically equivalent to the key being
+        # absent; both surface as None so the caller has a single
+        # falsy check.
+        p = _write(tmp_path, "agora_os_version=\nagora_app_floor=1.11.0\n")
+        assert parse_version_file(p) == {
+            "agora_os_version": None,
+            "agora_app_floor": "1.11.0",
+        }
+
+    def test_skips_comments_and_blank_lines(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "\n# comment\n\nagora_os_version=1.2.3\n\n# trailing\n",
+        )
+        assert parse_version_file(p)["agora_os_version"] == "1.2.3"
+
+    def test_tolerates_unknown_keys(self, tmp_path):
+        # agora-os may grow new keys (e.g. agora_kernel_pin) without
+        # coordinating with this parser; unknown keys are silently
+        # dropped, not stored.
+        p = _write(
+            tmp_path,
+            "agora_os_version=2.0.0\nagora_app_floor=1.11.0\nfuture_field=hello\n",
+        )
+        result = parse_version_file(p)
+        assert result["agora_os_version"] == "2.0.0"
+        assert result["agora_app_floor"] == "1.11.0"
+        assert "future_field" not in result
+
+    def test_strips_surrounding_whitespace(self, tmp_path):
+        p = _write(tmp_path, "  agora_os_version =   1.2.3   \n")
+        assert parse_version_file(p)["agora_os_version"] == "1.2.3"
+
+    def test_malformed_line_raises(self, tmp_path):
+        # Malformed lines are a hard fail in both modes — better to
+        # surface a corrupted version file than to silently drop data.
+        p = _write(
+            tmp_path,
+            "agora_os_version=1.0.0\nthis-line-has-no-equals\n",
+        )
+        with pytest.raises(RuntimeError, match="malformed line"):
+            parse_version_file(p)
+
+    def test_missing_file_raises_filenotfounderror(self, tmp_path):
+        # Caller (cms_client) can catch this and fall back to None
+        # when running off-device.
+        p = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError):
+            parse_version_file(p)
+
+    def test_empty_file_returns_all_none(self, tmp_path):
+        p = _write(tmp_path, "")
+        assert parse_version_file(p) == {
+            "agora_os_version": None,
+            "agora_app_floor": None,
+        }
+
+
+class TestReadOsVersionStrict:
+    """Strict wrapper: missing/empty agora_os_version raises."""
+
+    def test_happy_path(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "agora_os_version=0.0.16-test\nagora_app_floor=1.11.0\n",
+        )
+        assert read_os_version_strict(p) == "0.0.16-test"
+
+    def test_missing_key_raises(self, tmp_path):
+        p = _write(tmp_path, "agora_app_floor=1.11.0\n")
+        with pytest.raises(RuntimeError, match="agora_os_version"):
+            read_os_version_strict(p)
+
+    def test_empty_value_raises_with_distinctive_message(self, tmp_path):
+        # The error message disambiguates "empty value" from "key
+        # missing" so on-device journal logs are actionable.
+        p = _write(tmp_path, "agora_os_version=\n")
+        with pytest.raises(RuntimeError, match="empty value"):
+            read_os_version_strict(p)
+
+    def test_missing_file_raises_filenotfounderror(self, tmp_path):
+        p = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError):
+            read_os_version_strict(p)
+
+    def test_malformed_line_raises(self, tmp_path):
+        p = _write(
+            tmp_path,
+            "agora_os_version=1.0.0\nthis-line-has-no-equals\n",
+        )
+        with pytest.raises(RuntimeError, match="malformed line"):
+            read_os_version_strict(p)


### PR DESCRIPTION
## What

Phase **M4** device-side prep for the CMS upgrade-path migration (deb-install → bundle-OTA, plan.md). Three coupled changes that need to ship together so CMS can start dispatching `os_update_dispatch` in M5 without spamming the device log:

1. **`shared/version_file.py`** — new module with two APIs:
   - `parse_version_file()` — lenient: returns `{"agora_os_version": str | None, "agora_app_floor": str | None}`. cms_client uses this so it can still register cleanly on dev workstations without `/etc/agora/version`.
   - `read_os_version_strict()` — strict: raises `RuntimeError` with `agora_os_version` regex when the key is absent, or `empty value` regex when the key is present but empty. `os_updater` uses this; the two distinct error messages preserve the existing `tests/test_os_updater_main.py` assertions verbatim.

2. **`os_updater/main.py`** — replaces the inline 37-line `_read_current_version()` parser with a 3-line wrapper that delegates to `shared.version_file.read_os_version_strict()`. The function name + signature stay so existing tests continue to import `_read_current_version` unchanged.

3. **`cms_client/service.py`**:
   - Adds `_get_os_version()` helper that calls `parse_version_file()` lenient-mode and returns `None` on `FileNotFoundError` (workstations) or malformed file (logs a warning, keeps registering).
   - Adds `"os_version": self._get_os_version()` to the register payload (immediately after `firmware_version`). CMS-side companion change will land in agora-cms M4 and persist this into a new `devices.os_version` column.
   - Adds an explicit `elif msg_type == "os_update_dispatch": pass` route before the catch-all warning at ~line 750. `agora-os-updater` opens its own WPS subscription per `os_updater/service.py:543-580` and handles the dispatch directly; cms_client just needs to not log `WARNING: unknown message type ...` once M5 ships.

4. **`tests/test_version_file.py`** — 14 new tests across two classes:
   - `TestParseVersionFile` (9 cases): both keys returned, missing keys → None, empty value → None, comment skip, blank-line skip, unknown keys silently dropped (forward-compat), whitespace stripping, malformed line raises, missing file raises `FileNotFoundError`, empty file → all None.
   - `TestReadOsVersionStrict` (5 cases): happy, missing key raises with `agora_os_version` regex, empty value raises with `empty value` regex, missing file raises `FileNotFoundError`, malformed line raises.

## Convention note

plan.md says `agora/common/version_file.py`, but `agora/` already has a `shared/` namespace package (`board.py`, `models.py`, `state.py`, `identity.py`, `bootstrap_identity.py`). Creating a parallel `common/` namespace would split cross-package code across two ad-hoc locations. Used `shared/version_file.py` instead. plan.md will be updated to match.

## Routing topology re-confirmed

`agora-os-updater.service` opens its **own** WPS transport via `self.transport_factory()` (`os_updater/service.py:553`) and runs its own recv loop (lines 558-569) filtering `msg_type == "os_update_dispatch"`. `agora-cms-client` opens a separate transport. Both subscribers receive the per-device WPS-channel broadcast and filter independently by message type. **No CMS-side fan-out and no `cms_client._handle_os_update_dispatch` helper is needed** — CMS just publishes the JSON to the device's existing WPS channel, `os_updater` picks it up directly. The only cms_client-side work is the catch-all silence handled by this PR.

## Tests

- `pytest tests/test_version_file.py tests/test_os_updater_main.py tests/test_cms_client_connect.py tests/test_cms_client_transport.py -p no:timeout` → 54/54 green
- Full suite: 1454 passed locally. The 16 `tests/test_wss_e2e.py` errors are pre-existing `fixture 'page' not found` from missing pytest-playwright in the Windows venv; unrelated to this PR (CI has playwright). Same goes for the `tests/test_cms_url_reconnect.py` import error (websockets version mismatch in the local venv).

## Follow-ups (next PRs)

- agora-cms M4: add `devices.os_version` column + Alembic migration + persist from register handler in both `wps_webhook.py` and `ws.py`. UI device-detail page renders both `firmware_version` and `os_version` side-by-side.
- agora-cms M5: flip `POST /api/devices/{id}/upgrade` from `UpgradeMessage()` to `OSUpdateDispatchMessage(...)` populated from the bundle_checker cache; fix the pre-existing claim-clear lockout at `wps_webhook.py:267` and `ws.py:213` (currently only watches `firmware_version` → would lock out the operator for 15 min after every successful OS OTA).

## Plan

plan.md → "Sub-plan: CMS upgrade-path migration" → Phase M4. Companion CMS changes ship under the same M4 milestone in `agora-cms`.