### PR TITLE
os_updater: fix 5 bugs in apply.py from v0.0.18-test OTA failure

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -114,13 +114,32 @@ logger = logging.getLogger(__name__)
 #: :data:`os_updater.verifier.DEFAULT_BUNDLE_FILENAME`.
 DEFAULT_BUNDLE_FILENAME = "bundle.tar.zst"
 
-#: Slot A's boot partition mountpoint. Phase 0 fstab.
-DEFAULT_BOOT_MOUNT_SLOT_A = Path("/boot/firmware")
+#: Mountpoint of the **active** slot's boot (FAT32) partition. agora-os
+#: assemble.sh convention: regardless of which slot is active, the
+#: bootloader-selected boot partition is always exposed at
+#: ``/boot/firmware``. Read-only from the OTA stager's perspective —
+#: this is where we **read** per-device boot fleet-state from (e.g.
+#: ``autoboot.txt``) before tryboot.
+#:
+#: **Naming history:** previously called ``DEFAULT_BOOT_MOUNT_SLOT_A``,
+#: but the value never depended on slot identity — it always pointed at
+#: whatever slot the bootloader landed on. The old name caused a 5-bug
+#: chain (sslivins/agora-os v0.0.18-test brick) where the stager
+#: dispatched the inactive boot extract to ``/boot/firmware`` (the
+#: ACTIVE slot's boot, corrupting it) because :func:`boot_mount_for_slot`
+#: returned ``slot_a_mount`` when ``slot == 1`` even though the running
+#: slot was 2. Renamed to ``DEFAULT_ACTIVE_BOOT_MOUNT`` to make the
+#: invariant unambiguous.
+DEFAULT_ACTIVE_BOOT_MOUNT = Path("/boot/firmware")
 
-#: Slot B's boot partition mountpoint. Phase 0 fstab keeps slot B's
-#: FAT32 partition mounted at the mirror path so slot_mgr can keep
-#: ``autoboot.txt`` in sync across both copies.
-DEFAULT_BOOT_MOUNT_SLOT_B = Path("/boot/firmware-b")
+#: Mountpoint of the **inactive** slot's boot (FAT32) partition. Phase 0
+#: fstab keeps the inactive slot's FAT32 partition mounted at the mirror
+#: path so slot_mgr can keep ``autoboot.txt`` in sync across both copies
+#: and the OTA stager has a stable target for the boot-subtree extract.
+#:
+#: **Naming history:** previously ``DEFAULT_BOOT_MOUNT_SLOT_B``. See
+#: :data:`DEFAULT_ACTIVE_BOOT_MOUNT` for the rename rationale.
+DEFAULT_INACTIVE_BOOT_MOUNT = Path("/boot/firmware-b")
 
 #: Where the inactive slot's root partition is mounted while the
 #: running slot writes into it. :class:`SlotStager` ensures this is
@@ -195,6 +214,7 @@ DEFAULT_FLEET_STATE_CP_TIMEOUT_S = 30.0
 STAGE_PROGRESS_PHASES: tuple[str, ...] = (
     "extracting_meta",
     "mounting_inactive",
+    "wiping_inactive",
     "extracting_boot",
     "extracting_rootfs",
     "verifying_manifest",
@@ -224,10 +244,16 @@ def _safe_emit_progress(
             "progress_callback raised on phase=%s; continuing stage", phase
         )
 
-#: Root of the currently-running rootfs (slot A) from which
+#: Root of the currently-running rootfs from which
 #: :func:`copy_fleet_state` reads per-device identity files. Path is
 #: ``/`` in production; tests inject ``tmp_path`` to bypass.
-DEFAULT_SLOT_A_ROOT = Path("/")
+#:
+#: **Naming history:** previously ``DEFAULT_SLOT_A_ROOT``. The value
+#: was always ``/`` (the running slot's rootfs) regardless of which
+#: slot the device booted into, so "slot_a" was misleading. Renamed
+#: to ``DEFAULT_RUNNING_ROOT`` alongside the broader
+#: active-vs-inactive rename in the v0.0.19-test fix.
+DEFAULT_RUNNING_ROOT = Path("/")
 
 #: Files that **must** be present on slot A and copied into slot B
 #: before tryboot. Each entry is a path **relative** to the rootfs
@@ -264,6 +290,28 @@ FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = (
     "etc/NetworkManager/system-connections/wifi-*.nmconnection",
     "home/agora/.ssh",
 )
+
+#: Files that **must** be present on the active boot partition
+#: (``/boot/firmware``) and copied into the inactive boot partition
+#: (``/boot/firmware-b``) before tryboot.
+#:
+#: ``autoboot.txt`` is the **canonical** target: the bundle producer
+#: deliberately omits it so we can copy the device's own copy here.
+#: It carries the per-device tryboot/active slot selection and MUST
+#: survive the OTA — without it the bootloader has no slot-selection
+#: information and the device hangs at the rainbow screen.
+#:
+#: This is the boot-partition analog of :data:`FLEET_STATE_REQUIRED`.
+#: Refusing to apply on absence is the safe default: a device missing
+#: ``autoboot.txt`` on its active boot is either pre-A/B (vintage
+#: image, manual reflash required) or in a broken state, and the OTA
+#: shouldn't paper over that. See plan.md §"OTA v0.0.18-test brick".
+BOOT_FLEET_STATE_REQUIRED: tuple[str, ...] = ("autoboot.txt",)
+
+#: Boot-partition analog of :data:`FLEET_STATE_COPY_IF_PRESENT`.
+#: Currently empty — no boot files are merely-optional. Reserved for
+#: future use (e.g. a per-device ``config.txt`` overlay).
+BOOT_FLEET_STATE_COPY_IF_PRESENT: tuple[str, ...] = ()
 
 #: Relative path inside the inactive slot's root where the bundle ships
 #: an fstab template with ``{{BOOT_PARTLABEL}}`` placeholder. Replaced
@@ -377,23 +425,6 @@ def other_slot(slot: int) -> int:
     raise StagingError(f"invalid slot number: {slot!r} (expected 1 or 2)")
 
 
-def boot_mount_for_slot(
-    slot: int,
-    *,
-    slot_a_mount: Path = DEFAULT_BOOT_MOUNT_SLOT_A,
-    slot_b_mount: Path = DEFAULT_BOOT_MOUNT_SLOT_B,
-) -> Path:
-    """Return the mountpoint of ``slot``'s boot (FAT32) partition.
-
-    Raises :class:`StagingError` on bad input.
-    """
-    if slot == 1:
-        return slot_a_mount
-    if slot == 2:
-        return slot_b_mount
-    raise StagingError(f"invalid slot number: {slot!r} (expected 1 or 2)")
-
-
 #: GPT partition labels baked into the image by
 #: ``agora-os/image-build/assemble.sh`` (see plan.md D51).
 _BOOT_PARTLABEL_FOR_SLOT = {1: "boot-A", 2: "boot-B"}
@@ -432,28 +463,37 @@ def _tail(text: Optional[str], limit: int = 2000) -> str:
     return "…" + text[-limit:]
 
 
-def _is_mountpoint(
+def _mounted_device(
     target: Path,
     *,
     mounts_path: Path = DEFAULT_MOUNTS_PATH,
-) -> bool:
-    """Return True if ``target`` appears as a mountpoint in ``mounts_path``.
+) -> Optional[Path]:
+    """Return the device backing ``target`` per ``mounts_path``, or None.
 
     Reads ``mounts_path`` (``/proc/self/mounts`` in production) and looks
     for a line whose second field (mountpoint) resolves to the same path
-    as ``target`` after :py:meth:`Path.resolve`. Returns False if
+    as ``target`` after :py:meth:`Path.resolve`. The first field
+    (device) of the matching line is returned as a :class:`Path`.
+    Returns ``None`` if ``target`` is not a mountpoint or if
     ``mounts_path`` is missing — pure read with no side effects.
 
-    ``/proc/self/mounts`` encodes special characters in mountpoint paths
-    with C-style octal escapes (e.g. a literal space becomes ``\\040``);
-    this helper decodes them before comparison so that paths containing
-    spaces still match.
+    ``/proc/self/mounts`` encodes special characters in both the device
+    and mountpoint fields with C-style octal escapes (e.g. a literal
+    space becomes ``\\040``); this helper decodes them before
+    comparison/return so that paths containing spaces still match and
+    round-trip correctly.
+
+    This is the partlabel-verification primitive that fixes Bug 2 of
+    the v0.0.18-test brick: :func:`ensure_partition_mounted` uses it
+    to confirm the **right** device is mounted at ``target`` before
+    treating the mountpoint as ready, rather than admitting any
+    occupied mountpoint as "good enough."
     """
     target = Path(target).resolve()
     try:
         content = Path(mounts_path).read_text()
     except FileNotFoundError:
-        return False
+        return None
     for line in content.splitlines():
         parts = line.split()
         if len(parts) < 2:
@@ -466,15 +506,33 @@ def _is_mountpoint(
         # Windows paths like ``C:\Users\...`` even though we never see
         # such paths on real Pi hardware. Tests still want to run on
         # the maintainer's workstation.
-        decoded = _MOUNTS_OCTAL_RE.sub(
+        decoded_target = _MOUNTS_OCTAL_RE.sub(
             lambda m: chr(int(m.group(1), 8)), parts[1]
         )
         try:
-            if Path(decoded).resolve() == target:
-                return True
+            if Path(decoded_target).resolve() == target:
+                decoded_device = _MOUNTS_OCTAL_RE.sub(
+                    lambda m: chr(int(m.group(1), 8)), parts[0]
+                )
+                return Path(decoded_device)
         except OSError:
             continue
-    return False
+    return None
+
+
+def _is_mountpoint(
+    target: Path,
+    *,
+    mounts_path: Path = DEFAULT_MOUNTS_PATH,
+) -> bool:
+    """Return True if ``target`` appears as a mountpoint in ``mounts_path``.
+
+    Thin wrapper around :func:`_mounted_device` that discards the
+    device identity. Kept as a separate helper so existing callers
+    (and tests) that only care about "is anything mounted here?" stay
+    boolean-shaped.
+    """
+    return _mounted_device(target, mounts_path=mounts_path) is not None
 
 
 def ensure_partition_mounted(
@@ -490,10 +548,15 @@ def ensure_partition_mounted(
 ) -> None:
     """Ensure the partition labeled ``partlabel`` is mounted at ``target``.
 
-    Idempotent. If ``target`` is already a mountpoint per ``mounts_path``
-    this no-ops (we do not validate that the *right* partition is
-    mounted there — :func:`copy_fleet_state` and the manifest verify
-    step will catch a wrong-partition case). Otherwise:
+    Idempotent. If ``target`` is already a mountpoint per ``mounts_path``,
+    the device backing it is read via :func:`_mounted_device` and
+    compared byte-for-byte against the expected
+    ``<partlabel_base>/<partlabel>`` path. On match: no-op. On
+    mismatch: raise :class:`StagingError` immediately with both device
+    names — refusing to extract a bundle onto whatever happens to be
+    mounted there.
+
+    Otherwise (no mountpoint):
 
     1. Create ``target`` (and any missing parents) as a directory.
     2. Invoke ``mount(8)`` via ``runner`` to mount
@@ -501,20 +564,44 @@ def ensure_partition_mounted(
        fstype and options.
 
     Raises :class:`StagingError` on any of:
+    - mismatched device at an already-mounted ``target``,
     - ``mount(8)`` returning non-zero (with stderr in the message),
     - ``mount(8)`` binary missing from PATH,
     - ``mount(8)`` exceeding ``timeout_s``.
 
-    This is the defense-in-depth that fixes the v0.0.7-test brick: if
+    The partlabel-mismatch check fixes Bug 2 of the v0.0.18-test
+    brick: in that incident the active boot partition (``boot-B``,
+    GPT label) was mounted at ``/boot/firmware`` (the canonical
+    ACTIVE boot mountpoint), but the OTA stager treated
+    ``/boot/firmware`` as the **slot A** boot mount because of Bug
+    1's slot-keyed lookup, and dispatched the inactive-boot extract
+    onto the active slot. With partlabel verification, the apply step
+    would have aborted at ``ensure_partition_mounted("boot-A",
+    /boot/firmware)`` because the actual device at that mountpoint
+    was ``/dev/disk/by-partlabel/boot-B``.
+
+    Defense-in-depth from the v0.0.7-test brick is preserved: if
     agora-os didn't ship systemd .mount units for ``boot-B`` and
-    ``root-B``, slot B's mountpoints are empty rootfs directories, and
-    the streaming extract in step 6/7 would silently write the bundle
-    onto the *active* rootfs (slot A) — leaving slot B stale and
-    bricking the device on tryboot.
+    ``root-B``, this function still re-runs ``mount(8)`` after
+    finding no mountpoint at ``target``.
     """
     target = Path(target)
     target.mkdir(parents=True, exist_ok=True)
-    if _is_mountpoint(target, mounts_path=mounts_path):
+    expected_device = (Path(partlabel_base) / partlabel).resolve()
+    actual_device = _mounted_device(target, mounts_path=mounts_path)
+    if actual_device is not None:
+        try:
+            actual_resolved = actual_device.resolve()
+        except OSError:
+            actual_resolved = actual_device
+        if actual_resolved != expected_device:
+            raise StagingError(
+                f"partition mismatch at {target}: expected "
+                f"{expected_device} (partlabel {partlabel}) but "
+                f"{actual_device} is mounted there. Refusing to "
+                "extract bundle onto the wrong partition; check the "
+                "device's fstab and slot identification logic."
+            )
         logger.info(
             "partition %s already mounted at %s, skipping mount",
             partlabel,
@@ -962,28 +1049,36 @@ def rsync_tree(
 
 
 def copy_fleet_state(
-    slot_a_root: Path,
-    slot_b_root: Path,
+    source_root: Path,
+    dest_root: Path,
     *,
     runner: Runner = _default_runner,
     required: tuple[str, ...] = FLEET_STATE_REQUIRED,
     copy_if_present: tuple[str, ...] = FLEET_STATE_COPY_IF_PRESENT,
     cp_timeout_s: float = DEFAULT_FLEET_STATE_CP_TIMEOUT_S,
 ) -> None:
-    """Copy per-device identity files from slot A into slot B.
+    """Copy per-device identity files from one rootfs into another.
 
     Implements step 8b of the apply flow (D60 in plan.md §"Phase 2").
     Each entry in ``required`` and ``copy_if_present`` is a path
     **relative** to the rootfs root (no leading slash). Patterns
     containing ``*`` are treated as globs evaluated against
-    ``slot_a_root``; literal patterns are required to exist as
+    ``source_root``; literal patterns are required to exist as
     regular files / symlinks.
+
+    Historically this was hardcoded ``slot_a_root`` → ``slot_b_root``
+    for the rootfs identity copy. With the v0.0.19 fix, the same
+    primitive is also used for ``active_boot_mount`` →
+    ``inactive_boot_mount`` (copying ``autoboot.txt`` so the
+    bootloader can still find a slot to boot after the inactive
+    boot partition is wiped and re-extracted). Naming is generic
+    (source/dest) to reflect that.
 
     Semantics:
 
-    * **Required literal** — file must exist on slot A. Raises
-      :class:`FleetStateMissingError` (with ``path`` set to the
-      relative pattern) otherwise.
+    * **Required literal** — file must exist on ``source_root``.
+      Raises :class:`FleetStateMissingError` (with ``path`` set to
+      the relative pattern) otherwise.
     * **Required glob** — at least one match required. Zero matches
       raises :class:`FleetStateMissingError`.
     * **Copy-if-present literal/glob** — zero matches is fine and
@@ -993,67 +1088,68 @@ def copy_fleet_state(
     preserves uid/gid/mode/atime/mtime/xattrs/symlinks (matching
     rsync's ``-a`` semantics for the per-file case but without
     rsync's source-list ergonomics that don't fit a glob+literal
-    mix). Parent directories on slot B are created with mode 0755 if
-    missing.
+    mix). Parent directories on ``dest_root`` are created with mode
+    0755 if missing.
 
     Any non-zero ``cp`` exit, missing-binary error, or timeout
     raises :class:`FleetStateWriteError`. Per the module-level "no
-    cleanup on failure" policy, neither slot B nor the staging
-    directory is touched on failure — the device boots from slot A
-    on next reboot and the operator can forensic the partial copy.
+    cleanup on failure" policy, neither ``dest_root`` nor the
+    staging directory is touched on failure — the device boots from
+    its active slot on next reboot and the operator can forensic
+    the partial copy.
     """
-    slot_a_root = Path(slot_a_root)
-    slot_b_root = Path(slot_b_root)
+    source_root = Path(source_root)
+    dest_root = Path(dest_root)
 
     for pattern in required:
-        sources = _resolve_fleet_state_sources(slot_a_root, pattern)
+        sources = _resolve_fleet_state_sources(source_root, pattern)
         if not sources:
             raise FleetStateMissingError(
-                f"required fleet-state entry not present on slot A: "
-                f"{pattern!r} (resolved under {slot_a_root})",
+                f"required fleet-state entry not present at source: "
+                f"{pattern!r} (resolved under {source_root})",
                 path=pattern,
             )
         for src in sources:
             _cp_one(
                 src,
-                slot_a_root,
-                slot_b_root,
+                source_root,
+                dest_root,
                 pattern,
                 runner=runner,
                 cp_timeout_s=cp_timeout_s,
             )
 
     for pattern in copy_if_present:
-        sources = _resolve_fleet_state_sources(slot_a_root, pattern)
+        sources = _resolve_fleet_state_sources(source_root, pattern)
         if not sources:
             logger.info(
                 "fleet_state_skipped: %r (no match under %s)",
                 pattern,
-                slot_a_root,
+                source_root,
             )
             continue
         for src in sources:
             _cp_one(
                 src,
-                slot_a_root,
-                slot_b_root,
+                source_root,
+                dest_root,
                 pattern,
                 runner=runner,
                 cp_timeout_s=cp_timeout_s,
             )
 
 
-def _resolve_fleet_state_sources(slot_a_root: Path, pattern: str) -> list[Path]:
-    """Return the list of slot-A source paths matched by ``pattern``.
+def _resolve_fleet_state_sources(source_root: Path, pattern: str) -> list[Path]:
+    """Return the list of source paths matched by ``pattern``.
 
     Glob patterns (containing ``*``) are evaluated against
-    ``slot_a_root`` via :meth:`Path.glob`; literal patterns return
-    ``[slot_a_root / pattern]`` if the path exists, else ``[]``.
+    ``source_root`` via :meth:`Path.glob`; literal patterns return
+    ``[source_root / pattern]`` if the path exists, else ``[]``.
     Symlinks count as existing — ``cp -a`` will preserve them.
     """
     if "*" in pattern:
-        return sorted(slot_a_root.glob(pattern))
-    candidate = slot_a_root / pattern
+        return sorted(source_root.glob(pattern))
+    candidate = source_root / pattern
     if candidate.exists() or candidate.is_symlink():
         return [candidate]
     return []
@@ -1061,8 +1157,8 @@ def _resolve_fleet_state_sources(slot_a_root: Path, pattern: str) -> list[Path]:
 
 def _cp_one(
     src: Path,
-    slot_a_root: Path,
-    slot_b_root: Path,
+    source_root: Path,
+    dest_root: Path,
     pattern: str,
     *,
     runner: Runner,
@@ -1070,21 +1166,21 @@ def _cp_one(
 ) -> None:
     """Run ``cp -a <src> <dst>`` for a single fleet-state file.
 
-    Computes ``dst`` by re-rooting ``src`` from ``slot_a_root`` onto
-    ``slot_b_root`` (preserving the in-rootfs path). Creates the
-    parent directory on slot B if missing. Raises
+    Computes ``dst`` by re-rooting ``src`` from ``source_root`` onto
+    ``dest_root`` (preserving the in-rootfs path). Creates the
+    parent directory on ``dest_root`` if missing. Raises
     :class:`FleetStateWriteError` on any subprocess failure.
     """
-    rel = src.relative_to(slot_a_root)
-    dst = slot_b_root / rel
+    rel = src.relative_to(source_root)
+    dst = dest_root / rel
     dst.parent.mkdir(parents=True, exist_ok=True)
 
     # If ``src`` is a directory (e.g. ``home/agora/.ssh``) and ``dst``
-    # already exists on slot B from a prior partial apply, remove it
+    # already exists on dest_root from a prior partial apply, remove it
     # first so ``cp -a`` writes AT ``dst`` rather than INTO ``dst`` —
-    # i.e. avoids creating ``slot_b/home/agora/.ssh/.ssh``. Safe
+    # i.e. avoids creating ``dest_root/home/agora/.ssh/.ssh``. Safe
     # because copy_fleet_state is the sole source of truth for the
-    # fleet-state entries on slot B.
+    # fleet-state entries on dest_root.
     if src.is_dir() and dst.exists():
         shutil.rmtree(dst)
 
@@ -1170,8 +1266,17 @@ class SlotStager:
     boot_subdir: str = "boot"
     root_subdir: str = "root"
     meta_filename: str = "meta.json"
-    boot_mount_slot_a: Path = field(default_factory=lambda: DEFAULT_BOOT_MOUNT_SLOT_A)
-    boot_mount_slot_b: Path = field(default_factory=lambda: DEFAULT_BOOT_MOUNT_SLOT_B)
+    #: Mountpoint of the ACTIVE slot's boot partition — always
+    #: ``/boot/firmware`` on a healthy device per agora-os fstab
+    #: convention (regardless of whether the active slot is 1 or 2).
+    #: Read-only source for boot-fleet-state copy (``autoboot.txt``);
+    #: never written by the stager.
+    active_boot_mount: Path = field(default_factory=lambda: DEFAULT_ACTIVE_BOOT_MOUNT)
+    #: Mountpoint of the INACTIVE slot's boot partition — always
+    #: ``/boot/firmware-b`` on a healthy device per agora-os fstab
+    #: convention. Destination for the boot-subtree extract +
+    #: boot-fleet-state copy.
+    inactive_boot_mount: Path = field(default_factory=lambda: DEFAULT_INACTIVE_BOOT_MOUNT)
     inactive_root_mount: Path = field(default_factory=lambda: DEFAULT_INACTIVE_ROOT_MOUNT)
     zstd_long: int = DEFAULT_ZSTD_LONG
     stream_timeout_s: float = DEFAULT_STREAM_TIMEOUT_S
@@ -1181,9 +1286,24 @@ class SlotStager:
     )
     slot_state_fn: Optional[Callable[[], Any]] = None
     trigger_tryboot_fn: Optional[Callable[[int], Any]] = None
-    slot_a_root: Path = field(default_factory=lambda: DEFAULT_SLOT_A_ROOT)
+    #: Mountpoint of the running rootfs — always ``/`` on a real
+    #: device, overridable in tests. Read-only source for the
+    #: rootfs-fleet-state copy (machine-id, ssh host keys, etc.);
+    #: never written by the stager.
+    running_root: Path = field(default_factory=lambda: DEFAULT_RUNNING_ROOT)
     fleet_state_required: tuple[str, ...] = FLEET_STATE_REQUIRED
     fleet_state_copy_if_present: tuple[str, ...] = FLEET_STATE_COPY_IF_PRESENT
+    #: Fleet-state files copied from the active boot partition into
+    #: the inactive boot partition AFTER the boot subtree is wiped
+    #: and re-extracted. Default = ``("autoboot.txt",)``; the bundle
+    #: deliberately omits autoboot.txt because slot_mgr (not the
+    #: stager) is the authority for which slot the bootloader
+    #: should select. Without this copy, the bootloader has no way
+    #: to find any slot — device bricks.
+    boot_fleet_state_required: tuple[str, ...] = BOOT_FLEET_STATE_REQUIRED
+    boot_fleet_state_copy_if_present: tuple[str, ...] = (
+        BOOT_FLEET_STATE_COPY_IF_PRESENT
+    )
     fleet_state_cp_timeout_s: float = DEFAULT_FLEET_STATE_CP_TIMEOUT_S
     fstab_template_rel: str = DEFAULT_FSTAB_TEMPLATE_REL
     fstab_rel: str = DEFAULT_FSTAB_REL
@@ -1293,22 +1413,30 @@ class SlotStager:
         )
 
         # 5. Ensure the inactive slot's boot + root partitions are
-        # mounted. Defense-in-depth (see plan.md §"OTA v0.0.7-test
-        # mount gap"): early agora-os images did not ship systemd
+        # mounted at their canonical mountpoints. Per agora-os fstab
+        # convention the INACTIVE slot's boot is always
+        # ``/boot/firmware-b`` and its root always at
+        # ``/mnt/inactive-root``, regardless of whether the inactive
+        # slot is 1 or 2. (The pre-v0.0.19 ``boot_mount_for_slot``
+        # lookup was slot-keyed; if Bug 1 had not been fixed, this
+        # would have resolved to ``/boot/firmware`` when the inactive
+        # slot was 1, which is the ACTIVE slot's mountpoint —
+        # bricking the device by extracting the bundle onto the
+        # running slot. See v0.0.18-test post-mortem.)
+        #
+        # Defense-in-depth (see plan.md §"OTA v0.0.7-test mount
+        # gap"): early agora-os images did not ship systemd
         # ``.mount`` units for ``/boot/firmware-b`` and
-        # ``/mnt/inactive-root``, so the mountpoints were empty rootfs
-        # directories and step 6/7's stream-extract would silently
-        # write the bundle onto the **active** rootfs (slot A),
-        # leaving slot B stale and bricking the device on tryboot.
-        # ``ensure_partition_mounted`` is idempotent — if a systemd
-        # unit already mounted the partition (the agora-os 0.0.8+
-        # path), this is a no-op.
+        # ``/mnt/inactive-root``, so the mountpoints were empty
+        # rootfs directories and step 6/7's stream-extract would
+        # silently write the bundle onto the **active** rootfs (slot
+        # A), leaving slot B stale. ``ensure_partition_mounted`` is
+        # idempotent — if a systemd unit already mounted the
+        # partition (the agora-os 0.0.8+ path), this is a no-op,
+        # AND it now verifies the correct partlabel is mounted
+        # there (Bug 2 fix).
         _safe_emit_progress(progress_callback, "mounting_inactive")
-        boot_target = boot_mount_for_slot(
-            inactive,
-            slot_a_mount=self.boot_mount_slot_a,
-            slot_b_mount=self.boot_mount_slot_b,
-        )
+        boot_target = Path(self.inactive_boot_mount)
         root_target = Path(self.inactive_root_mount)
         ensure_partition_mounted(
             boot_partlabel_for_slot(inactive),
@@ -1330,6 +1458,21 @@ class SlotStager:
             partlabel_base=self.partlabel_base,
             timeout_s=self.mount_timeout_s,
         )
+
+        # 5b. Wipe the inactive slot's boot + root partitions before
+        # extracting the bundle. Without this, an old release's files
+        # that are NOT in the new bundle's manifest survive into the
+        # newly-extracted slot and quietly contaminate it. The
+        # streaming extract overwrites same-path files but leaves
+        # orphans alone — this is how v0.0.18-test left a stale
+        # ``bcm2712-rpi-5-b.dtb`` + companion overlays on the boot
+        # partition that pointed the bootloader at a kernel the new
+        # rootfs no longer matched. Wiping is a destructive, slot-B-
+        # only operation; the staging runner aborts before this if
+        # the wrong device is mounted at either target (see Bug 2
+        # fix in ``ensure_partition_mounted``).
+        _safe_emit_progress(progress_callback, "wiping_inactive")
+        self._wipe_inactive_partitions(boot_target, root_target)
 
         # 6. Stream boot/ subtree straight onto the inactive boot partition.
         # --strip-components=1 turns "boot/foo" into "<boot_target>/foo" and
@@ -1368,16 +1511,28 @@ class SlotStager:
             len(meta.sha256_manifest),
         )
 
-        # 9. Copy per-device fleet-state files from slot A into slot B.
-        # Done AFTER manifest verify so the manifest check doesn't see
-        # files added by us. Implements D60 of plan.md §"Phase 2".
+        # 9. Copy per-device fleet-state from the active slot into
+        # the inactive slot. Done AFTER manifest verify so the
+        # manifest check doesn't see files added by us. Two distinct
+        # copies — the rootfs identity files (D60 of plan.md §"Phase
+        # 2") and the boot-partition state (``autoboot.txt``,
+        # required so the bootloader still has a slot to select
+        # post-extract). See v0.0.18-test post-mortem.
         _safe_emit_progress(progress_callback, "copying_fleet_state")
         copy_fleet_state(
-            self.slot_a_root,
+            self.running_root,
             root_target,
             runner=self.runner,
             required=self.fleet_state_required,
             copy_if_present=self.fleet_state_copy_if_present,
+            cp_timeout_s=self.fleet_state_cp_timeout_s,
+        )
+        copy_fleet_state(
+            self.active_boot_mount,
+            boot_target,
+            runner=self.runner,
+            required=self.boot_fleet_state_required,
+            copy_if_present=self.boot_fleet_state_copy_if_present,
             cp_timeout_s=self.fleet_state_cp_timeout_s,
         )
 
@@ -1409,6 +1564,56 @@ class SlotStager:
                 f"trigger_tryboot({inactive}) failed: "
                 f"{type(exc).__name__}: {exc}"
             ) from exc
+
+    def _wipe_inactive_partitions(self, boot_target: Path, root_target: Path) -> None:
+        """Delete every entry under ``boot_target`` and ``root_target``.
+
+        Run between mount (step 5) and extract (step 6) to clear out
+        stale files from a prior release that are NOT in the new
+        bundle's manifest. Without this, the streaming extract only
+        overwrites same-path files and orphans survive — the exact
+        contamination mode that bricked Pi100 on v0.0.18-test, where
+        a stale ``bcm2712-rpi-5-b.dtb`` from the prior bundle pointed
+        the bootloader at a kernel the new rootfs no longer matched.
+
+        Uses ``find <target> -mindepth 1 -delete`` on the live mount
+        so the mountpoint itself stays (preserving the device-node /
+        FS — we are emphatically NOT formatting). ``-mindepth 1``
+        keeps the mountpoint inode. The find binary handles
+        FAT32-on-boot and ext4-on-root identically.
+
+        Aborts with :class:`StagingError` on any subprocess failure;
+        in particular this fails fast on EROFS, which would indicate
+        the wrong partition is mounted (the active slot's root
+        partition is mounted read-only on a healthy boot — wiping it
+        would be catastrophic). The Bug 2 partlabel check in
+        :func:`ensure_partition_mounted` should already have caught
+        that case in step 5; this is defense-in-depth.
+        """
+        for label, target in (("boot", boot_target), ("root", root_target)):
+            logger.info(
+                "wiping inactive %s partition: %s (find -mindepth 1 -delete)",
+                label,
+                target,
+            )
+            try:
+                result = self.runner(
+                    ["find", str(target), "-mindepth", "1", "-delete"],
+                    timeout=self.mount_timeout_s,
+                )
+            except FileNotFoundError as exc:
+                raise StagingError(
+                    f"find binary not found on PATH while wiping {target}: {exc}"
+                ) from exc
+            except subprocess.TimeoutExpired as exc:
+                raise StagingError(
+                    f"wipe of {target} timed out after {self.mount_timeout_s}s"
+                ) from exc
+            if result.returncode != 0:
+                raise StagingError(
+                    f"wipe of {target} failed (rc={result.returncode}): "
+                    f"stderr={_tail(result.stderr)!r}"
+                )
 
     def _read_running_slot(self) -> int:
         slot_state_fn = self.slot_state_fn or _default_slot_state

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -33,9 +33,11 @@ from typing import Optional, Sequence
 import pytest
 
 from os_updater.apply import (
+    BOOT_FLEET_STATE_COPY_IF_PRESENT,
+    BOOT_FLEET_STATE_REQUIRED,
+    DEFAULT_ACTIVE_BOOT_MOUNT,
     DEFAULT_BOOT_MOUNT_OPTS,
-    DEFAULT_BOOT_MOUNT_SLOT_A,
-    DEFAULT_BOOT_MOUNT_SLOT_B,
+    DEFAULT_INACTIVE_BOOT_MOUNT,
     DEFAULT_MOUNT_TIMEOUT_S,
     DEFAULT_ROOT_MOUNT_OPTS,
     FLEET_STATE_COPY_IF_PRESENT,
@@ -50,7 +52,6 @@ from os_updater.apply import (
     StagingError,
     TrybootError,
     _is_mountpoint,
-    boot_mount_for_slot,
     boot_partlabel_for_slot,
     copy_fleet_state,
     ensure_partition_mounted,
@@ -219,25 +220,10 @@ class TestOtherSlot:
             other_slot(bad)
 
 
-class TestBootMountForSlot:
-    def test_slot_1_returns_a_mount(self, tmp_path):
-        a, b = tmp_path / "a", tmp_path / "b"
-        assert boot_mount_for_slot(1, slot_a_mount=a, slot_b_mount=b) == a
-
-    def test_slot_2_returns_b_mount(self, tmp_path):
-        a, b = tmp_path / "a", tmp_path / "b"
-        assert boot_mount_for_slot(2, slot_a_mount=a, slot_b_mount=b) == b
-
-    def test_defaults_match_phase_0_fstab(self):
-        """Sanity-pin the production paths — touching these is a fleet-wide
-        breaking change."""
-        assert boot_mount_for_slot(1) == DEFAULT_BOOT_MOUNT_SLOT_A
-        assert boot_mount_for_slot(2) == DEFAULT_BOOT_MOUNT_SLOT_B
-
-    @pytest.mark.parametrize("bad", [0, 3, -1])
-    def test_invalid_slot_raises_staging_error(self, bad):
-        with pytest.raises(StagingError, match="invalid slot number"):
-            boot_mount_for_slot(bad)
+# NOTE: TestBootMountForSlot deleted with the slot-keyed boot mount lookup —
+# the agora-os fstab convention pins active boot to /boot/firmware and
+# inactive boot to /boot/firmware-b regardless of slot number. See
+# DEFAULT_ACTIVE_BOOT_MOUNT / DEFAULT_INACTIVE_BOOT_MOUNT in apply.py.
 
 
 # ── boot_partlabel_for_slot / root_partlabel_for_slot ──────────────────────
@@ -332,8 +318,16 @@ class TestEnsurePartitionMounted:
     def test_noop_when_already_mounted(self, tmp_path):
         target = tmp_path / "mnt"
         target.mkdir()
+        partlabel_base = tmp_path / "partlabel-base"
+        partlabel_base.mkdir()
+        # Device at the already-mounted target must match
+        # ``<partlabel_base>/root-B`` (Bug 2 fix: partlabel verification
+        # against /proc/self/mounts). Touch so .resolve() returns the
+        # canonical path on every platform.
+        device = partlabel_base / "root-B"
+        device.touch()
         mounts = tmp_path / "proc-mounts"
-        mounts.write_text(f"/dev/foo {target} ext4 rw 0 0\n")
+        mounts.write_text(f"{device} {target} ext4 rw 0 0\n")
         runner = _FakeRunner()
         ensure_partition_mounted(
             "root-B",
@@ -342,7 +336,7 @@ class TestEnsurePartitionMounted:
             opts="rw",
             runner=runner,
             mounts_path=mounts,
-            partlabel_base=tmp_path / "partlabel-base",
+            partlabel_base=partlabel_base,
         )
         # No mount(8) call should have been recorded.
         assert runner.calls == []
@@ -902,16 +896,16 @@ class _FakeSlotStatus:
         self.running_slot = running_slot
 
 
-def _seed_fake_slot_a(slot_a_root: Path) -> None:
-    """Populate ``slot_a_root`` with every :data:`FLEET_STATE_REQUIRED`
+def _seed_fake_active_root(active_root: Path) -> None:
+    """Populate ``active_root`` with every :data:`FLEET_STATE_REQUIRED`
     fixture plus one ``copy_if_present`` optional file.
 
-    Mirrors a real provisioned device's slot A so fleet-state copy
-    sees a satisfied required set. Tests that want to exercise
+    Mirrors a real provisioned device's running rootfs so fleet-state
+    copy sees a satisfied required set. Tests that want to exercise
     "missing required" / "missing optional" paths call ``unlink``
     on individual files after this seeds.
     """
-    slot_a_root.mkdir(parents=True, exist_ok=True)
+    active_root.mkdir(parents=True, exist_ok=True)
 
     files = {
         "etc/agora/environment": b"AGORA_FLEET_ID=test-fleet\n",
@@ -938,7 +932,7 @@ def _seed_fake_slot_a(slot_a_root: Path) -> None:
         ),
     }
     for rel, content in files.items():
-        path = slot_a_root / rel
+        path = active_root / rel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
 
@@ -955,11 +949,11 @@ def _make_stager(
 ) -> SlotStager:
     """Build a SlotStager pointed at ``tmp_path`` with injected seams.
 
-    By default seeds a fake slot-A rootfs under ``tmp_path/slot-a-root``
+    By default seeds a fake active rootfs under ``tmp_path/active-root``
     populated with every :data:`FLEET_STATE_REQUIRED` fixture so the
     full happy-path pipeline runs end-to-end. Pass
-    ``seed_fleet_state=False`` to leave slot A empty for "missing
-    required" tests.
+    ``seed_fleet_state=False`` to leave the active root empty for
+    "missing required" tests.
 
     ``pipeline_runner`` defaults to a no-canned-files fake which is
     useful for tests that don't drive the full pipeline (e.g. the
@@ -981,48 +975,83 @@ def _make_stager(
         return _FakeSlotStatus(target_slot)
 
     # All mountpoints live under tmp_path. They start as empty dirs;
-    # SlotStager.step5 calls ensure_partition_mounted on slot-B's boot
-    # + the inactive-root, which reads ``mounts_path`` (a fake
+    # SlotStager.step5 calls ensure_partition_mounted on the inactive
+    # slot's boot + root, which reads ``mounts_path`` (a fake
     # /proc/self/mounts) and no-ops if the target is already mounted.
-    # We seed that fake mounts file with the slot-B + inactive-root
-    # entries so happy-path tests skip mount(8) entirely — there's no
-    # real device node to mount and the runner would record a phantom
-    # ``mount`` call. Tests that exercise the mount-fails-with-stderr
-    # path can swap in a runner whose `results_by_head["mount"]=N` and
-    # leave the entries out of the mounts file (rewriting mounts_file
-    # after _make_stager returns, or constructing the stager
-    # explicitly).
-    slot_a_boot = tmp_path / "boot-slot-a"
-    slot_b_boot = tmp_path / "boot-slot-b"
+    # We seed that fake mounts file with the active-boot, inactive-boot
+    # and inactive-root entries so happy-path tests skip mount(8)
+    # entirely — there's no real device node to mount and the runner
+    # would record a phantom ``mount`` call. Tests that exercise the
+    # mount-fails-with-stderr path can swap in a runner whose
+    # `results_by_head["mount"]=N` and leave the entries out of the
+    # mounts file (rewriting mounts_file after _make_stager returns,
+    # or constructing the stager explicitly).
+    active_boot = tmp_path / "active-boot"
+    inactive_boot = tmp_path / "inactive-boot"
     inactive_root = tmp_path / "inactive-root"
-    slot_a_boot.mkdir()
-    slot_b_boot.mkdir()
+    active_boot.mkdir()
+    inactive_boot.mkdir()
     inactive_root.mkdir()
 
-    mounts_file = tmp_path / "proc-mounts"
-    mounts_file.write_text(
-        f"/dev/mmcblk0p1 {slot_a_boot} vfat rw 0 0\n"
-        f"/dev/mmcblk0p2 {slot_b_boot} vfat rw 0 0\n"
-        f"/dev/mmcblk0p4 {inactive_root} ext4 rw 0 0\n"
+    # BOOT_FLEET_STATE_REQUIRED includes ``autoboot.txt`` — the
+    # boot-side fleet-state copy step at the end of every successful
+    # stage reads it from active_boot and writes to inactive_boot.
+    # Seed a stub here so happy-path tests don't trip
+    # FleetStateMissingError. Tests that want to exercise the
+    # missing-autoboot path call ``(stager.active_boot_mount /
+    # "autoboot.txt").unlink()`` after _make_stager returns.
+    (active_boot / "autoboot.txt").write_bytes(
+        b"[all]\nboot_partition=1\n[tryboot]\nboot_partition=2\n"
     )
+
     partlabel_base = tmp_path / "partlabel-base"
     partlabel_base.mkdir()
-
-    slot_a_root = tmp_path / "slot-a-root"
-    if seed_fleet_state:
-        _seed_fake_slot_a(slot_a_root)
+    mounts_file = tmp_path / "proc-mounts"
+    # The active/inactive partlabels depend on running_slot. Devices in
+    # the fake /proc/self/mounts must point at
+    # ``<partlabel_base>/<partlabel>`` because ensure_partition_mounted
+    # now verifies that the device at an already-mounted target matches
+    # the expected partlabel — Bug 2 of the v0.0.18-test brick. Touch
+    # the device files so .resolve() returns canonical paths on every
+    # platform (Windows .resolve() of a non-existent path still works
+    # because pathlib doesn't require existence in non-strict mode, but
+    # touching is harmless and keeps the fake mountspec readable).
+    #
+    # ``running_slot is None`` means the SUT can't tell which slot is
+    # live; the stager bails before step5 with
+    # ``could not determine running slot`` so the mounts file content
+    # is irrelevant. Write an empty file and skip the partlabel arith
+    # (other_slot(None) would raise an unrelated StagingError).
+    if running_slot is None:
+        mounts_file.write_text("")
     else:
-        slot_a_root.mkdir()
+        inactive_slot = other_slot(running_slot)
+        active_boot_dev = partlabel_base / boot_partlabel_for_slot(running_slot)
+        inactive_boot_dev = partlabel_base / boot_partlabel_for_slot(inactive_slot)
+        inactive_root_dev = partlabel_base / root_partlabel_for_slot(inactive_slot)
+        for dev in (active_boot_dev, inactive_boot_dev, inactive_root_dev):
+            dev.touch()
+        mounts_file.write_text(
+            f"{active_boot_dev} {active_boot} vfat rw 0 0\n"
+            f"{inactive_boot_dev} {inactive_boot} vfat rw 0 0\n"
+            f"{inactive_root_dev} {inactive_root} ext4 rw 0 0\n"
+        )
+
+    active_root = tmp_path / "active-root"
+    if seed_fleet_state:
+        _seed_fake_active_root(active_root)
+    else:
+        active_root.mkdir()
 
     return SlotStager(
         runner=runner,
         pipeline_runner=pipeline_runner,
-        boot_mount_slot_a=slot_a_boot,
-        boot_mount_slot_b=slot_b_boot,
+        active_boot_mount=active_boot,
+        inactive_boot_mount=inactive_boot,
         inactive_root_mount=inactive_root,
         slot_state_fn=fake_slot_state,
         trigger_tryboot_fn=fake_trigger_tryboot,
-        slot_a_root=slot_a_root,
+        running_root=active_root,
         mounts_path=mounts_file,
         partlabel_base=partlabel_base,
     )
@@ -1106,29 +1135,47 @@ class TestSlotStagerHappyPath:
         pipeline_subpaths = [c[0] for c in pipeline.calls]
         assert pipeline_subpaths == ["__meta__", "boot", "root"]
 
-        # Runner only saw cp calls — no zstd/tar/rsync at all.
+        # Runner only saw cp + find calls — no zstd/tar/rsync at all.
+        # ``find`` is from _wipe_inactive_partitions (Bug 3 fix:
+        # ``find <target> -mindepth 1 -delete`` runs once for the
+        # inactive boot mount and once for the inactive root mount).
+        # ``cp`` is fleet-state (Bug 4): 8 cp invocations for the
+        # rootfs identity copy (4 required literals + 2 ssh host
+        # keys + 1 wifi nmconnection + 1 home/agora/.ssh dir from
+        # _seed_fake_active_root) + 1 cp for boot fleet-state
+        # (autoboot.txt) = 9 cps. Total 11.
         heads = [c[0] for c in runner.calls]
-        assert heads, "expected cp invocations for fleet-state copy"
-        assert all(h == "cp" for h in heads), (
-            f"expected only cp calls in runner, got {heads}"
+        assert heads, "expected cp + find invocations for stage"
+        assert all(h in ("cp", "find") for h in heads), (
+            f"expected only cp + find calls in runner, got {heads}"
         )
-        # 4 required literals + 2 ssh host keys + 1 optional wifi nmconnection
-        # + 1 home/agora/.ssh dir from _seed_fake_slot_a == 8 cp invocations.
-        assert len(heads) == 8
+        assert heads.count("find") == 2, (
+            f"expected 2 find calls (boot+root wipe), got {heads}"
+        )
+        assert heads.count("cp") == 9, (
+            f"expected 9 cp calls (8 rootfs fleet-state + 1 boot "
+            f"autoboot.txt), got {heads}"
+        )
 
-        # Boot was streamed into slot-B boot mount.
+        # Boot was streamed into the inactive boot mount.
         boot_call = next(c for c in pipeline.calls if c[0] == "boot")
-        assert boot_call[2] == str(stager.boot_mount_slot_b)
+        assert boot_call[2] == str(stager.inactive_boot_mount)
 
         # Root was streamed into inactive-root mount.
         root_call = next(c for c in pipeline.calls if c[0] == "root")
         assert root_call[2] == str(stager.inactive_root_mount)
 
-        # Every cp's destination must be inside the inactive_root_mount —
-        # otherwise we're writing identity files into the running slot.
+        # Every cp's destination must be inside either the
+        # inactive_root_mount (rootfs fleet-state) or the
+        # inactive_boot_mount (boot fleet-state, autoboot.txt).
+        # Otherwise we're writing identity files into the running slot.
         cp_calls = [c for c in runner.calls if c[0] == "cp"]
         for cp in cp_calls:
-            assert str(stager.inactive_root_mount) in cp[-1]
+            dest = cp[-1]
+            assert (
+                str(stager.inactive_root_mount) in dest
+                or str(stager.inactive_boot_mount) in dest
+            ), f"cp dest outside inactive slot: {cp}"
 
         # substitute_fstab side-effect: etc/fstab now exists on slot B
         # and references boot-B (since we tryboot to slot 2).
@@ -1137,13 +1184,19 @@ class TestSlotStagerHappyPath:
         assert b"{{BOOT_PARTLABEL}}" not in fstab
 
         # rewrite_cmdline side-effect: cmdline.txt references root-B.
-        cmdline = (stager.boot_mount_slot_b / "cmdline.txt").read_text()
+        cmdline = (stager.inactive_boot_mount / "cmdline.txt").read_text()
         assert "root=PARTLABEL=root-B" in cmdline
         assert "root=PARTLABEL=root-A" not in cmdline
 
     def test_full_pipeline_running_slot_2(self, tmp_path):
         """Running slot 2 ⇒ tryboot must target slot 1 ⇒ streaming
-        writes hit the slot-A boot mount + the inactive-root mount."""
+        writes hit the inactive boot mount + the inactive-root mount.
+
+        The inactive boot mount is always at the same fstab mountpoint
+        (``/boot/firmware-b`` in production) regardless of slot number;
+        which physical partition lives there is a function of which
+        slot is currently active, but the stager just trusts the
+        configured mountpoint."""
         runner = _FakeRunner()
         tryboot_calls: list[int] = []
         staging_dir, stager, pipeline = _setup_stager_with_bundle(
@@ -1156,10 +1209,10 @@ class TestSlotStagerHappyPath:
         assert tryboot_calls == [1]
 
         boot_call = next(c for c in pipeline.calls if c[0] == "boot")
-        assert boot_call[2] == str(stager.boot_mount_slot_a)
+        assert boot_call[2] == str(stager.inactive_boot_mount)
 
         # cmdline rewritten to root-A.
-        cmdline = (stager.boot_mount_slot_a / "cmdline.txt").read_text()
+        cmdline = (stager.inactive_boot_mount / "cmdline.txt").read_text()
         assert "root=PARTLABEL=root-A" in cmdline
 
         # fstab references boot-A.
@@ -1313,15 +1366,15 @@ class TestSlotStagerErrors:
             raise RuntimeError("dbus is down")
 
         runner = _FakeRunner()
-        slot_a = tmp_path / "boot-a"
-        slot_b = tmp_path / "boot-b"
+        active_boot = tmp_path / "active-boot"
+        inactive_boot = tmp_path / "inactive-boot"
         inactive = tmp_path / "inactive"
-        slot_a.mkdir(); slot_b.mkdir(); inactive.mkdir()
+        active_boot.mkdir(); inactive_boot.mkdir(); inactive.mkdir()
         stager = SlotStager(
             runner=runner,
             pipeline_runner=pipeline,
-            boot_mount_slot_a=slot_a,
-            boot_mount_slot_b=slot_b,
+            active_boot_mount=active_boot,
+            inactive_boot_mount=inactive_boot,
             inactive_root_mount=inactive,
             slot_state_fn=boom,
             trigger_tryboot_fn=lambda s: None,
@@ -1412,7 +1465,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         runner = _FakeRunner()
 
         copy_fleet_state(slot_a, slot_b, runner=runner)
@@ -1432,7 +1485,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         # Yank one of the required literal files.
         (slot_a / "etc/agora/environment").unlink()
         runner = _FakeRunner()
@@ -1454,7 +1507,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         # Strip every ssh host key so the glob returns empty.
         import shutil
         shutil.rmtree(slot_a / "etc/ssh")
@@ -1474,7 +1527,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         # Drop the only optional file we seeded.
         (slot_a / "etc/NetworkManager/system-connections/wifi-home.nmconnection").unlink()
         runner = _FakeRunner()
@@ -1493,7 +1546,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         runner = _FakeRunner(
             results_by_head={"cp": 1},
             stderr_by_head={"cp": "permission denied"},
@@ -1509,7 +1562,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         runner = _FakeRunner(raise_timeout_for={"cp"})
 
         with pytest.raises(FleetStateWriteError) as exc_info:
@@ -1529,7 +1582,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         runner = _FakeRunner()
 
         copy_fleet_state(slot_a, slot_b, runner=runner)
@@ -1561,7 +1614,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         # Drop the seeded .ssh dir.
         _shutil.rmtree(slot_a / "home" / "agora" / ".ssh")
         runner = _FakeRunner()
@@ -1592,7 +1645,7 @@ class TestCopyFleetState:
         slot_a = tmp_path / "slot-a"
         slot_b = tmp_path / "slot-b"
         slot_b.mkdir()
-        _seed_fake_slot_a(slot_a)
+        _seed_fake_active_root(slot_a)
         # Simulate a stale .ssh directory left over from a prior
         # partial apply (e.g. apply aborted after rsync but before
         # tryboot triggered).
@@ -1792,7 +1845,7 @@ class TestSlotStagerProgressCallback:
         )
 
         assert tryboot_calls == [2]
-        cmdline = (stager.boot_mount_slot_b / "cmdline.txt").read_text()
+        cmdline = (stager.inactive_boot_mount / "cmdline.txt").read_text()
         assert "root=PARTLABEL=root-B" in cmdline
 
     def test_async_entrypoint_forwards_callback(self, tmp_path):


### PR DESCRIPTION
## What

Fixes 5 bugs in `os_updater/apply.py` discovered during the v0.0.18-test OTA on Pi100 that bricked the slot B boot:

1. **Slot-keyed boot mount → active/inactive boot mount.** The stager was treating `/boot/firmware-a` and `/boot/firmware-b` as fixed slot-A/slot-B paths instead of the active-vs-inactive distinction the rest of `apply.py` already used. On a Pi running slot B (with `/boot/firmware` = boot-B), the stager mounted boot-A as "inactive" and proceeded to write the v0.0.18 kernel + dtbs there — but the running `/boot/firmware` (= boot-B) was the actually-active mount and got cross-contaminated.
2. **Weak mountpoint check.** The "is this device already mounted at the right place" check only compared device-paths, which let bind mounts and partlabel aliases pass even when they pointed at the wrong slot. Now enforces `PARTLABEL=boot-A`/`root-A` matches what the running slot says.
3. **No wipe before extract.** Tar over a non-empty inactive slot left orphan files from the previous OS version. New `_wipe_inactive_partitions` step runs `find -mindepth 1 -delete` on inactive boot + root before extract.
4. **Fleet-state copy is rootfs-only.** The per-device fleet-state copy ran for rootfs but missed boot. `autoboot.txt` on the running slot's boot partition was never copied to the inactive slot's boot partition, so a freshly-extracted slot B would tryboot without the device's actual boot config. New constant `BOOT_FLEET_STATE_REQUIRED = ("autoboot.txt",)` + generic `copy_fleet_state` primitive used for both rootfs and boot.
5. **Manifest verify ordering (doc-only).** Already correct in code; comment expanded to call out the ordering invariant.

Bonus: `slot_a_root` → `running_root` rename for clarity (was misleading on slot-B-running devices).

## Test changes

- `_make_stager` test helper seeds `autoboot.txt` on `active_boot` so the new boot fleet-state copy has something to copy.
- `test_noop_when_already_mounted` rewrites the mounts entry to use `<partlabel_base>/root-B` so it survives the new partlabel verification.
- `test_full_pipeline_running_slot_1` runner-call assertions updated for the 2 new `find` calls (wipe step) + 1 new `cp` call (boot fleet-state) + partitioned cp-destination check (rootfs cps land under `inactive_root_mount`, boot cps under `inactive_boot_mount`).

## Test results

```
83 passed, 1 warning in 1.40s
```

Targeted: `pytest -p no:timeout tests/test_os_updater_apply.py`. No full suite (signal.SIGALRM not available on Windows; full suite takes too long).

## Validation plan

1. Merge + tag v0.0.19-test in `sslivins/agora-os`.
2. Track B (parallel): hot-patch Pi100's `/opt/agora/src/os_updater/apply.py` with this same diff and retry the staged v0.0.18 bundle. If the retry promotes cleanly, the bug-set is confirmed fixed in-situ.
3. Once v0.0.19-test bundle is built, dispatch via CMS to Pi100 as the first real end-to-end OTA on the new apply.py.

## References

- Bricked Pi100 root-cause: see session notes for v0.0.18-test OTA failure.
- Related: agora-os v0.0.18-test (the bundle that surfaced the bugs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
