### PR TITLE
slot_confirm: defer strike when agora services not yet aged (#209 Bug A)

### DIFF
--- a/slot_confirm/__main__.py
+++ b/slot_confirm/__main__.py
@@ -11,10 +11,11 @@ Modes (these may be combined):
                        ``next_action`` by invoking the corresponding
                        :mod:`slot_mgr` verb:
 
-                         next_action="promote" → slot_mgr.promote_slot(running_slot)
-                         next_action="strike"  → slot_mgr.record_tryboot_strike(running_slot)
-                         next_action="skipped" → no-op
-                         next_action="error"   → no action, exit 2
+                         next_action="promote"  → slot_mgr.promote_slot(running_slot)
+                         next_action="strike"   → slot_mgr.record_tryboot_strike(running_slot)
+                         next_action="deferred" → no-op (services not yet aged)
+                         next_action="skipped"  → no-op
+                         next_action="error"    → no action, exit 2
 
                        The emitted JSON adds ``action_taken`` and any
                        ``action_error``.
@@ -35,11 +36,17 @@ JSON shape (without ``--auto``)::
 
 Exit codes:
 
-* 0 — checks ran (default), or checks ran + acted (--auto), or
-      ``--check`` and ``ok=True``.
-* 1 — ``--check`` and ``ok=False``.
-* 2 — couldn't even run the gate (slot_mgr import failed, or
-      ``next_action=="error"`` under ``--auto``).
+* 0  — checks ran (default), or checks ran + acted (--auto), or
+       ``--check`` and ``ok=True``.
+* 1  — ``--check`` and ``ok=False``.
+* 2  — couldn't even run the gate (slot_mgr import failed, or
+       ``next_action=="error"`` under ``--auto``).
+* 75 — ``--auto`` and ``next_action=="deferred"``. The agora-*
+       services aren't yet aged (≥5 min Active) but everything
+       else is healthy; the strike counter MUST NOT advance for
+       this transient condition. Exit 75 (``EX_TEMPFAIL``) is a
+       signal to systemd's ``Restart=on-failure`` to retry the
+       unit after ``RestartSec``. See bug #209.
 """
 
 from __future__ import annotations
@@ -86,12 +93,21 @@ def _act(status: ConfirmStatus) -> tuple[str, str]:
     """Carry out ``status.next_action`` via slot_mgr.
 
     Returns a ``(action_taken, action_error)`` tuple. ``action_taken``
-    is one of ``"promote"``, ``"strike"``, ``"skipped"``, or
-    ``"none"`` (when ``next_action == "error"``). ``action_error`` is
-    a free-form message on failure, ``""`` otherwise.
+    is one of ``"promote"``, ``"strike"``, ``"deferred"``,
+    ``"skipped"``, or ``"none"`` (when ``next_action == "error"``).
+    ``action_error`` is a free-form message on failure, ``""``
+    otherwise.
     """
     if status.next_action == "skipped":
         return "skipped", ""
+
+    if status.next_action == "deferred":
+        # agora-* services are up but haven't met the ≥5min Active
+        # bar yet (bug #209). No on-device side effect — the CLI
+        # caller (systemd unit) is expected to retry via
+        # Restart=on-failure on the EX_TEMPFAIL exit code emitted by
+        # main().
+        return "deferred", ""
 
     if status.next_action == "error":
         return "none", status.error or "slot_state() failed"
@@ -158,6 +174,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.auto and status.next_action == "error":
         return 2
+    if args.auto and status.next_action == "deferred":
+        # EX_TEMPFAIL — signals systemd's Restart=on-failure to retry
+        # this unit after RestartSec. See bug #209 and the deferred
+        # branch in slot_confirm.core.slot_confirm().
+        return 75
     if args.check and not status.ok:
         return 1
     return 0

--- a/slot_confirm/core.py
+++ b/slot_confirm/core.py
@@ -91,9 +91,14 @@ class ConfirmStatus:
         nothing to confirm.
     next_action
         One of ``"promote"`` (tentative + all checks passed),
-        ``"strike"`` (tentative + ≥1 check failed), or ``"skipped"``
-        (not tentative). The CLI's ``--auto`` mode uses this to
-        decide which :mod:`slot_mgr` verb to invoke.
+        ``"deferred"`` (tentative + the *only* failure is the
+        agora-* services not having reached the ≥5 min Active
+        threshold yet — caller should retry rather than strike,
+        see bug #209), ``"strike"`` (tentative + any other
+        failure), or ``"skipped"`` (not tentative). The CLI's
+        ``--auto`` mode uses this to decide which :mod:`slot_mgr`
+        verb to invoke (and ``"deferred"`` triggers a clean retry
+        via systemd ``Restart=on-failure``).
     checks
         Tuple of all :class:`CheckResult` instances, in the order they
         were run. Empty when ``next_action == "skipped"``.
@@ -377,6 +382,13 @@ def check_agora_services_active(
                     "min_active_seconds": min_active_seconds,
                     "entered_at": entered.isoformat(),
                     "clock_source": clock_source,
+                    # ``not_yet_aged`` is the discriminator the aggregator
+                    # uses to distinguish "this service is up but hasn't
+                    # met the ≥5min bar yet — try me again in a moment"
+                    # from "this service is broken — strike me". See
+                    # :func:`_only_services_not_yet_aged` and bug #209
+                    # for the failure that motivated this split.
+                    "reason": "not_yet_aged",
                 },
             )
 
@@ -754,6 +766,15 @@ def slot_confirm(
     if all_ok:
         next_action = "promote"
         ok = True
+    elif _only_services_not_yet_aged(results):
+        # The agora-* services are up and healthy, they just haven't
+        # been Active for the required ≥5 min yet (see bug #209). We
+        # MUST NOT strike — striking burns the slot's strike budget
+        # for a transient, expected condition. Recommend the caller
+        # try again in a few seconds; the systemd unit's Restart=
+        # policy does exactly that.
+        next_action = "deferred"
+        ok = False
     else:
         next_action = "strike"
         ok = False
@@ -766,3 +787,28 @@ def slot_confirm(
         tentative=tentative,
         error="",
     )
+
+
+def _only_services_not_yet_aged(results: Sequence[CheckResult]) -> bool:
+    """True iff the only failing check is ``agora_services_active`` with reason ``not_yet_aged``.
+
+    The discriminator is :func:`check_agora_services_active`'s
+    ``measurement["reason"] == "not_yet_aged"`` tag, which is emitted
+    only on the "service is Active but hasn't met the ≥5 min
+    threshold" branch. Other failure modes of the services check
+    (inactive/failed unit, missing timestamp, negative-age clock
+    bug) have a different reason or no reason and therefore still
+    strike — they are genuine red flags, not the boot-timing race
+    that bug #209 fixes.
+    """
+    saw_not_yet_aged = False
+    for result in results:
+        if result.ok:
+            continue
+        if result.name != "agora_services_active":
+            return False
+        reason = (result.measurement or {}).get("reason")
+        if reason != "not_yet_aged":
+            return False
+        saw_not_yet_aged = True
+    return saw_not_yet_aged

--- a/systemd/agora-slot-mgr.service
+++ b/systemd/agora-slot-mgr.service
@@ -30,25 +30,44 @@ StartLimitIntervalSec=600
 [Service]
 # `oneshot` so the unit runs once after boot and exits; the gate's job
 # is a single decision, not a long-running daemon. Combined with
-# `Restart=on-failure` below, this gives us a bounded retry budget when
-# `slot_state()` or one of the checks raises transiently.
+# `Restart=on-failure` below, this gives us a bounded retry budget for
+# the one case in `--auto` where the right answer really is "try again
+# in a moment": services not yet aged (bug #209).
 Type=oneshot
 ExecStart=/usr/bin/python3 -m slot_confirm --auto
 WorkingDirectory=/opt/agora/src
 Environment=PYTHONPATH=/opt/agora/src
 Environment=AGORA_BASE=/opt/agora
 
-# Retry transient failures (e.g. systemctl-show RPC timeout, status
-# file briefly missing) up to ~5 minutes total. `next_action="error"`
-# from --auto exits 2 which counts as failure; `strike` exits 0, so
-# the unit stops on its own as soon as a non-error decision has been
-# recorded.
+# `--auto` has three terminal exit codes:
+#   0  → promote OR strike OR skipped. The gate ran to completion and
+#        recorded a decision. systemd sees success, unit stops, no
+#        retry. This is what we want when the slot has been judged
+#        good *or* bad — striking burns one of the three attempts and
+#        is itself a "decision". (Skipped means not tentative; nothing
+#        to do.)
+#   75 → deferred (EX_TEMPFAIL). The agora-* services are up and
+#        healthy but haven't reached the ≥5 min Active threshold yet
+#        — the normal boot race, see bug #209. NOT a strike: this is
+#        an *expected* transient that the retry budget below covers.
+#        systemd sees failure, sleeps RestartSec, retries; eventually
+#        the services age past the threshold and we exit 0 with a
+#        promote or strike, OR StartLimitBurst runs out and the unit
+#        stops with a real failure.
+#   2  → error (slot_state() raised, etc.). systemd retries the same
+#        way as 75 — also a transient condition (e.g. systemctl-show
+#        RPC timeout, status file briefly missing) — until the burst
+#        budget runs out.
+#
+# `--check` exits 1 on a "gate-failed" result; the unit does not run
+# --check so that branch never reaches systemd.
+#
+# Budget math: RestartSec=45s × StartLimitBurst=10 = 450s ≈ 7.5 min,
+# which covers the 5-min service-age window with margin. StartLimit*
+# live in [Unit] above; see the comment there for why.
 Restart=on-failure
-RestartSec=30
+RestartSec=45
 
-# Both `--auto` exit codes that mean "ran to completion" are 0 or 1,
-# and we already filter exit 1 via `--auto` (which always exits 0 or 2).
-# Keep SuccessExitStatus minimal; let the retry budget handle failures.
 StandardOutput=journal
 StandardError=journal
 

--- a/tests/test_slot_confirm.py
+++ b/tests/test_slot_confirm.py
@@ -167,6 +167,24 @@ class TestCheckAgoraServicesActive:
         assert "60s" in result.detail
         assert result.measurement["active_for_seconds"] == pytest.approx(60.0)
 
+    def test_too_young_emits_not_yet_aged_reason(self) -> None:
+        # Bug #209: the "services are up but haven't reached the ≥5 min
+        # threshold yet" branch must tag its measurement with
+        # ``reason="not_yet_aged"`` so the aggregator can defer (retry)
+        # rather than strike a slot during the normal boot race. Other
+        # failure modes (inactive unit, missing timestamp, negative age)
+        # do NOT carry this reason and continue to strike.
+        now = _fixed_now(0)
+        entered = (now - timedelta(seconds=120)).strftime("%Y-%m-%d %H:%M:%S UTC")
+        runner = _systemctl_runner(
+            {svc: ("active", entered) for svc in DEFAULT_AGORA_SERVICES}
+        )
+        result = check_agora_services_active(
+            runner=runner, now_fn=lambda: now, min_active_seconds=300
+        )
+        assert result.ok is False
+        assert result.measurement.get("reason") == "not_yet_aged"
+
     def test_missing_timestamp_fails(self) -> None:
         now = _fixed_now(0)
         runner = _systemctl_runner(
@@ -610,6 +628,19 @@ def _fail_check(name: str) -> CheckResult:
     return CheckResult(name=name, ok=False, detail="bad")
 
 
+def _services_not_yet_aged_check() -> CheckResult:
+    # Mirrors the shape produced by check_agora_services_active when
+    # an agora-* unit is Active but hasn't met the ≥5 min threshold
+    # yet. The aggregator branches on measurement["reason"], so the
+    # rest of the fields are illustrative only.
+    return CheckResult(
+        name="agora_services_active",
+        ok=False,
+        detail="agora-api has been active for 120s, need ≥300s",
+        measurement={"reason": "not_yet_aged", "active_for_seconds": 120.0},
+    )
+
+
 class TestSlotConfirm:
     def test_skipped_when_not_tentative(self) -> None:
         status = slot_confirm(
@@ -678,6 +709,39 @@ class TestSlotConfirm:
         assert status.ok is False
         assert status.next_action == "strike"
         assert sum(1 for c in status.checks if not c.ok) == 2
+
+    def test_not_yet_aged_defers_aggregator(self) -> None:
+        # Bug #209: when the *only* failing check is agora-* services
+        # not having met their ≥5 min Active threshold yet, the gate
+        # must defer (retry) rather than strike. The other 3 checks
+        # all pass so the discriminator is unambiguous.
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=_services_not_yet_aged_check,
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.ok is False
+        assert status.next_action == "deferred"
+        assert status.running_slot == 2
+        assert status.tentative is True
+
+    def test_not_yet_aged_plus_other_failure_strikes(self) -> None:
+        # "Only failure is services-not-yet-aged" is the *only* case
+        # that defers. If anything else is failing alongside it, that
+        # other failure is a real red flag and we strike. Pairs with
+        # ``_only_services_not_yet_aged``'s "every failing check must
+        # match" semantics.
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=_services_not_yet_aged_check,
+            framebuffer_fn=lambda: _fail_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+        )
+        assert status.ok is False
+        assert status.next_action == "strike"
 
     def test_runs_all_4_checks_in_order(self) -> None:
         order: list[str] = []
@@ -840,6 +904,29 @@ class TestCli:
             rc, payload = self._capture(["--auto"])
         assert rc == 0
         assert payload["action_taken"] == "skipped"
+        assert payload["action_error"] == ""
+
+    def test_auto_deferred_exits_75(self) -> None:
+        # Bug #209: ``--auto`` must exit 75 (EX_TEMPFAIL) when the
+        # gate defers, so systemd's ``Restart=on-failure`` retries
+        # the unit rather than treating the deferral as a clean
+        # one-shot success. Neither promote nor strike may be
+        # called: a deferred slot is one we have not yet decided
+        # about, and burning a strike on a transient boot-race
+        # condition is exactly the bug this fix prevents.
+        deferred_status = ConfirmStatus(
+            ok=False, next_action="deferred", running_slot=2, tentative=True
+        )
+        fake_mgr = SimpleNamespace(
+            promote_slot=lambda slot: pytest.fail("noop"),
+            record_tryboot_strike=lambda slot, *, reason: pytest.fail("noop"),
+        )
+        with patch.object(cli, "slot_confirm", return_value=deferred_status), patch.dict(
+            sys.modules, {"slot_mgr": fake_mgr}
+        ):
+            rc, payload = self._capture(["--auto"])
+        assert rc == 75
+        assert payload["action_taken"] == "deferred"
         assert payload["action_error"] == ""
 
     def test_auto_error_exits_2(self) -> None:


### PR DESCRIPTION
# slot_confirm: don't strike a healthy slot at boot+5s for un-aged services

Fixes Bug A of #209 (M7 OTA postmortem).

## Symptom

On boot, `agora-slot-mgr` calls `slot_confirm()`. Today the gate considers
`check_agora_services_active` failed if any of the four agora-* services has
been active for **<5 min**, which is ~always true at boot+5s when the slot
manager actually runs. The aggregator then records a strike and — across 3
boots — pins the slot. The slot itself is fully healthy; we just struck it
because the gate is impatient with itself.

## Root cause

`slot_confirm/core.py` had a binary aggregator: every check either passed
(`promote`) or failed (`strike`). There was no third "healthy-but-not-yet-
provable" state, so a transient `not_yet_aged` measurement was conflated with
permanent failure modes (unit inactive, missing timestamp, negative age).

## Fix shape

Three-state aggregator:

| All checks ok | `promote`   | as before |
| Only failures are services-active w/ `reason="not_yet_aged"` | **`deferred`** (new) | exit `75` (`EX_TEMPFAIL`); slot-mgr retries via `Restart=on-failure` |
| Any other failure (inactive unit, missing ts, negative age, missing partlabel, /data RO, etc.) | `strike`   | as before |
| Not tentative | `skipped`   | as before |

- `check_agora_services_active` now stamps `reason="not_yet_aged"` on the
  measurement dict when the only failing condition is the 5-min minimum age.
  Other failure modes of that check do NOT carry the reason and still strike.
- `_only_services_not_yet_aged()` discriminator: returns `True` only when at
  least one check is failing AND every failing check is `agora_services_active`
  with `reason="not_yet_aged"`.
- `__main__._act()` returns `("deferred", "")`; `main()` maps that to exit `75`.
- `--check` still returns `1` on any gate-fail (deferred or strike); only
  `--auto` distinguishes them via exit codes.

## Why no `.timer` unit

`Restart=on-failure` + bounded `StartLimitBurst=10` already gives us a finite
retry budget without adding a second unit. Math: `RestartSec=45` × `StartLimitBurst=10`
= `450s` = **7.5 min**, which comfortably covers the 5-min aging window. After
the burst limit, systemd self-terminates the unit (no infinite retry loop, no
strike accumulation while we wait).

Exit codes from `--auto`:
- `0`   — success (promoted or skipped)
- `1`   — reserved (`--check` failed; unused by `--auto`)
- `2`   — error (config/runtime)
- `75`  — **deferred** (EX_TEMPFAIL; systemd treats as failure → triggers `Restart=on-failure`)

## Tests

4 new cases in `tests/test_slot_confirm.py`:

- `test_too_young_emits_not_yet_aged_reason` — sentinel on the measurement.
- `test_not_yet_aged_defers_aggregator` — pure not-yet-aged → `deferred`.
- `test_not_yet_aged_plus_other_failure_strikes` — mixed → `strike` (no false
  defer when something else is actually broken).
- `test_auto_deferred_exits_75` — `--auto` end-to-end exit code.

Plus `_services_not_yet_aged_check` helper.

```
$ pytest -p no:timeout tests/test_slot_confirm.py
79 passed in 0.72s
```

Full suite locally hits a pre-existing pytest-asyncio cross-pollination issue
on Python 3.14 (`test_wss_support.py` errors in setup when run after other
async tests — every affected test passes individually); CI uses the locked
Python and will be the real gate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
