### PR TITLE
fix(os_updater): wire promote->migration handshake (#209 Bug B)

### DIFF
--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -51,10 +51,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
 
+from migration_fence import (
+    DEFAULT_SENTINEL_PATH,
+    FenceStatus,
+    check_migration_fence,
+)
 from os_updater.dispatch import (
     DispatchPayload,
     DispatchPayloadError,
@@ -86,6 +92,13 @@ DEFAULT_STAGING_ROOT = Path("/data/.update/staging")
 #: Mirrors the existing cms_client transport behavior.
 _RECONNECT_INITIAL_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
+
+#: Cadence (seconds) for the promote-handshake watcher tick. The watcher
+#: polls ``migration_fence`` while the FSM is in ``tryboot_running`` and
+#: drives the SLOT_CONFIRMED -> PROMOTED -> MIGRATION_COMPLETE chain once
+#: slot-mgr writes the migration-allowed sentinel. See issue
+#: ``sslivins/agora#209`` Bug B and ``files/v0026-ota-postmortem.md``.
+_PROMOTE_HANDSHAKE_TICK_SEC = 30.0
 
 #: Same regex as dispatch._VERSION_RE — kept local to avoid importing a
 #: private symbol. Used by the version-floor check.
@@ -289,6 +302,8 @@ class OSUpdaterService:
         migrator: Optional[Migrator] = None,
         state_path: Path = DEFAULT_STATE_PATH,
         staging_root: Path = DEFAULT_STAGING_ROOT,
+        migration_sentinel_path: Optional[Path] = None,
+        promote_handshake_tick_sec: float = _PROMOTE_HANDSHAKE_TICK_SEC,
     ) -> None:
         self.transport_factory = transport_factory
         self.event_sink: EventSink = event_sink or OutboxEventSink()
@@ -299,6 +314,8 @@ class OSUpdaterService:
         self.migrator: Migrator = migrator or ForwardMigrator()
         self.state_path = state_path
         self.staging_root = staging_root
+        self.migration_sentinel_path = migration_sentinel_path
+        self._promote_handshake_tick_sec = promote_handshake_tick_sec
         self.state: UpdaterState = load_state(self.state_path)
 
     # -- public API used by tests and the run loop --------------------------
@@ -531,6 +548,19 @@ class OSUpdaterService:
             )
             raise UpdaterError(reason) from exc
 
+        staging_dir = self.state.staging_dir
+        if staging_dir:
+            try:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+            except Exception:  # pragma: no cover - defensive
+                log.exception("failed to clean staging dir %s", staging_dir)
+
+        sentinel_path = Path(self.migration_sentinel_path or DEFAULT_SENTINEL_PATH)
+        try:
+            sentinel_path.unlink(missing_ok=True)
+        except Exception:  # pragma: no cover - defensive
+            log.exception("failed to remove migration sentinel %s", sentinel_path)
+
         transition(self.state, UpdaterFSMState.IDLE)
         save_state(self.state, path=self.state_path)
         emit_event(
@@ -540,44 +570,159 @@ class OSUpdaterService:
             state_path=self.state_path,
         )
 
+    async def _tick_promote_handshake(self) -> None:
+        """Check the migration fence and advance the FSM if slot-mgr has promoted.
+
+        Idempotent: a no-op unless ``state.fsm`` is ``TRYBOOT_RUNNING``,
+        ``state.target_version`` is set, the fence reports ``allowed``,
+        and the currently-running version matches the dispatch target.
+
+        Closes the gap between ``slot_mgr.promote_slot()`` (which writes
+        the migration-allowed sentinel) and ``continue_after_promote()``
+        (which drives MIGRATING -> IDLE). See issue ``sslivins/agora#209``
+        Bug B and ``files/v0026-ota-postmortem.md`` option (a).
+        """
+
+        state = self.state
+        if state.fsm is not UpdaterFSMState.TRYBOOT_RUNNING:
+            return
+        if state.target_version is None:
+            log.debug("promote-handshake tick skipped: no target_version on state")
+            return
+
+        try:
+            fence: FenceStatus = check_migration_fence(
+                sentinel_path=self.migration_sentinel_path
+            )
+        except Exception:
+            log.exception("promote-handshake tick: check_migration_fence raised")
+            return
+
+        if not fence.allowed:
+            log.debug(
+                "promote-handshake tick: fence not allowed (%s)", fence.reason
+            )
+            return
+
+        try:
+            current = self.current_version_provider()
+        except Exception:
+            log.exception("promote-handshake tick: current_version_provider raised")
+            return
+
+        if current != state.target_version:
+            log.info(
+                "promote-handshake tick: version mismatch current=%r target=%r; "
+                "treating as stale sentinel and waiting",
+                current,
+                state.target_version,
+            )
+            return
+
+        log.info(
+            "promote-handshake tick: fence allowed and version matches; "
+            "advancing FSM (slot=%s target=%s)",
+            fence.allowed_slot,
+            state.target_version,
+        )
+
+        emit_event(
+            state,
+            LifecycleEventType.SLOT_CONFIRMED,
+            self.event_sink,
+            payload={"slot": fence.allowed_slot},
+            state_path=self.state_path,
+        )
+
+        transition(state, UpdaterFSMState.PROMOTED_PENDING_MIGRATION)
+        save_state(state, path=self.state_path)
+
+        emit_event(
+            state,
+            LifecycleEventType.PROMOTED,
+            self.event_sink,
+            payload={"slot": fence.allowed_slot},
+            state_path=self.state_path,
+        )
+
+        try:
+            await self.continue_after_promote()
+        except UpdaterError:
+            # continue_after_promote already emitted FAILED + logged; the
+            # FSM is now in FAILED so subsequent ticks will no-op.
+            pass
+
+    async def _promote_handshake_loop(self) -> None:
+        """Periodically drive ``_tick_promote_handshake`` until cancelled."""
+
+        while True:
+            try:
+                await self._tick_promote_handshake()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("promote-handshake tick failed; will retry")
+            await asyncio.sleep(self._promote_handshake_tick_sec)
+
     async def run(self) -> None:
         """Main async run loop.
 
         Connects to WPS with exponential backoff (2s -> 60s), receives
-        messages, dispatches them. Returns only on cancellation.
+        messages, dispatches them. Also spawns a background watcher task
+        that periodically polls the migration fence to advance the FSM
+        out of ``tryboot_running`` once slot-mgr has promoted the slot.
+        Returns only on cancellation.
         """
 
         self.recover_on_start()
-        delay = _RECONNECT_INITIAL_DELAY
-        while True:
-            transport = self.transport_factory()
-            try:
-                await transport.connect()
-                log.info("WPS connected; awaiting dispatch messages")
-                delay = _RECONNECT_INITIAL_DELAY
-                while True:
-                    msg = await transport.recv()
-                    msg_type = msg.get("type") if isinstance(msg, dict) else None
-                    if msg_type != "os_update_dispatch":
-                        log.debug("ignoring non-dispatch message type=%r", msg_type)
-                        continue
-                    try:
-                        await self.handle_dispatch(msg)
-                    except UpdaterError:
-                        # Already emitted; loop continues so we can accept
-                        # the next dispatch once we're back to FAILED.
-                        pass
-            except asyncio.CancelledError:
-                await transport.close()
-                raise
-            except Exception:
-                log.exception("WPS loop crashed; reconnecting in %.1fs", delay)
+
+        try:
+            await self._tick_promote_handshake()
+        except Exception:
+            log.exception("startup promote-handshake tick failed; loop will retry")
+
+        handshake_task = asyncio.create_task(
+            self._promote_handshake_loop(),
+            name="os-updater-promote-handshake",
+        )
+
+        try:
+            delay = _RECONNECT_INITIAL_DELAY
+            while True:
+                transport = self.transport_factory()
                 try:
+                    await transport.connect()
+                    log.info("WPS connected; awaiting dispatch messages")
+                    delay = _RECONNECT_INITIAL_DELAY
+                    while True:
+                        msg = await transport.recv()
+                        msg_type = msg.get("type") if isinstance(msg, dict) else None
+                        if msg_type != "os_update_dispatch":
+                            log.debug("ignoring non-dispatch message type=%r", msg_type)
+                            continue
+                        try:
+                            await self.handle_dispatch(msg)
+                        except UpdaterError:
+                            # Already emitted; loop continues so we can accept
+                            # the next dispatch once we're back to FAILED.
+                            pass
+                except asyncio.CancelledError:
                     await transport.close()
-                except Exception:  # pragma: no cover - defensive
-                    pass
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, _RECONNECT_MAX_DELAY)
+                    raise
+                except Exception:
+                    log.exception("WPS loop crashed; reconnecting in %.1fs", delay)
+                    try:
+                        await transport.close()
+                    except Exception:  # pragma: no cover - defensive
+                        pass
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, _RECONNECT_MAX_DELAY)
+        finally:
+            handshake_task.cancel()
+            try:
+                await handshake_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
     # -- internals ----------------------------------------------------------
 

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -128,6 +128,8 @@ def _build_service(
     stager=None,
     migrator=None,
     sink=None,
+    migration_sentinel_path=None,
+    promote_handshake_tick_sec: float = 30.0,
 ):
     """Construct an :class:`OSUpdaterService` for tests with safe defaults."""
 
@@ -143,6 +145,8 @@ def _build_service(
         migrator=migrator or _OkStub(),
         state_path=state_path,
         staging_root=staging_root,
+        migration_sentinel_path=migration_sentinel_path,
+        promote_handshake_tick_sec=promote_handshake_tick_sec,
     )
 
 
@@ -739,3 +743,350 @@ class TestHandleDispatchStageProgress:
             if e.event_type is LifecycleEventType.STAGE_PROGRESS
         ]
         assert progress_events == []
+
+
+# ── promote handshake tick (Bug B fix, issue #209) ─────────────────────────
+
+
+class TestPromoteHandshakeTick:
+    """Acceptance for the periodic promote-handshake watcher.
+
+    Closes the gap between ``slot_mgr.promote_slot()`` (which writes the
+    migration-allowed sentinel) and ``continue_after_promote()`` (which
+    drives MIGRATING -> IDLE). See ``sslivins/agora#209`` Bug B and
+    ``files/v0026-ota-postmortem.md`` option (a).
+    """
+
+    @staticmethod
+    def _patch_fence(monkeypatch, fence_or_factory):
+        """Patch ``check_migration_fence`` on the service module.
+
+        Accepts either a ``FenceStatus`` (returned verbatim on every call)
+        or a zero-arg callable producing one.
+        """
+
+        from migration_fence import FenceStatus
+
+        def _stub(**_kwargs):
+            if callable(fence_or_factory) and not isinstance(
+                fence_or_factory, FenceStatus
+            ):
+                return fence_or_factory()
+            return fence_or_factory
+
+        monkeypatch.setattr(
+            "os_updater.service.check_migration_fence", _stub
+        )
+
+    def test_tick_noop_when_fsm_not_tryboot_running(self, tmp_path, monkeypatch):
+        from migration_fence import FenceStatus
+
+        calls = {"n": 0}
+
+        def _should_not_be_called(**_kwargs):
+            calls["n"] += 1
+            return FenceStatus(
+                allowed=True,
+                reason="ok",
+                allowed_slot=2,
+                running_slot=2,
+                sentinel_present=True,
+            )
+
+        monkeypatch.setattr(
+            "os_updater.service.check_migration_fence", _should_not_be_called
+        )
+
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        # state.fsm defaults to IDLE; no need to force.
+        assert s.state.fsm is UpdaterFSMState.IDLE
+
+        _run(s._tick_promote_handshake())
+
+        assert calls["n"] == 0
+        assert sink.events == []
+        assert s.state.fsm is UpdaterFSMState.IDLE
+
+    def test_tick_noop_when_no_target_version(self, tmp_path, monkeypatch):
+        calls = {"n": 0}
+
+        def _should_not_be_called(**_kwargs):
+            calls["n"] += 1
+            raise AssertionError("fence must not be checked without target_version")
+
+        monkeypatch.setattr(
+            "os_updater.service.check_migration_fence", _should_not_be_called
+        )
+
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        # target_version intentionally left None.
+
+        _run(s._tick_promote_handshake())
+
+        assert calls["n"] == 0
+        assert sink.events == []
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+    def test_tick_noop_when_fence_not_allowed(self, tmp_path, monkeypatch):
+        from migration_fence import FenceStatus
+
+        denied = FenceStatus(
+            allowed=False,
+            reason="sentinel absent",
+            allowed_slot=None,
+            running_slot=1,
+            sentinel_present=False,
+        )
+        self._patch_fence(monkeypatch, denied)
+
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        save_state(s.state, path=s.state_path)
+
+        _run(s._tick_promote_handshake())
+
+        assert sink.events == []
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+    def test_tick_noop_when_version_mismatch(self, tmp_path, monkeypatch):
+        from migration_fence import FenceStatus
+
+        allowed = FenceStatus(
+            allowed=True,
+            reason="ok",
+            allowed_slot=2,
+            running_slot=2,
+            sentinel_present=True,
+        )
+        self._patch_fence(monkeypatch, allowed)
+
+        sink = _ListSink()
+        # current_version_provider returns 0.0.20 but target is 0.0.21
+        s = _build_service(tmp_path, sink=sink, current_version="0.0.20")
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        save_state(s.state, path=s.state_path)
+
+        _run(s._tick_promote_handshake())
+
+        assert sink.events == []
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+    def test_tick_swallows_fence_exception(self, tmp_path, monkeypatch):
+        def _boom(**_kwargs):
+            raise RuntimeError("fence boom")
+
+        monkeypatch.setattr(
+            "os_updater.service.check_migration_fence", _boom
+        )
+
+        sink = _ListSink()
+        s = _build_service(tmp_path, sink=sink)
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        save_state(s.state, path=s.state_path)
+
+        # Must not raise — the tick is a periodic background watcher and
+        # operational issues should not crash the loop.
+        _run(s._tick_promote_handshake())
+
+        assert sink.events == []
+        assert s.state.fsm is UpdaterFSMState.TRYBOOT_RUNNING
+
+    def test_tick_happy_path_drives_full_transition(self, tmp_path, monkeypatch):
+        from migration_fence import FenceStatus
+
+        sentinel_path = tmp_path / "migration-allowed"
+        sentinel_path.write_text("slot=2\n")
+
+        staging_dir = tmp_path / "staging" / "rel_happy_1"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "scratch.txt").write_text("payload")
+
+        allowed = FenceStatus(
+            allowed=True,
+            reason="ok",
+            allowed_slot=2,
+            running_slot=2,
+            sentinel_present=True,
+        )
+        self._patch_fence(monkeypatch, allowed)
+
+        sink = _ListSink()
+        migrator = _RecordingMigrator()
+        s = _build_service(
+            tmp_path,
+            sink=sink,
+            migrator=migrator,
+            current_version="0.0.21",
+            migration_sentinel_path=sentinel_path,
+        )
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        s.state.staging_dir = str(staging_dir)
+        s.state.release_id = "rel_happy_1"
+        save_state(s.state, path=s.state_path)
+
+        _run(s._tick_promote_handshake())
+
+        # FSM walked TRYBOOT_RUNNING -> PROMOTED_PENDING_MIGRATION ->
+        # MIGRATING -> IDLE.
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        assert migrator.calls == 1
+
+        kinds = [e.event_type for e in sink.events]
+        assert LifecycleEventType.SLOT_CONFIRMED in kinds
+        assert LifecycleEventType.PROMOTED in kinds
+        assert LifecycleEventType.MIGRATION_COMPLETE in kinds
+        # Ordering: slot_confirmed -> promoted -> migration_complete.
+        sc_idx = kinds.index(LifecycleEventType.SLOT_CONFIRMED)
+        pr_idx = kinds.index(LifecycleEventType.PROMOTED)
+        mc_idx = kinds.index(LifecycleEventType.MIGRATION_COMPLETE)
+        assert sc_idx < pr_idx < mc_idx
+
+        # Slot payload from fence.allowed_slot.
+        sc_event = sink.events[sc_idx]
+        pr_event = sink.events[pr_idx]
+        assert sc_event.payload.get("slot") == 2
+        assert pr_event.payload.get("slot") == 2
+
+        # Cleanup ran: staging dir removed, sentinel unlinked.
+        assert not staging_dir.exists()
+        assert not sentinel_path.exists()
+
+        # IDLE transition cleared dispatch-specific fields.
+        assert s.state.target_version is None
+        assert s.state.staging_dir is None
+        assert s.state.release_id is None
+
+    def test_tick_cleanup_handles_missing_staging_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """Happy path but ``state.staging_dir`` points at a path that
+        doesn't exist. ``shutil.rmtree(..., ignore_errors=True)`` must
+        swallow the FileNotFoundError so the FSM still completes."""
+        from migration_fence import FenceStatus
+
+        sentinel_path = tmp_path / "migration-allowed"
+        sentinel_path.write_text("slot=2\n")
+
+        allowed = FenceStatus(
+            allowed=True,
+            reason="ok",
+            allowed_slot=2,
+            running_slot=2,
+            sentinel_present=True,
+        )
+        self._patch_fence(monkeypatch, allowed)
+
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            sink=sink,
+            migrator=_RecordingMigrator(),
+            current_version="0.0.21",
+            migration_sentinel_path=sentinel_path,
+        )
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        # Point at a path that was never created.
+        s.state.staging_dir = str(tmp_path / "staging" / "does-not-exist")
+        save_state(s.state, path=s.state_path)
+
+        _run(s._tick_promote_handshake())
+
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        assert not sentinel_path.exists()
+
+    def test_continue_after_promote_cleans_up_staging_dir(self, tmp_path):
+        """Direct invocation: ``continue_after_promote`` from
+        PROMOTED_PENDING_MIGRATION must rmtree ``state.staging_dir`` before
+        the IDLE transition clears the field."""
+        staging_dir = tmp_path / "staging" / "rel_cleanup_1"
+        staging_dir.mkdir(parents=True)
+        (staging_dir / "blob.bin").write_bytes(b"x" * 32)
+
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            sink=sink,
+            migrator=_RecordingMigrator(),
+            migration_sentinel_path=tmp_path / "sentinel-absent",
+        )
+        _force_state(s, UpdaterFSMState.PROMOTED_PENDING_MIGRATION)
+        s.state.staging_dir = str(staging_dir)
+        save_state(s.state, path=s.state_path)
+
+        _run(s.continue_after_promote())
+
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        assert not staging_dir.exists()
+
+    def test_continue_after_promote_unlinks_sentinel(self, tmp_path):
+        """Direct invocation: ``continue_after_promote`` must remove the
+        migration-allowed sentinel before the IDLE transition. Otherwise
+        a stale sentinel would let the next tryboot fence-pass without
+        slot-mgr ever re-confirming."""
+        sentinel_path = tmp_path / "migration-allowed"
+        sentinel_path.write_text("slot=2\n")
+
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            sink=sink,
+            migrator=_RecordingMigrator(),
+            migration_sentinel_path=sentinel_path,
+        )
+        _force_state(s, UpdaterFSMState.PROMOTED_PENDING_MIGRATION)
+
+        _run(s.continue_after_promote())
+
+        assert s.state.fsm is UpdaterFSMState.IDLE
+        assert not sentinel_path.exists()
+
+    def test_promote_handshake_loop_cancellable(self, tmp_path, monkeypatch):
+        """Spawning the loop, awaiting one tick, then cancelling must
+        exit cleanly without raising past the cancellation."""
+        from migration_fence import FenceStatus
+
+        # Fence denied → tick is a fast no-op. Lets us spin the loop a
+        # couple of times without driving any FSM state.
+        denied = FenceStatus(
+            allowed=False,
+            reason="sentinel absent",
+            allowed_slot=None,
+            running_slot=1,
+            sentinel_present=False,
+        )
+        self._patch_fence(monkeypatch, denied)
+
+        sink = _ListSink()
+        s = _build_service(
+            tmp_path,
+            sink=sink,
+            promote_handshake_tick_sec=0.01,
+        )
+        _force_state(s, UpdaterFSMState.TRYBOOT_RUNNING)
+        s.state.target_version = "0.0.21"
+        save_state(s.state, path=s.state_path)
+
+        async def _spin_and_cancel():
+            task = asyncio.create_task(s._promote_handshake_loop())
+            # Give the loop a couple of ticks.
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                return "cancelled"
+            return "exited"
+
+        result = asyncio.run(_spin_and_cancel())
+        assert result == "cancelled"
+        # No spurious lifecycle events from the no-op ticks.
+        assert sink.events == []


### PR DESCRIPTION
Closes #209.

## What

PR2 of 2 for #209. PR1 (#210, commit `b8ddd80`) shipped **Bug A** (`slot_confirm` striking healthy slots when agora-* services were too young to be in `enter_running`). This PR ships **Bug B**: the `os_updater` FSM stalls in `TRYBOOT_RUNNING` forever because the promote→migration handshake was designed but never wired.

## Why

Per the v0.0.26 OTA postmortem (`files/v0026-ota-postmortem.md` option (a), reproduced on Pi100 against goodwill prod CMS on 2026-05-16):

1. Stager triggers tryboot, FSM moves `staged` → `tryboot_pending` → `TRYBOOT_RUNNING`.
2. Slot B comes up healthy. `slot_mgr` writes the `/data/agora/migration-allowed` sentinel (the "fence opens") and rewrites `autoboot.txt` to promote.
3. **Nothing on the os_updater side notices.** The FSM stays in `TRYBOOT_RUNNING`. `continue_after_promote()` exists and is correct, but no code path ever calls it. The CMS UI shows the device on the new `os_version`, but the staging dir + sentinel persist, and a subsequent OTA attempt fails because the cleanup never ran.

## Fix

`OSUpdaterService.run()` now spawns a periodic watcher task (default 30 s, configurable via `promote_handshake_tick_sec` ctor kwarg). Each tick:

1. Reads FSM state. If not `TRYBOOT_RUNNING`, return (no-op).
2. Reads `state.target_version`. If `None`, return.
3. Calls `migration_fence.check_migration_fence(sentinel_path=...)`. Swallows any exception (next tick retries).
4. If `fence.allowed is False`, return.
5. Resolves `current_version_provider()`; if it doesn't match `target_version`, return (waiting on slot-mgr to actually flip).
6. Otherwise, emit `SLOT_CONFIRMED` with `payload.slot = fence.allowed_slot`, transition `TRYBOOT_RUNNING → PROMOTED_PENDING_MIGRATION`, emit `PROMOTED`, then call `continue_after_promote()`.

`continue_after_promote()` already drove `PROMOTED_PENDING_MIGRATION → MIGRATING → IDLE` and emitted `MIGRATION_COMPLETE`. This PR adds two cleanup steps to it, gated on success, **before** the IDLE transition:

- `shutil.rmtree(state.staging_dir, ignore_errors=True)` — wipes `/data/.update/staging/<release_id>`.
- `Path(self.migration_sentinel_path).unlink(missing_ok=True)` — drops the fence sentinel so the next OTA starts clean.

Failures inside the tick (`UpdaterError` from `continue_after_promote`) drop the FSM to `FAILED` via the existing machinery; the watcher then short-circuits on subsequent ticks (`not TRYBOOT_RUNNING`).

## Tests

New `TestPromoteHandshakeTick` class (9 cases), all green:

- `test_tick_noop_when_fsm_not_tryboot_running`
- `test_tick_noop_when_no_target_version`
- `test_tick_noop_when_fence_not_allowed`
- `test_tick_noop_when_version_mismatch`
- `test_tick_swallows_fence_exception`
- `test_tick_happy_path_drives_full_transition` (full FSM walk + staging dir gone + sentinel unlinked + IDLE clears state)
- `test_tick_cleanup_handles_missing_staging_dir`
- `test_continue_after_promote_cleans_up_staging_dir`
- `test_continue_after_promote_unlinks_sentinel`
- `test_promote_handshake_loop_cancellable`

`_build_service` test helper extended to forward `migration_sentinel_path` + `promote_handshake_tick_sec` kwargs.

### Results

- **Targeted: 44/44 green** (35 pre-existing + 9 new) in 1.26 s.
- **Full suite: 1469 passed, 64 pre-existing pytest-asyncio collection errors** (Py3.14 cross-pollution baseline — NOT regressions).

## Validation plan

Once this merges, cut release tags (Bug A only first, then Bug A+B 15 min later per user's request), OTA Pi100 from goodwill prod CMS, watch the FSM walk all the way through `MIGRATION_COMPLETE` with no manual SSH intervention. This is the M7 acceptance criterion that was deferred when the postmortem went up.
