### PR TITLE
fix(postinst): restart agora-slot-mgr and agora-os-updater on upgrade

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -268,4 +268,9 @@ if [ "$1" = "configure" ]; then
     systemctl restart agora-player || true
     systemctl restart agora-api || true
     systemctl restart agora-cms-client || true
+    # OTA / slot services must restart so hotfixes shipped through APT
+    # actually take effect without a full reboot (see issue #212).
+    # slot-mgr first so os-updater can talk to it on reconnect.
+    systemctl restart agora-slot-mgr || true
+    systemctl restart agora-os-updater || true
 fi


### PR DESCRIPTION
Fixes #212

## What

Adds `agora-slot-mgr` and `agora-os-updater` to the postinst's service-restart block, so APT-shipped hotfixes to the OTA path actually take effect without a full reboot.

## Why

The .deb postinst already enables both services at install time (line 258), but the `if [ "" = "configure" ]; then ... systemctl restart ... fi` block at the bottom (lines 264-271) only restarts the five user-facing services. The two OTA-side daemons stay on the previous version's code until the system reboots.

This bit us live on Pi100 during M7 OTA validation:

- Pi100 was running `agora 1.11.64` (had Bug A + Bug B).
- `apt-get install -y agora=1.11.66` succeeded -- `dpkg -l agora` showed 1.11.66 on disk.
- `agora-os-updater.service` was still running PID 1234 from before the upgrade (8h uptime, 1.11.64 code in memory).
- Every OTA dispatch was rejected with `rejecting dispatch ... while in state tryboot_running` because the old code couldn't recover from a stuck state -- exactly what 1.11.66 was supposed to fix.
- Manual `systemctl restart agora-os-updater` immediately did the promote-handshake tick and went IDLE; next dispatch was accepted within seconds.

## Change

Add two lines to `packaging/debian/postinst`:

\\\
systemctl restart agora-slot-mgr || true
systemctl restart agora-os-updater || true
\\\

slot-mgr first so os-updater has a fresh slot-mgr connection when it reconnects to WPS.

## Acceptance

Reproduced via the v1.11.64 -> v1.11.66 pair on Pi100. With this fix, an APT-only hotfix to either service will pick up the new code on the next `apt-get install` without manual intervention.

## Risk

Low. `systemctl restart` of both services is already happening manually in our hotfix runbook; this just automates it. The `|| true` guards a fresh-install scenario where the units may not be active yet.