### PR TITLE
os_updater: emit live download/extract progress (#215)

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -90,6 +90,8 @@ import logging
 import re
 import shutil
 import subprocess
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
@@ -102,6 +104,7 @@ from os_updater.bundle import (
     verify_bundle_manifest,
 )
 from os_updater.dispatch import DispatchPayload
+from os_updater.events import PROGRESS_MIN_INTERVAL_S
 
 
 logger = logging.getLogger(__name__)
@@ -243,6 +246,94 @@ def _safe_emit_progress(
         logger.exception(
             "progress_callback raised on phase=%s; continuing stage", phase
         )
+
+
+#: Soft deadline for the zstd PID to materialize after the pipeline runner
+#: starts. The default subprocess.Popen child shows up in /proc within
+#: microseconds; 5 s is a comfortably large ceiling even on a thrashing Pi.
+#: If the poll never sees a PID by this deadline it just exits quietly —
+#: progress is advisory and we'd rather lose progress than introduce a
+#: spurious timeout.
+_PID_OBSERVER_WAIT_S = 5.0
+
+
+def _read_fdinfo_pos(pid: int) -> Optional[int]:
+    """Return the byte position of ``/proc/<pid>/fdinfo/0`` (zstd's stdin).
+
+    Returns ``None`` if the file is unreadable for any reason (PID gone,
+    not on Linux, malformed contents). The poller treats every ``None``
+    as "stop polling" — there's nothing to recover from at this layer.
+    """
+
+    try:
+        with open(f"/proc/{pid}/fdinfo/0", "rt") as f:
+            for line in f:
+                if line.startswith("pos:"):
+                    try:
+                        return int(line.split(":", 1)[1].strip())
+                    except (ValueError, IndexError):
+                        return None
+        return None
+    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+        return None
+
+
+def _poll_extract_progress(
+    pid_holder: dict[str, Optional[int]],
+    stop_event: threading.Event,
+    compressed_size: int,
+    callback: Callable[[int, int], None],
+    *,
+    interval_s: float = PROGRESS_MIN_INTERVAL_S,
+    pid_wait_deadline_s: float = _PID_OBSERVER_WAIT_S,
+    fdinfo_reader: Callable[[int], Optional[int]] = _read_fdinfo_pos,
+) -> None:
+    """Poll ``/proc/<zstd_pid>/fdinfo/0`` and emit bytes-progress.
+
+    Runs in a worker thread spawned by :func:`stream_extract_subtree`.
+    Reads the ``pos:`` field of zstd's stdin fdinfo (== compressed
+    bytes consumed from the .tar.zst on disk) at most every
+    ``interval_s`` seconds, then calls ``callback(bytes_read,
+    compressed_size)``.
+
+    Exits cleanly when any of these happens, in order of likelihood:
+
+    * ``stop_event`` is set by the caller (pipeline completed).
+    * fdinfo read returns ``None`` (zstd exited; ``/proc/<pid>/...`` gone).
+    * ``pid_holder["pid"]`` is still ``None`` after ``pid_wait_deadline_s``.
+
+    Callback exceptions are caught — progress is advisory, must not
+    take down the extract. Test-only knobs (``interval_s``,
+    ``pid_wait_deadline_s``, ``fdinfo_reader``) are explicit kwargs so
+    unit tests can drive the poller without touching ``/proc``.
+    """
+
+    # Wait for the pipeline runner to capture and publish zstd's PID.
+    wait_deadline = time.monotonic() + pid_wait_deadline_s
+    while pid_holder["pid"] is None:
+        if stop_event.wait(0.05):
+            return
+        if time.monotonic() > wait_deadline:
+            logger.debug(
+                "extract progress poller gave up waiting for zstd PID after %.2fs",
+                pid_wait_deadline_s,
+            )
+            return
+
+    pid = pid_holder["pid"]
+    assert pid is not None  # for type narrowing
+    while not stop_event.is_set():
+        pos = fdinfo_reader(pid)
+        if pos is None:
+            return
+        try:
+            callback(pos, compressed_size)
+        except Exception:  # noqa: BLE001 — advisory; never brick the extract
+            logger.exception(
+                "extract progress callback raised; continuing poll"
+            )
+        if stop_event.wait(interval_s):
+            return
 
 #: Root of the currently-running rootfs from which
 #: :func:`copy_fleet_state` reads per-device identity files. Path is
@@ -653,6 +744,7 @@ def _default_pipeline_runner(
     *,
     tar_stdout_path: Optional[Path] = None,
     timeout_s: float,
+    pid_observer: Optional[Callable[[int], None]] = None,
 ) -> tuple[int, str, int, str]:
     """Run ``zstd_argv | tar_argv`` as a streaming pipeline.
 
@@ -665,6 +757,13 @@ def _default_pipeline_runner(
     If ``tar_stdout_path`` is set, ``tar``'s stdout is redirected to that
     file (used by ``tar -O`` for meta-only extract — the manifest member
     is written to stdout instead of disk).
+
+    If ``pid_observer`` is set, it's invoked exactly once with zstd's
+    PID immediately after :func:`subprocess.Popen` returns. The bytes-
+    progress poller (:func:`_poll_extract_progress`) uses this to look
+    up ``/proc/<pid>/fdinfo/0`` for the compressed-bytes-consumed
+    counter. Observer exceptions are caught so a buggy observer cannot
+    bring down an OTA.
 
     Always returns ``(zstd_rc, zstd_stderr, tar_rc, tar_stderr)`` so the
     caller decides how to classify failure (zstd-side ⇒ corrupted bytes
@@ -685,6 +784,13 @@ def _default_pipeline_runner(
             stderr=subprocess.PIPE,
             text=True,
         )
+        if pid_observer is not None:
+            try:
+                pid_observer(zstd_proc.pid)
+            except Exception:  # noqa: BLE001 — observer is advisory
+                logger.exception(
+                    "pid_observer raised; continuing pipeline"
+                )
         try:
             if tar_stdout_path is not None:
                 stdout_fp = open(tar_stdout_path, "wb")
@@ -755,6 +861,9 @@ def stream_extract_subtree(
     pipeline_runner: Callable[..., tuple[int, str, int, str]] = _default_pipeline_runner,
     zstd_long: int = DEFAULT_ZSTD_LONG,
     timeout_s: float = DEFAULT_STREAM_TIMEOUT_S,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+    compressed_size: Optional[int] = None,
+    poller: Callable[..., None] = _poll_extract_progress,
 ) -> None:
     """Stream-extract ``<subpath>/`` from ``bundle.tar.zst`` directly into ``dst_dir``.
 
@@ -768,6 +877,17 @@ def stream_extract_subtree(
     :class:`BundleIntegrityError` on any zstd or tar failure (corrupted
     bytes, missing binary, timeout). Bundle bytes → unusable, same wire-code
     rationale as for the meta-only extractor.
+
+    When both ``progress_callback`` and ``compressed_size`` are
+    provided, a sidecar thread polls ``/proc/<zstd_pid>/fdinfo/0`` at
+    most every ``PROGRESS_MIN_INTERVAL_S`` seconds and emits
+    ``(bytes_done, compressed_size)`` callbacks throughout the pass.
+    The poller exits as soon as the pipeline returns (success OR
+    failure) so a failed extract never leaks a thread. After a
+    successful return the caller's callback is fired one last time with
+    ``(compressed_size, compressed_size)`` so the badge always reaches
+    100% before the next FSM event clears it. ``poller`` is overridable
+    for tests; default points at :func:`_poll_extract_progress`.
     """
     bundle_path = Path(bundle_path)
     dst_dir = Path(dst_dir)
@@ -800,9 +920,42 @@ def stream_extract_subtree(
         dst_dir,
         zstd_long,
     )
+
+    # Optional bytes-progress polling: only active when the caller wants
+    # progress AND has handed us a non-zero compressed size to anchor
+    # the percentage against. The sidecar thread reads
+    # /proc/<zstd_pid>/fdinfo/0 'pos:' field, so it's a no-op outside
+    # Linux (test fakes that swap pipeline_runner won't see polling).
+    poll_thread: Optional[threading.Thread] = None
+    stop_event: Optional[threading.Event] = None
+    pid_holder: Optional[dict[str, Optional[int]]] = None
+    pipeline_kwargs: dict[str, Any] = {"timeout_s": timeout_s}
+    want_progress = (
+        progress_callback is not None
+        and compressed_size is not None
+        and compressed_size > 0
+    )
+    if want_progress:
+        assert progress_callback is not None  # for type narrowing
+        assert compressed_size is not None
+        stop_event = threading.Event()
+        pid_holder = {"pid": None}
+
+        def _pid_observer(p: int) -> None:
+            pid_holder["pid"] = p  # type: ignore[index]
+
+        pipeline_kwargs["pid_observer"] = _pid_observer
+        poll_thread = threading.Thread(
+            target=poller,
+            args=(pid_holder, stop_event, compressed_size, progress_callback),
+            name=f"extract-progress-{subpath}",
+            daemon=True,
+        )
+        poll_thread.start()
+
     try:
         zstd_rc, zstd_stderr, tar_rc, tar_stderr = pipeline_runner(
-            zstd_argv, tar_argv, timeout_s=timeout_s
+            zstd_argv, tar_argv, **pipeline_kwargs
         )
     except FileNotFoundError as exc:
         # We don't know which binary was missing from the OSError alone;
@@ -815,6 +968,14 @@ def stream_extract_subtree(
             f"stream extract timed out after {timeout_s}s: bundle={bundle_path} "
             f"subpath={subpath}"
         ) from exc
+    finally:
+        # Always tear down the polling thread before returning — a stuck
+        # poller (e.g. PID never showed up, fdinfo unreadable on a
+        # non-Linux test box) would otherwise leak across passes.
+        if stop_event is not None:
+            stop_event.set()
+        if poll_thread is not None:
+            poll_thread.join(timeout=5.0)
 
     if zstd_rc != 0:
         raise BundleIntegrityError(
@@ -825,6 +986,16 @@ def stream_extract_subtree(
             f"tar extract failed (rc={tar_rc}): subpath={subpath} "
             f"stderr={_tail(tar_stderr)!r}"
         )
+
+    # Final 100% emit so the badge always lands at the end of the pass
+    # rather than wherever the last fdinfo poll happened to catch zstd.
+    if want_progress and progress_callback is not None and compressed_size is not None:
+        try:
+            progress_callback(compressed_size, compressed_size)
+        except Exception:  # noqa: BLE001 — advisory
+            logger.exception(
+                "extract progress final-emit raised; ignoring"
+            )
 
 
 def extract_meta_only(
@@ -1332,6 +1503,9 @@ class SlotStager:
         staging_dir: Path,
         *,
         progress_callback: Optional[Callable[[str], None]] = None,
+        extract_progress_callback: Optional[
+            Callable[[str, int, int], None]
+        ] = None,
     ) -> None:
         """Run the full stage-and-tryboot pipeline (10-step streaming orchestration).
 
@@ -1343,12 +1517,22 @@ class SlotStager:
         name from :data:`STAGE_PROGRESS_PHASES` at that phase's
         boundary (before the phase's work begins). Callback exceptions
         are caught and logged — they do not interrupt the stage.
+
+        ``extract_progress_callback``, if provided, is invoked during
+        the two long ``stream_extract_subtree`` passes with
+        ``(phase, bytes_done, compressed_size)`` where ``phase`` is
+        either ``"extracting_boot"`` or ``"extracting_rootfs"``. Rate-
+        limited to ``PROGRESS_MIN_INTERVAL_S`` cadence by the polling
+        thread. Final ``(compressed_size, compressed_size)`` is fired
+        at the end of each pass so the badge always lands at 100%.
+        Callback exceptions are caught and logged.
         """
         await asyncio.to_thread(
             self._stage_sync,
             payload,
             staging_dir,
             progress_callback=progress_callback,
+            extract_progress_callback=extract_progress_callback,
         )
 
     def _stage_sync(
@@ -1357,6 +1541,9 @@ class SlotStager:
         staging_dir: Path,
         *,
         progress_callback: Optional[Callable[[str], None]] = None,
+        extract_progress_callback: Optional[
+            Callable[[str, int, int], None]
+        ] = None,
     ) -> None:
         staging_dir = Path(staging_dir)
         bundle_path = staging_dir / self.bundle_filename
@@ -1478,6 +1665,35 @@ class SlotStager:
         # --strip-components=1 turns "boot/foo" into "<boot_target>/foo" and
         # naturally filters anything not under boot/.
         _safe_emit_progress(progress_callback, "extracting_boot")
+        try:
+            compressed_size = bundle_path.stat().st_size
+        except OSError:
+            # Bundle disappeared between meta-extract and now — let the
+            # real pipeline runner surface the failure; the size lookup
+            # is only used to anchor progress and is purely advisory.
+            compressed_size = 0
+        boot_progress: Optional[Callable[[int, int], None]] = None
+        root_progress: Optional[Callable[[int, int], None]] = None
+        if extract_progress_callback is not None and compressed_size > 0:
+            def _on_boot_bytes(done: int, total: int) -> None:
+                try:
+                    extract_progress_callback("extracting_boot", done, total)
+                except Exception:  # noqa: BLE001 — advisory
+                    logger.exception(
+                        "extract_progress_callback raised; continuing extract"
+                    )
+
+            def _on_root_bytes(done: int, total: int) -> None:
+                try:
+                    extract_progress_callback("extracting_rootfs", done, total)
+                except Exception:  # noqa: BLE001 — advisory
+                    logger.exception(
+                        "extract_progress_callback raised; continuing extract"
+                    )
+
+            boot_progress = _on_boot_bytes
+            root_progress = _on_root_bytes
+
         stream_extract_subtree(
             bundle_path,
             self.boot_subdir,
@@ -1485,6 +1701,8 @@ class SlotStager:
             pipeline_runner=self.pipeline_runner,
             zstd_long=self.zstd_long,
             timeout_s=self.stream_timeout_s,
+            progress_callback=boot_progress,
+            compressed_size=compressed_size if boot_progress else None,
         )
 
         # 7. Stream root/ subtree straight onto the inactive root partition.
@@ -1496,6 +1714,8 @@ class SlotStager:
             pipeline_runner=self.pipeline_runner,
             zstd_long=self.zstd_long,
             timeout_s=self.stream_timeout_s,
+            progress_callback=root_progress,
+            compressed_size=compressed_size if root_progress else None,
         )
 
         # 8. Manifest sha256 verification — hash the bytes that actually

--- a/os_updater/downloader.py
+++ b/os_updater/downloader.py
@@ -29,17 +29,26 @@ Implementation notes (Phase 2):
   the GitHub-release ``browser_download_url`` directly, and GitHub's
   release-asset endpoint is unauthenticated for public repos. If the
   release ever moves to a private bucket, this is the seam to extend.
+* Bytes-progress is reported via an optional ``progress_callback``
+  signature ``(bytes_done: int, bytes_total: int) -> None``.  The
+  downloader calls back at most every ``PROGRESS_MIN_INTERVAL_S``
+  seconds during the streaming GET, plus a final forced call at
+  completion so a stuck callback never lands at 99% in the UI.  The
+  service wraps this into a ``download_progress`` lifecycle event so
+  the CMS progress badge can animate live (agora#215).
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Callable, Optional
 
 from os_updater.bundle import BundleError
 from os_updater.dispatch import DispatchPayload
+from os_updater.events import PROGRESS_MIN_INTERVAL_S, RateLimitedProgress
 from os_updater.verifier import (
     DEFAULT_BUNDLE_FILENAME,
     DEFAULT_SIGNATURE_FILENAME,
@@ -53,6 +62,10 @@ logger = logging.getLogger(__name__)
 #: overhead against memory pressure on the Pi 5 (1 GiB bundle / 64 KiB =
 #: ~16k iterations -- nothing).
 DEFAULT_CHUNK_SIZE = 65536
+
+
+#: Type alias for the bytes-progress callback shape.
+ProgressCallback = Callable[[int, int], None]
 
 
 class BundleDownloadError(BundleError):
@@ -74,11 +87,16 @@ class BundleDownloader:
     * ``bundle_filename`` / ``signature_filename`` -- on-disk filenames
       that the verifier + stager expect.  Default to the canonical values
       from :mod:`os_updater.verifier`.
+    * ``progress_callback`` -- if set, invoked with ``(bytes_done,
+      bytes_total)`` during the bundle download (NOT the much-smaller
+      signature download).  Rate-limited internally via
+      :class:`RateLimitedProgress`; final call is always forced.
     """
 
     chunk_size: int = DEFAULT_CHUNK_SIZE
     bundle_filename: str = DEFAULT_BUNDLE_FILENAME
     signature_filename: str = DEFAULT_SIGNATURE_FILENAME
+    progress_callback: Optional[ProgressCallback] = None
 
     async def run(
         self, payload: DispatchPayload, staging_dir: Path
@@ -103,7 +121,7 @@ class BundleDownloader:
             payload.bundle_url,
             bundle_target,
         )
-        await self._fetch(payload.bundle_url, bundle_target)
+        await self._fetch(payload.bundle_url, bundle_target, with_progress=True)
 
         logger.info(
             "downloading signature: release_id=%s url=%s -> %s",
@@ -111,7 +129,7 @@ class BundleDownloader:
             payload.signature_url,
             sig_target,
         )
-        await self._fetch(payload.signature_url, sig_target)
+        await self._fetch(payload.signature_url, sig_target, with_progress=False)
 
         logger.info(
             "bundle download complete: release_id=%s target_version=%s",
@@ -119,15 +137,25 @@ class BundleDownloader:
             payload.target_version,
         )
 
-    async def _fetch(self, url: str, target: Path) -> None:
+    async def _fetch(
+        self, url: str, target: Path, *, with_progress: bool = False,
+    ) -> None:
         """Stream ``url`` into ``target`` via a ``.tmp`` sibling + rename.
 
         ``aiohttp`` is imported lazily so test runs that patch
         ``sys.modules["aiohttp"]`` see the mock when the production code
         first reaches for it. Same trick the cms_client downloader uses.
+
+        When ``with_progress`` is true and a ``progress_callback`` is
+        configured, fires ``(bytes_done, bytes_total)`` callbacks
+        throughout the streaming GET.
         """
 
         import aiohttp
+
+        rate_limited: Optional[RateLimitedProgress] = None
+        if with_progress and self.progress_callback is not None:
+            rate_limited = RateLimitedProgress(self.progress_callback)
 
         tmp = target.with_suffix(target.suffix + ".tmp")
         try:
@@ -137,13 +165,31 @@ class BundleDownloader:
                         raise BundleDownloadError(
                             f"HTTP {resp.status} fetching {url}"
                         )
+                    # ``Content-Length`` is the only available total here
+                    # because the bundle is served as a single GitHub
+                    # release asset (no chunked-transfer-encoding).
+                    # Missing/garbled header -> emit progress with
+                    # total=0 so the UI falls back to the "Downloading
+                    # bundle" label-only badge.
+                    try:
+                        total = int(resp.headers.get("Content-Length") or 0)
+                    except (TypeError, ValueError):
+                        total = 0
+                    bytes_done = 0
                     with open(tmp, "wb") as f:
                         async for chunk in resp.content.iter_chunked(
                             self.chunk_size
                         ):
                             f.write(chunk)
+                            bytes_done += len(chunk)
+                            if rate_limited is not None:
+                                rate_limited(bytes_done, total)
                         f.flush()
                         os.fsync(f.fileno())
+                    # Final forced emit so the badge always reaches
+                    # 100% before the next FSM event clears it.
+                    if rate_limited is not None:
+                        rate_limited(bytes_done, total or bytes_done, force=True)
             os.replace(tmp, target)
         except BundleDownloadError:
             # Already a typed failure -- still want to drop the tmp so a

--- a/os_updater/events.py
+++ b/os_updater/events.py
@@ -17,19 +17,30 @@ This module ships the scaffold:
   consume.  No WPS send is performed in Phase 2 — that's wired up in
   Phase 4 along with the buffer FIFO eviction policy (1000 events / 10
   MB cap).
+* :class:`WpsEventSink` — live-send sink used in production from
+  agora#215 onward.  Fires events as ``{"type": "lifecycle_event", ...}``
+  over the currently-active WPS transport.  Best-effort: logs and drops
+  on send failure (Phase 4 replayer will eventually take over the
+  durability story).
 * :func:`emit_event` — convenience that stamps the next event-id from a
   passed-in :class:`UpdaterState`, builds the event, persists state, and
   forwards to the sink.
+* :class:`RateLimitedProgress` — helper for any sub-system that wants to
+  emit bytes-progress callbacks without flooding the wire.  Used by the
+  bundle downloader and the streaming-extract polling loop.
 """
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import json
+import logging
+import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterator, Mapping, Optional, Protocol
+from typing import Any, Awaitable, Callable, Iterator, Mapping, Optional, Protocol
 
 from shared.state import atomic_write
 
@@ -41,9 +52,24 @@ from os_updater.state import (
 )
 
 
+logger = logging.getLogger(__name__)
+
 #: Directory where pending lifecycle events buffer when the WPS connection
 #: is down. Lives under ``/data`` so the queue survives reboot.
 DEFAULT_OUTBOX_DIR = Path("/data/agora/event-buffer")
+
+#: Minimum interval between rate-limited progress emissions, per
+#: callback instance.  2 seconds is a conservative trade-off:
+#:
+#: * Worst-case event count for a 10-minute OTA is ~300 — trivial for
+#:   the CMS to ingest.
+#: * Slow enough that the device doesn't backpressure the WPS connection
+#:   under sustained throughput.
+#: * Fast enough that the CMS progress bar feels live (humans can't
+#:   distinguish 2 s updates from continuous on a 30-90 s download).
+#:
+#: Final-state emissions bypass the rate limiter by passing ``force=True``.
+PROGRESS_MIN_INTERVAL_S: float = 2.0
 
 
 class LifecycleEventType(str, enum.Enum):
@@ -55,6 +81,13 @@ class LifecycleEventType(str, enum.Enum):
     """
 
     DOWNLOAD_STARTED = "download_started"
+    #: Bytes-progress milestone emitted from :class:`BundleDownloader`
+    #: while the streaming HTTP GET is in flight.  Carries
+    #: ``payload = {"bytes_done": int, "bytes_total": int}`` so the CMS
+    #: progress badge can render a live percentage.  Emitted at most
+    #: every :data:`PROGRESS_MIN_INTERVAL_S` seconds; the final
+    #: ``(bytes_total, bytes_total)`` call is always forced through.
+    DOWNLOAD_PROGRESS = "download_progress"
     SIGNATURE_VERIFIED = "signature_verified"
     STAGED = "staged"
     #: Sub-phase milestone emitted from within :meth:`SlotStager.stage`
@@ -67,6 +100,15 @@ class LifecycleEventType(str, enum.Enum):
     #: never desynchronizes the CMS-side state machine. Tracked as
     #: ``sslivins/agora#202``.
     STAGE_PROGRESS = "stage_progress"
+    #: Bytes-progress milestone emitted from :func:`stream_extract_subtree`
+    #: while a ``zstd | tar`` pipeline is in flight.  Distinct from
+    #: ``STAGE_PROGRESS`` (which fires at phase BOUNDARIES) — this
+    #: fires DURING the two long extract phases (``extracting_boot``
+    #: and ``extracting_rootfs``) with byte counts polled from
+    #: ``/proc/<zstd_pid>/fdinfo/0``.  Carries
+    #: ``payload = {"phase": "extracting_boot" | "extracting_rootfs",
+    #: "bytes_done": int, "bytes_total": int}``.
+    EXTRACT_PROGRESS = "extract_progress"
     TRYBOOT_INITIATED = "tryboot_initiated"
     SLOT_CONFIRMED = "slot_confirmed"
     PROMOTED = "promoted"
@@ -242,3 +284,132 @@ def emit_event(
     save_state(state, path=state_path or DEFAULT_STATE_PATH)
     sink.put(event)
     return event
+
+
+# A callable that returns the currently-active WPS transport (or ``None``
+# if the device is offline / mid-reconnect).  Used by :class:`WpsEventSink`
+# so the sink doesn't have to know about the service's reconnect lifecycle.
+TransportProvider = Callable[[], Optional[Any]]
+
+
+class WpsEventSink:
+    """Send each lifecycle event live over the active WPS transport.
+
+    The sink is intentionally fire-and-forget:
+
+    * If no transport is currently connected, the event is dropped with a
+      DEBUG log.  (Phase 4 will replace this with a disk-backed replayer
+      that drains on reconnect — out of scope for v1, tracked in
+      ``sslivins/agora#215``.)
+    * If the underlying ``transport.send`` raises, the failure is logged
+      at WARNING but never propagates back to the caller.  Lifecycle
+      events are advisory — a failed send must not abort the OTA FSM.
+
+    The wire shape matches what ``cms.services.device_inbound`` dispatches
+    on:
+
+        {"type": "lifecycle_event",
+         "event_id": <int>, "event_type": <str>,
+         "release_id": <str|None>, "target_version": <str|None>,
+         "occurred_at": <ISO-8601>, "reason": <str|None>,
+         "payload": {...}}
+
+    Construction takes a ``transport_provider`` callable so the sink can
+    be built BEFORE the first connect (it doesn't hold a reference to a
+    transport that might later disconnect — it asks for the current one
+    every time it sends).
+    """
+
+    def __init__(self, transport_provider: TransportProvider) -> None:
+        self._transport_provider = transport_provider
+
+    def put(self, event: LifecycleEvent) -> None:
+        """Fire ``event`` over the active transport, or drop on failure.
+
+        Schedules an async send via :func:`asyncio.get_running_loop`.
+        Must therefore be called from a coroutine context (which all of
+        the FSM's emit sites are).  If no event loop is running, the
+        event is dropped — this is the test-only "called from sync
+        teardown" case where there's no transport anyway.
+        """
+
+        transport = self._transport_provider()
+        if transport is None:
+            logger.debug(
+                "WpsEventSink: no active transport, dropping event_id=%d type=%s",
+                event.event_id, event.event_type.value,
+            )
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug(
+                "WpsEventSink: no running loop, dropping event_id=%d type=%s",
+                event.event_id, event.event_type.value,
+            )
+            return
+        payload = json.dumps(event.to_jsonable())
+        loop.create_task(self._send(transport, payload, event.event_id))
+
+    @staticmethod
+    async def _send(transport: Any, payload: str, event_id: int) -> None:
+        try:
+            await transport.send(payload)
+        except Exception:
+            # Lifecycle events are advisory; a stale transport / network
+            # blip must not abort the OTA FSM.  Log at WARNING so a
+            # systematic failure shows up in ops, but swallow.
+            logger.warning(
+                "WpsEventSink: send failed for event_id=%d", event_id,
+                exc_info=True,
+            )
+
+
+class RateLimitedProgress:
+    """Rate-limited wrapper for a bytes-progress callback.
+
+    Use case: download / extract progress fires hundreds of times per
+    OTA on a fast network.  We don't want to flood the wire with
+    ``download_progress`` events at chunk-level granularity — the CMS
+    badge can't usefully render >1 update per second anyway, and every
+    event costs a WPS round trip.
+
+    Each instance maintains its own ``last-emit`` clock.  The first
+    call always fires (so the badge appears immediately when the OTA
+    starts).  Subsequent calls fire only if at least
+    :data:`PROGRESS_MIN_INTERVAL_S` has elapsed since the last fire,
+    OR the caller passes ``force=True`` (used for the terminal
+    ``(bytes_total, bytes_total)`` call so the bar always reaches 100%
+    before the next FSM event lands).
+
+    Exceptions from the wrapped callback are logged and swallowed —
+    progress is advisory and a buggy callback must not crash the
+    download/extract loop.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[..., None],
+        *,
+        min_interval_s: float = PROGRESS_MIN_INTERVAL_S,
+        time_source: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._callback = callback
+        self._min_interval_s = min_interval_s
+        self._time_source = time_source
+        # None = "never fired", so the first call goes through immediately.
+        self._last_emit: Optional[float] = None
+
+    def __call__(self, *args: Any, force: bool = False, **kwargs: Any) -> None:
+        now = self._time_source()
+        if not force and self._last_emit is not None \
+                and (now - self._last_emit) < self._min_interval_s:
+            return
+        self._last_emit = now
+        try:
+            self._callback(*args, **kwargs)
+        except Exception:
+            logger.warning(
+                "RateLimitedProgress callback raised; continuing",
+                exc_info=True,
+            )

--- a/os_updater/main.py
+++ b/os_updater/main.py
@@ -44,6 +44,7 @@ from typing import Any, Optional, Sequence
 from os_updater import __version__
 from os_updater.apply import SlotStager
 from os_updater.downloader import BundleDownloader
+from os_updater.events import WpsEventSink
 from os_updater.service import (
     DEFAULT_STAGING_ROOT,
     OSUpdaterService,
@@ -340,8 +341,26 @@ async def _run(args: argparse.Namespace) -> int:
     current_version = _read_current_version(args.current_version_file)
     log.info("agora-os-updater starting; current_version=%s", current_version)
 
+    # Forward-reference dance: the WpsEventSink needs a callable that
+    # returns the *currently-live* transport, but the transport itself
+    # only exists per-reconnect inside the service's run loop. The
+    # service exposes ``_active_transport`` (Optional[WPSTransport])
+    # which is set on connect and cleared on disconnect; the
+    # transport_provider lambda below closes over the freshly-built
+    # service instance and reads the attribute lazily on each event
+    # send. agora#215.
+    service: Optional[OSUpdaterService] = None
+
+    def _transport_provider() -> Optional[WPSTransport]:
+        if service is None:  # pragma: no cover — defensive, only window is <100us
+            return None
+        return service._active_transport
+
+    event_sink = WpsEventSink(transport_provider=_transport_provider)
+
     service = OSUpdaterService(
         transport_factory=_build_transport_factory(settings),
+        event_sink=event_sink,
         current_version_provider=lambda: current_version,
         downloader=BundleDownloader(),
         verifier=SignatureVerifier(),

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -186,6 +186,9 @@ class Stager(Protocol):
         staging_dir: Path,
         *,
         progress_callback: Optional[Callable[[str], None]] = None,
+        extract_progress_callback: Optional[
+            Callable[[str, int, int], None]
+        ] = None,
     ) -> None:  # pragma: no cover - protocol
         ...
 
@@ -317,6 +320,16 @@ class OSUpdaterService:
         self.migration_sentinel_path = migration_sentinel_path
         self._promote_handshake_tick_sec = promote_handshake_tick_sec
         self.state: UpdaterState = load_state(self.state_path)
+        # Phase 2 / agora#215: the per-reconnect WPS transport, set by
+        # :meth:`run` after every successful ``transport_factory()`` +
+        # ``connect()``, cleared on any disconnect/exception in the loop.
+        # ``WpsEventSink`` reads this lazily via the
+        # ``transport_provider`` it was constructed with so that
+        # lifecycle events (including the high-rate
+        # ``download_progress`` / ``extract_progress`` events) can be
+        # fire-and-forgot over the live transport without the sink
+        # needing to know about reconnect bookkeeping.
+        self._active_transport: Optional[WPSTransport] = None
 
     # -- public API used by tests and the run loop --------------------------
 
@@ -474,8 +487,38 @@ class OSUpdaterService:
                     state_path=self.state_path,
                 )
 
+            def _on_extract_progress(
+                phase: str, bytes_done: int, bytes_total: int
+            ) -> None:
+                """Wired into :meth:`Stager.stage` so each fdinfo poll
+                of the boot/rootfs extract emits an EXTRACT_PROGRESS
+                lifecycle event with compressed-bytes-consumed
+                (agora#215).
+
+                ``phase`` is one of ``"extracting_boot"`` or
+                ``"extracting_rootfs"`` so the CMS progress bar can
+                weight the two passes correctly. The CMS-side parser
+                clamps the percentage at 100% even when zstd's pos:
+                lands slightly past the file size (zstd reads in
+                window-sized chunks).
+                """
+                emit_event(
+                    self.state,
+                    LifecycleEventType.EXTRACT_PROGRESS,
+                    self.event_sink,
+                    payload={
+                        "phase": phase,
+                        "bytes_done": bytes_done,
+                        "bytes_total": bytes_total,
+                    },
+                    state_path=self.state_path,
+                )
+
             await self.stager.stage(
-                payload, staging_dir, progress_callback=_on_stage_progress
+                payload,
+                staging_dir,
+                progress_callback=_on_stage_progress,
+                extract_progress_callback=_on_extract_progress,
             )
 
             transition(self.state, UpdaterFSMState.TRYBOOT_RUNNING)
@@ -692,6 +735,7 @@ class OSUpdaterService:
                 transport = self.transport_factory()
                 try:
                     await transport.connect()
+                    self._active_transport = transport
                     log.info("WPS connected; awaiting dispatch messages")
                     delay = _RECONNECT_INITIAL_DELAY
                     while True:
@@ -707,9 +751,11 @@ class OSUpdaterService:
                             # the next dispatch once we're back to FAILED.
                             pass
                 except asyncio.CancelledError:
+                    self._active_transport = None
                     await transport.close()
                     raise
                 except Exception:
+                    self._active_transport = None
                     log.exception("WPS loop crashed; reconnecting in %.1fs", delay)
                     try:
                         await transport.close()
@@ -718,6 +764,7 @@ class OSUpdaterService:
                     await asyncio.sleep(delay)
                     delay = min(delay * 2, _RECONNECT_MAX_DELAY)
         finally:
+            self._active_transport = None
             handshake_task.cancel()
             try:
                 await handshake_task

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -155,7 +155,19 @@ class _FakePipelineRunner:
         *,
         tar_stdout_path=None,
         timeout_s,
+        pid_observer=None,
     ):
+        # Honor pid_observer if provided so the extract-progress poller
+        # in stream_extract_subtree sees a PID land in its pid_holder
+        # and exercises its happy path during tests that flip on
+        # progress_callback. Real subprocesses don't exist here, so we
+        # synthesize a PID of 0; tests that drive the poller swap in a
+        # fdinfo_reader fake that ignores the value anyway.
+        if pid_observer is not None:
+            try:
+                pid_observer(0)
+            except Exception:  # noqa: BLE001 — observer is advisory
+                pass
         if self.raise_file_not_found:
             raise FileNotFoundError("zstd")
         if self.raise_timeout:
@@ -1863,3 +1875,254 @@ class TestSlotStagerProgressCallback:
             )
         )
         assert tuple(phases) == STAGE_PROGRESS_PHASES
+
+# --- agora#215: extract progress (fdinfo poller + stream_extract wiring) ----
+
+
+import threading as _threading
+from os_updater.apply import (
+    _poll_extract_progress,
+    _read_fdinfo_pos,
+    stream_extract_subtree,
+)
+
+
+class TestReadFdinfoPos:
+    """The /proc/<pid>/fdinfo/0 reader is the hot inner loop of the
+    extract-progress poller; it must never raise (always return None
+    on any error)."""
+
+    def test_returns_none_on_missing_proc_entry(self):
+        # PID 1 fdinfo/0 exists on linux but is not readable as
+        # a non-root user; on Windows the path doesn't exist. Either
+        # outcome -> None.
+        result = _read_fdinfo_pos(1)
+        assert result is None or isinstance(result, int)
+
+    def test_returns_none_on_garbage_pid(self):
+        assert _read_fdinfo_pos(999_999_999) is None
+
+
+class TestPollExtractProgress:
+    def test_emits_callback_with_fake_fdinfo_reader(self):
+        """Stop event is set after the first emit; poller exits cleanly
+        and the callback receives (bytes_read, compressed_size)."""
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+        reads = iter([100, 200, 300])
+
+        def fake_reader(_pid: int):
+            try:
+                v = next(reads)
+            except StopIteration:
+                return None
+            # Stop after the third emit so the test terminates.
+            if v == 300:
+                stop.set()
+            return v
+
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: calls.append((d, t)),
+            interval_s=0.001,
+            pid_wait_deadline_s=0.5,
+            fdinfo_reader=fake_reader,
+        )
+
+        assert calls == [(100, 1000), (200, 1000), (300, 1000)]
+
+    def test_exits_when_fdinfo_returns_none(self):
+        """zstd exiting mid-poll surfaces as fdinfo None -> poller stops."""
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+        reads = iter([42, None])
+
+        def fake_reader(_pid):
+            return next(reads)
+
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: calls.append((d, t)),
+            interval_s=0.001,
+            pid_wait_deadline_s=0.5,
+            fdinfo_reader=fake_reader,
+        )
+
+        assert calls == [(42, 1000)]
+        # Stop event was NOT set by the test; the poller stopped on
+        # its own when the reader returned None.
+        assert not stop.is_set()
+
+    def test_exits_quickly_when_pid_never_arrives(self):
+        """If the pipeline runner never publishes a PID, poller bails
+        without spinning forever."""
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int | None] = {"pid": None}
+
+        # Fake reader never gets called because PID never arrives.
+        def fake_reader(_pid):  # pragma: no cover
+            raise AssertionError("reader should never be invoked")
+
+        import time as _time
+        t0 = _time.monotonic()
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: calls.append((d, t)),
+            interval_s=0.01,
+            pid_wait_deadline_s=0.1,
+            fdinfo_reader=fake_reader,
+        )
+        elapsed = _time.monotonic() - t0
+        assert calls == []
+        assert elapsed < 1.0
+
+    def test_callback_exception_does_not_break_poll(self):
+        """Buggy callback must not bring down the polling thread."""
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+        reads = iter([10, 20, None])
+
+        def boom(d, t):
+            calls.append((d, t))
+            if d == 10:
+                raise RuntimeError("intentional")
+
+        def fake_reader(_pid):
+            return next(reads)
+
+        # Must not raise.
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=100,
+            callback=boom,
+            interval_s=0.001,
+            pid_wait_deadline_s=0.5,
+            fdinfo_reader=fake_reader,
+        )
+        # Both emits ran (second one despite first one throwing).
+        assert calls == [(10, 100), (20, 100)]
+
+    def test_stop_event_set_before_pid_arrives_returns_immediately(self):
+        """Caller can cancel the poller during the wait-for-PID phase."""
+        stop = _threading.Event()
+        stop.set()
+        pid_holder: dict[str, int | None] = {"pid": None}
+
+        # Reader should never be called.
+        def fake_reader(_pid):  # pragma: no cover
+            raise AssertionError("reader should not run after stop")
+
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: None,
+            interval_s=0.01,
+            pid_wait_deadline_s=5.0,
+            fdinfo_reader=fake_reader,
+        )
+
+
+class TestStreamExtractSubtreeProgressIntegration:
+    """End-to-end glue between stream_extract_subtree, the pipeline
+    runner's pid_observer hook, and the poller thread."""
+
+    def test_progress_callback_receives_final_force_emit(self, tmp_path):
+        """Even if the poller fires zero intermediate callbacks (PID
+        showed up but fdinfo read returned None immediately because
+        the fake pipeline returned instantly), stream_extract_subtree
+        still fires a final (compressed_size, compressed_size) emit."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.write_bytes(b"x" * 500)
+        dst = tmp_path / "boot"
+        calls: list[tuple[int, int]] = []
+
+        observed_pids: list[int] = []
+
+        def fake_pipeline(zstd_argv, tar_argv, *, tar_stdout_path=None, timeout_s, pid_observer=None):
+            if pid_observer is not None:
+                observed_pids.append(99)
+                pid_observer(99)
+            # Return immediately as success.
+            return (0, "", 0, "")
+
+        # Skip the poller (it spins on real /proc which isn't available
+        # on Windows); the final-emit code path is what we're pinning.
+        def no_op_poller(*args, **kwargs):
+            return None
+
+        stream_extract_subtree(
+            bundle,
+            "boot",
+            dst,
+            pipeline_runner=fake_pipeline,
+            progress_callback=lambda d, t: calls.append((d, t)),
+            compressed_size=500,
+            poller=no_op_poller,
+        )
+
+        # pid_observer fired once.
+        assert observed_pids == [99]
+        # Final 100% emit fired.
+        assert calls[-1] == (500, 500)
+
+    def test_no_progress_when_callback_omitted(self, tmp_path):
+        """Backwards-compat: no callback -> no pid_observer wired
+        through to the pipeline runner (the size-zero case)."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.write_bytes(b"x" * 50)
+        dst = tmp_path / "boot"
+
+        observed_pids: list[int] = []
+
+        def fake_pipeline(zstd_argv, tar_argv, *, tar_stdout_path=None, timeout_s, pid_observer=None):
+            if pid_observer is not None:
+                observed_pids.append(0)
+            return (0, "", 0, "")
+
+        stream_extract_subtree(
+            bundle,
+            "boot",
+            dst,
+            pipeline_runner=fake_pipeline,
+            # No progress_callback, no compressed_size.
+        )
+        assert observed_pids == []
+
+    def test_zero_compressed_size_disables_progress(self, tmp_path):
+        """compressed_size=0 also disables progress (defensive against
+        a stale-stat race producing zero)."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.write_bytes(b"x" * 50)
+        dst = tmp_path / "boot"
+        calls: list[tuple[int, int]] = []
+
+        observed_pids: list[int] = []
+
+        def fake_pipeline(zstd_argv, tar_argv, *, tar_stdout_path=None, timeout_s, pid_observer=None):
+            if pid_observer is not None:
+                observed_pids.append(0)
+            return (0, "", 0, "")
+
+        stream_extract_subtree(
+            bundle,
+            "boot",
+            dst,
+            pipeline_runner=fake_pipeline,
+            progress_callback=lambda d, t: calls.append((d, t)),
+            compressed_size=0,
+        )
+
+        assert observed_pids == []
+        assert calls == []

--- a/tests/test_os_updater_downloader.py
+++ b/tests/test_os_updater_downloader.py
@@ -327,3 +327,128 @@ class TestBundleDownloaderFailures:
         assert isinstance(exc_info.value.__cause__, OSError)
         if staging.exists():
             assert not any(p.name.endswith(".tmp") for p in staging.iterdir())
+
+# --- agora#215: progress callback ------------------------------------------
+
+
+class _RecordingProgress:
+    """Records each (bytes_done, bytes_total) pair handed in."""
+
+    def __init__(self):
+        self.calls: list[tuple[int, int]] = []
+
+    def __call__(self, done: int, total: int) -> None:
+        self.calls.append((done, total))
+
+
+class TestBundleDownloaderProgress:
+    def test_progress_callback_fires_during_bundle_fetch(self, tmp_path):
+        """Two chunks of 5 bytes each -> first call always fires;
+        subsequent intermediate calls are rate-limited (so we may see
+        only the first + the final forced 10/10)."""
+        staging = tmp_path / "stage"
+        recorder = _RecordingProgress()
+        downloader = BundleDownloader(progress_callback=recorder)
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"xxxxx", b"yyyyy"]),  # bundle: 10 bytes
+            _AsyncIterChunks([b"sig-bytes"]),         # signature
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {"Content-Length": "10"}
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(_payload(), staging))
+
+        # First chunk fires (RateLimitedProgress first-call rule), final
+        # 10/10 force-emit always fires. Middle chunks may rate-limit.
+        assert recorder.calls, "progress callback should have fired at least once"
+        # Final emit must be the 10/10 force.
+        assert recorder.calls[-1] == (10, 10)
+        # No emit should report bytes_done > bytes_total.
+        for done, total in recorder.calls:
+            assert done <= total
+
+    def test_progress_callback_not_called_for_signature_fetch(self, tmp_path):
+        """Signature is tiny + advisory; we deliberately don't emit
+        progress events for it (would just flood the wire with one
+        100% pulse per OTA)."""
+        staging = tmp_path / "stage"
+        recorder = _RecordingProgress()
+        downloader = BundleDownloader(progress_callback=recorder)
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"b"]),    # bundle: 1 byte
+            _AsyncIterChunks([b"sig"]),  # signature: 3 bytes
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {"Content-Length": "1"}
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(_payload(), staging))
+
+        # Every recorded call must have total<=1 (bundle's Content-Length).
+        # Any call with total>1 would mean we counted signature bytes too.
+        assert recorder.calls, "expected at least one progress emit"
+        for done, total in recorder.calls:
+            assert total <= 1, f"unexpected progress total={total} (signature leak?)"
+
+    def test_progress_with_no_content_length_emits_total_zero(self, tmp_path):
+        """Some servers omit Content-Length on chunked responses. The
+        downloader should still emit progress with total=0 so the CMS
+        side can show an indeterminate badge instead of crashing."""
+        staging = tmp_path / "stage"
+        recorder = _RecordingProgress()
+        downloader = BundleDownloader(progress_callback=recorder)
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"abc"]),
+            _AsyncIterChunks([b"sig"]),
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {}  # No Content-Length.
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(_payload(), staging))
+
+        # At least the first call fires; final emit force-fires too.
+        assert recorder.calls
+        # Final emit reports done=total=actual-bytes (3) since
+        # Content-Length was 0 -> we use bytes_done as the floor.
+        done, total = recorder.calls[-1]
+        assert done == 3
+        assert total == 3
+
+    def test_no_progress_callback_works_normally(self, tmp_path):
+        """Backwards-compat: omitting the callback must not change behavior."""
+        staging = tmp_path / "stage"
+        downloader = BundleDownloader()
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"bundle"]),
+            _AsyncIterChunks([b"sig"]),
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {"Content-Length": "6"}
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(_payload(), staging))
+
+        assert (staging / DEFAULT_BUNDLE_FILENAME).read_bytes() == b"bundle"
+        assert (staging / DEFAULT_SIGNATURE_FILENAME).read_bytes() == b"sig"

--- a/tests/test_os_updater_events.py
+++ b/tests/test_os_updater_events.py
@@ -8,17 +8,31 @@ Acceptance hooks (plan §"Phase 2 — Deliverables" + plan #33):
 * ``iter_events`` round-trips events that were written.
 * Malformed lines are skipped, not raised on.
 * ``emit_event`` stamps release_id / target_version from state.
+
+Plus agora#215 additions (download/extract progress, live WPS sink):
+
+* :class:`WpsEventSink` drops when no transport, swallows send errors.
+* :class:`RateLimitedProgress` first-call fires, rate-limits, force bypass.
+* :class:`LifecycleEventType.DOWNLOAD_PROGRESS` / ``EXTRACT_PROGRESS``
+  wire values are stable.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from os_updater.events import (
+    PROGRESS_MIN_INTERVAL_S,
     LifecycleEvent,
     LifecycleEventType,
     OutboxEventSink,
+    RateLimitedProgress,
+    WpsEventSink,
     emit_event,
     next_event_id,
 )
@@ -304,3 +318,193 @@ class TestStageProgressEnum:
         assert event.event_type is LifecycleEventType.STAGE_PROGRESS
         assert event.payload == {"phase": "extracting_rootfs"}
         assert sink.events == [event]
+
+
+# --- agora#215: progress events + WPS live sink -----------------------------
+
+
+class TestProgressEnumValues:
+    """Wire-format pinning for the two new progress event types
+    (agora#215). The CMS-side parser in ``cms/services/device_inbound.py``
+    switches on these string values; any rename here is a coordinated
+    schema migration."""
+
+    def test_download_progress_value(self):
+        assert LifecycleEventType.DOWNLOAD_PROGRESS.value == "download_progress"
+
+    def test_extract_progress_value(self):
+        assert LifecycleEventType.EXTRACT_PROGRESS.value == "extract_progress"
+
+    def test_progress_min_interval_is_2_seconds(self):
+        # Test pins the default cadence the CMS UX was designed against.
+        assert PROGRESS_MIN_INTERVAL_S == 2.0
+
+
+class _FakeClock:
+    """Manually advanceable monotonic-time source for RateLimitedProgress."""
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+class TestRateLimitedProgress:
+    def test_first_call_always_fires(self):
+        calls: list[tuple] = []
+        rl = RateLimitedProgress(lambda *a: calls.append(a), time_source=_FakeClock())
+        rl(10, 100)
+        assert calls == [(10, 100)]
+
+    def test_second_call_within_interval_drops(self):
+        calls: list[tuple] = []
+        clock = _FakeClock()
+        rl = RateLimitedProgress(lambda *a: calls.append(a), time_source=clock)
+        rl(10, 100)
+        clock.advance(0.5)
+        rl(20, 100)
+        assert calls == [(10, 100)]
+
+    def test_call_after_interval_fires(self):
+        calls: list[tuple] = []
+        clock = _FakeClock()
+        rl = RateLimitedProgress(lambda *a: calls.append(a), time_source=clock)
+        rl(10, 100)
+        clock.advance(PROGRESS_MIN_INTERVAL_S + 0.01)
+        rl(20, 100)
+        assert calls == [(10, 100), (20, 100)]
+
+    def test_force_bypasses_rate_limit(self):
+        calls: list[tuple] = []
+        clock = _FakeClock()
+        rl = RateLimitedProgress(lambda *a: calls.append(a), time_source=clock)
+        rl(10, 100)
+        clock.advance(0.1)
+        rl(100, 100, force=True)
+        assert calls == [(10, 100), (100, 100)]
+
+    def test_force_resets_clock_for_subsequent_calls(self):
+        """After a force call, the rate-limit window restarts from that
+        emit so the next non-force still has to wait PROGRESS_MIN_INTERVAL_S."""
+        calls: list[tuple] = []
+        clock = _FakeClock()
+        rl = RateLimitedProgress(lambda *a: calls.append(a), time_source=clock)
+        rl(50, 100, force=True)
+        clock.advance(0.1)
+        rl(60, 100)
+        assert calls == [(50, 100)]
+
+    def test_callback_exception_is_swallowed(self):
+        def boom(*a, **kw):
+            raise RuntimeError("intentional")
+
+        rl = RateLimitedProgress(boom, time_source=_FakeClock())
+        rl(10, 100)  # must not raise
+
+
+class _FakeTransport:
+    """Captures every payload sent over the transport."""
+
+    def __init__(self, raise_on_send: bool = False) -> None:
+        self.sent: list[str] = []
+        self.raise_on_send = raise_on_send
+
+    async def send(self, payload: str) -> None:
+        if self.raise_on_send:
+            raise RuntimeError("transport-dead")
+        self.sent.append(payload)
+
+
+def _drain_pending(loop: asyncio.AbstractEventLoop) -> None:
+    """Run the loop briefly so any pending ``create_task`` calls complete."""
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.run_until_complete(asyncio.sleep(0))
+
+
+def _make_event(event_id: int = 1, event_type=LifecycleEventType.DOWNLOAD_PROGRESS) -> LifecycleEvent:
+    return LifecycleEvent(
+        event_id=event_id,
+        event_type=event_type,
+        release_id="rel-1",
+        target_version="1.0.0",
+        occurred_at="2026-05-07T03:30:00Z",
+        payload={"bytes_done": 10, "bytes_total": 100},
+    )
+
+
+class TestWpsEventSink:
+    def test_drops_when_no_transport(self):
+        sink = WpsEventSink(transport_provider=lambda: None)
+        # Should NOT raise even though there is no loop and no transport.
+        sink.put(_make_event())
+
+    def test_drops_when_no_running_loop(self):
+        # Transport is present but no loop is running — must not raise.
+        sink = WpsEventSink(transport_provider=lambda: _FakeTransport())
+        sink.put(_make_event())
+
+    def test_fires_send_on_active_transport(self):
+        transport = _FakeTransport()
+        sink = WpsEventSink(transport_provider=lambda: transport)
+
+        async def go():
+            sink.put(_make_event())
+            # Yield so the create_task'd send actually runs.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(go())
+
+        assert len(transport.sent) == 1
+        decoded = json.loads(transport.sent[0])
+        assert decoded["type"] == "lifecycle_event"
+        assert decoded["event_type"] == "download_progress"
+        assert decoded["event_id"] == 1
+        assert decoded["release_id"] == "rel-1"
+        assert decoded["payload"] == {"bytes_done": 10, "bytes_total": 100}
+
+    def test_swallows_send_exception(self):
+        transport = _FakeTransport(raise_on_send=True)
+        sink = WpsEventSink(transport_provider=lambda: transport)
+
+        async def go():
+            sink.put(_make_event())
+            # Two yields so the failing send task actually runs through
+            # its except branch.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        # Must not propagate — lifecycle events are advisory.
+        asyncio.run(go())
+
+    def test_reads_transport_lazily_each_put(self):
+        """The sink must re-query the provider on every put so a
+        post-reconnect transport replacement Just Works."""
+        # State: current transport, mutated between puts to simulate
+        # a reconnect cycle (first put sees None -> drops; second put
+        # sees a live transport -> sends).
+        current: dict[str, Any] = {"t": None}
+
+        def provider():
+            return current["t"]
+
+        sink = WpsEventSink(transport_provider=provider)
+
+        async def go():
+            sink.put(_make_event(1))
+            await asyncio.sleep(0)
+            current["t"] = _FakeTransport()
+            sink.put(_make_event(2))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(go())
+
+        transport = current["t"]
+        assert len(transport.sent) == 1
+        decoded = json.loads(transport.sent[0])
+        assert decoded["event_id"] == 2

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -658,12 +658,25 @@ class _ProgressEmittingStager:
         self.phase = phase
         self.calls: list[tuple] = []
         self.captured_callback = None
+        self.captured_extract_callback = None
 
-    async def stage(self, payload, staging_dir, *, progress_callback=None):
+    async def stage(
+        self,
+        payload,
+        staging_dir,
+        *,
+        progress_callback=None,
+        extract_progress_callback=None,
+    ):
         self.calls.append(("stage", payload, staging_dir))
         self.captured_callback = progress_callback
+        self.captured_extract_callback = extract_progress_callback
         if progress_callback is not None:
             progress_callback(self.phase)
+        if extract_progress_callback is not None:
+            # Simulate one mid-pass byte-progress emit so the service-
+            # side closure has something to forward to the outbox.
+            extract_progress_callback("extracting_rootfs", 500_000, 1_000_000)
 
 
 class TestHandleDispatchStageProgress:
@@ -1090,3 +1103,60 @@ class TestPromoteHandshakeTick:
         assert result == "cancelled"
         # No spurious lifecycle events from the no-op ticks.
         assert sink.events == []
+
+
+# -- handle_dispatch wires EXTRACT_PROGRESS (agora#215) -------------------------
+
+
+class TestHandleDispatchExtractProgress:
+    """The service-side ``_on_extract_progress`` closure forwards each
+    byte-progress emit from the stager into an EXTRACT_PROGRESS
+    lifecycle event on the outbox (agora#215)."""
+
+    def test_stager_extract_callback_emits_extract_progress_event(self, tmp_path):
+        sink = _ListSink()
+        stager = _ProgressEmittingStager(phase="extracting_rootfs")
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            stager=stager,
+        )
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-extract")))
+
+        # Service handed the stager a non-None extract callback.
+        assert stager.captured_extract_callback is not None
+
+        extract_events = [
+            e for e in sink.events
+            if e.event_type is LifecycleEventType.EXTRACT_PROGRESS
+        ]
+        assert len(extract_events) == 1
+        assert extract_events[0].payload == {
+            "phase": "extracting_rootfs",
+            "bytes_done": 500_000,
+            "bytes_total": 1_000_000,
+        }
+        assert extract_events[0].release_id == "rel-extract"
+        assert extract_events[0].target_version == "1.1.0"
+
+    def test_extract_progress_lands_between_staged_and_tryboot_initiated(self, tmp_path):
+        """Like STAGE_PROGRESS, EXTRACT_PROGRESS is mid-stage and must
+        sit between STAGED and TRYBOOT_INITIATED so CMS rollups are
+        sane."""
+        sink = _ListSink()
+        stager = _ProgressEmittingStager(phase="extracting_rootfs")
+        s = _build_service(tmp_path, current_version="1.0.0", sink=sink, stager=stager)
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-extract-ord")))
+
+        kinds = [e.event_type for e in sink.events]
+        assert LifecycleEventType.EXTRACT_PROGRESS in kinds
+        ext_idx = kinds.index(LifecycleEventType.EXTRACT_PROGRESS)
+        staged_idx = kinds.index(LifecycleEventType.STAGED)
+        tryboot_idx = kinds.index(LifecycleEventType.TRYBOOT_INITIATED)
+        assert staged_idx < ext_idx < tryboot_idx
+
+        ids = [e.event_id for e in sink.events]
+        assert ids == sorted(ids)


### PR DESCRIPTION
Emit live OTA download + extract byte-progress so CMS can render a real
progress bar in place of the static "Upgrading…" badge. CMS-side
consumer shipped in [agora-cms#575](https://github.com/sslivins/agora-cms/pull/575).

## Wire shape

Two new lifecycle event types over the existing WPS lifecycle-event
channel:

```
{"type":"lifecycle_event","event_id":int,"event_type":"download_progress",
 "release_id":str|None,"target_version":str|None,"occurred_at":ISO-8601,
 "reason":null,"payload":{"bytes_done":int,"bytes_total":int}}
```

```
{"type":"lifecycle_event", ... "event_type":"extract_progress",
 "payload":{"phase":"extracting_boot"|"extracting_rootfs",
            "bytes_done":int,"bytes_total":int}}
```

Both rate-limited to one emit per `PROGRESS_MIN_INTERVAL_S` (2.0s) per
`RateLimitedProgress`. Each phase force-emits a final 100% so the
badge always lands on the full bar.

## What's wired

- `BundleDownloader._fetch`: reads `Content-Length`, calls
  `progress_callback(bytes_done, bytes_total)` from the chunk loop;
  signature fetch never wires a progress callback.
- `stream_extract_subtree`: spawns a daemon thread on `Popen` of the
  zstd|tar pipeline that polls `/proc/<zstd_pid>/fdinfo/0` `pos:` (=
  compressed bytes consumed). `compressed_size = bundle_path.stat().st_size`.
  PID is published from the pipeline runner via a `pid_observer` kwarg.
- `SlotStager.stage` accepts `extract_progress_callback(phase, bytes_done, bytes_total)`
  and wires two per-phase closures (boot, rootfs).
- `OSUpdaterService` tracks `_active_transport` across WPS reconnects;
  new `_on_extract_progress` closure emits `EXTRACT_PROGRESS` events to
  the outbox.
- `WpsEventSink` takes a `transport_provider` callable so reconnect-new
  sockets are honored without sink reconstruction.

## Test coverage

- `tests/test_os_updater_events.py` — +14 tests: enum wire values,
  `RateLimitedProgress` (first/rate-limit/force/exception swallow),
  `WpsEventSink` (no-transport, no-loop, happy path, send exception,
  lazy provider re-query).
- `tests/test_os_updater_downloader.py` — +4 tests: progress callback
  fires during bundle fetch, no progress on signature fetch, no
  Content-Length fallback, backwards-compat without callback.
- `tests/test_os_updater_apply.py` — +10 tests: `_read_fdinfo_pos` no-throw
  semantics, `_poll_extract_progress` (happy, fdinfo returns None,
  PID never arrives, callback exception swallowed, stop before pid),
  `stream_extract_subtree` end-to-end (final force emit, no-callback
  no-pid-observer, compressed_size=0 disables).
- `tests/test_os_updater_service.py` — +2 tests: stager-extract callback
  emits `EXTRACT_PROGRESS`, ordering between `STAGED` and
  `TRYBOOT_INITIATED`.

`367 passed, 1 skipped` across `tests/test_os_updater_*.py`.

## Risks

- `/proc/<pid>/fdinfo` is Linux-only; on Windows / non-Linux the
  reader returns `None` and the poller exits cleanly — defended in
  `test_read_fdinfo_pos`.
- Poller thread is daemonized and always joined under `finally` with
  a 5s timeout, so a stuck poller can't leak across passes.
- `WpsEventSink.put` is sync but schedules via `asyncio.get_running_loop()`;
  drops if no loop (test-teardown safe).
