### PR TITLE
os_updater: add send() to _CMSWPSTransportAdapter (agora#216 follow-up)

### DIFF
--- a/os_updater/main.py
+++ b/os_updater/main.py
@@ -190,6 +190,19 @@ class _CMSWPSTransportAdapter:
             )
         return obj
 
+    async def send(self, data) -> None:
+        """Forward outbound payloads to the underlying cms_client transport.
+
+        Used by :class:`os_updater.events.WpsEventSink` to emit lifecycle
+        events back to the CMS over the same websocket the service uses
+        to receive dispatch messages.  Delegates to ``self._t.send`` which
+        is the live :class:`cms_client.transport._Transport` (Direct or
+        WPS-enveloped). agora#216.
+        """
+        if self._t is None:
+            raise RuntimeError("transport.send() called before connect()")
+        await self._t.send(data)
+
     async def close(self) -> None:
         if self._t is not None:
             try:

--- a/tests/test_os_updater_main.py
+++ b/tests/test_os_updater_main.py
@@ -20,7 +20,7 @@ import types
 
 import pytest
 
-from os_updater.main import _read_current_version, _build_transport_factory
+from os_updater.main import _read_current_version, _build_transport_factory, _CMSWPSTransportAdapter
 
 
 def _write(tmp_path, content: str):
@@ -267,6 +267,36 @@ class TestBuildTransportFactory:
         setattr(settings, missing_field, "")
         with pytest.raises(RuntimeError, match=expected_msg):
             _build_transport_factory(settings)
+
+
+class TestCMSWPSTransportAdapterSend:
+    """Pins that the adapter exposes ``send()`` for outbound traffic.
+
+    The pre-agora#216 bug was that the adapter only implemented
+    ``connect()``/``recv()``/``close()`` (what ``OSUpdaterService``
+    consumes), but :class:`os_updater.events.WpsEventSink` also needs
+    to push lifecycle events back to the CMS over the same transport.
+    The missing ``send()`` made every progress event log
+    ``AttributeError: '_CMSWPSTransportAdapter' object has no attribute 'send'``
+    and silently dropped the entire OTA-progress badge feed.
+    """
+
+    def test_send_delegates_to_underlying_transport(self):
+        sent: list = []
+
+        class _FakeInner:
+            async def send(self, data):
+                sent.append(data)
+
+        adapter = _CMSWPSTransportAdapter(lambda: None)
+        adapter._t = _FakeInner()  # bypass connect()
+        asyncio.run(adapter.send('{"hello":"world"}'))
+        assert sent == ['{"hello":"world"}']
+
+    def test_send_before_connect_raises(self):
+        adapter = _CMSWPSTransportAdapter(lambda: None)
+        with pytest.raises(RuntimeError, match="before connect"):
+            asyncio.run(adapter.send("anything"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up fix to agora#216.

## What

The new `WpsEventSink` calls `transport.send(payload)` to push lifecycle events (`download_progress` / `extract_progress` etc.) back to the CMS over the same websocket the service uses for inbound dispatch frames.

But `_CMSWPSTransportAdapter` in `os_updater/main.py` only proxied `connect` / `recv` / `close`. Every emit died with:

\\\
AttributeError: '_CMSWPSTransportAdapter' object has no attribute 'send'
\\\

Because event-sink errors are intentionally caught + logged at WARNING (events are advisory), the OTA itself still succeeded — but the entire OTA-progress-badge feed was silently dropped end-to-end. Validated in production on the v0.0.30-test and v0.0.31-test cycles on Pi100: \ota_phase\ / \ota_pct\ stayed \
ull\ for the whole upgrade window, journal full of the AttributeError.

## Fix

Forward `send()` to `self._t.send()`, which is the live `cms_client.transport` (DirectTransport or WPSTransport) — both already implement `async def send(data)`.

## Tests

Adds `TestCMSWPSTransportAdapterSend` (2 cases) covering the delegation and the before-connect error path. Full os_updater suite: 228 pass.

## Next

Once this lands and is baked into the next agora-os tag, redo the Pi100 v0.0.31→v0.0.32 OTA validation and confirm the badge animates through both phases.