### PR TITLE
ci: remove GITHUB_TOKEN fallback on VERSION_BUMP_TOKEN

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -208,16 +208,14 @@ jobs:
           # this to a normal release at the very end (publish-catalog
           # job's "Promote release" step).
           prerelease: true
-          # Use a PAT (VERSION_BUMP_TOKEN) so the `release` event fires
-          # downstream workflows. Releases created with the default
+          # Use the shared VERSION_BUMP_TOKEN PAT so the `release` event
+          # fires downstream workflows. Releases created with the default
           # GITHUB_TOKEN do NOT trigger `release: types: [prereleased]`
           # listeners (GitHub blocks workflow recursion), which would
-          # break the chain into build-image.yml and prevent
-          # catalog.json / Pi images from being published. Falls back
-          # to GITHUB_TOKEN if the PAT is not configured (chain will
-          # not auto-trigger; build-image must then be dispatched
-          # manually).
-          token: ${{ secrets.VERSION_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          # break the chain into build-image.yml and prevent catalog.json
+          # / Pi images from being published. No fallback: fail loudly if
+          # the secret is missing rather than silently breaking the chain.
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
   publish-apt:
     needs: build
@@ -288,12 +286,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-          # GITHUB_TOKEN works if main is unprotected, or if
-          # github-actions[bot] is on the branch-protection bypass list.
-          # If main is PR-protected and the bot can't bypass, the repo
-          # secret VERSION_BUMP_TOKEN (a fine-grained PAT with contents:
-          # write on this repo) is used instead.
-          token: ${{ secrets.VERSION_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          # Push the version bump via the shared VERSION_BUMP_TOKEN PAT
+          # (fine-grained, contents:write). No GITHUB_TOKEN fallback:
+          # fail loudly if the secret is missing rather than silently
+          # downgrading to github-actions[bot] and hiding the misconfig.
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
       - name: Bump patch version and push
         run: |


### PR DESCRIPTION
We now share a single fine-grained PAT (`VERSION_BUMP_TOKEN`) across all of our publishing repos (`agora`, `agora-cms`, `agora-os`, `pygemstone`, `pynapoleon`, `pyomnisense`, `pysensorlinx`).

The previous `|| secrets.GITHUB_TOKEN` fallback turned out to be hiding a year-long misconfiguration on `agora-cms`: the secret value was set but the actual auth was silently coming from `github-actions[bot]` via the fallback. The PAT showed `Never used` while we assumed it was working.

Removing the fallback so any future misconfig (missing secret, wrong value, expired PAT, repo not in the PAT's allow-list) fails loudly at the next release instead of being masked. `bump-main` is a non-critical post-publish step; failing it does not break the release itself, just stops the patch bump until the secret is fixed.