### PR TITLE
os_updater: deliver download/extract progress lifecycle events (agora#219)

### DIFF
--- a/os_updater/downloader.py
+++ b/os_updater/downloader.py
@@ -99,7 +99,11 @@ class BundleDownloader:
     progress_callback: Optional[ProgressCallback] = None
 
     async def run(
-        self, payload: DispatchPayload, staging_dir: Path
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[ProgressCallback] = None,
     ) -> None:
         """Download the bundle + signature into ``staging_dir``.
 
@@ -107,12 +111,23 @@ class BundleDownloader:
         responsible for cleaning up partial state from a prior aborted
         attempt before invoking us. We just create the dir if missing and
         write the two artifacts.
+
+        ``progress_callback`` (added in agora#219) overrides the
+        dataclass field of the same name for this invocation.  This is
+        the seam the service uses to bind a per-dispatch callback
+        without mutating shared downloader state.  If both are unset,
+        download progress is not reported.
         """
 
         staging_dir.mkdir(parents=True, exist_ok=True)
 
         bundle_target = staging_dir / self.bundle_filename
         sig_target = staging_dir / self.signature_filename
+
+        # Per-call callback wins over the dataclass field so the service
+        # can bind a dispatch-scoped emitter without us needing to know
+        # about lifecycle state.
+        active_callback = progress_callback or self.progress_callback
 
         logger.info(
             "downloading bundle: release_id=%s target_version=%s url=%s -> %s",
@@ -121,7 +136,12 @@ class BundleDownloader:
             payload.bundle_url,
             bundle_target,
         )
-        await self._fetch(payload.bundle_url, bundle_target, with_progress=True)
+        await self._fetch(
+            payload.bundle_url,
+            bundle_target,
+            with_progress=True,
+            progress_callback=active_callback,
+        )
 
         logger.info(
             "downloading signature: release_id=%s url=%s -> %s",
@@ -138,7 +158,12 @@ class BundleDownloader:
         )
 
     async def _fetch(
-        self, url: str, target: Path, *, with_progress: bool = False,
+        self,
+        url: str,
+        target: Path,
+        *,
+        with_progress: bool = False,
+        progress_callback: Optional[ProgressCallback] = None,
     ) -> None:
         """Stream ``url`` into ``target`` via a ``.tmp`` sibling + rename.
 
@@ -147,15 +172,17 @@ class BundleDownloader:
         first reaches for it. Same trick the cms_client downloader uses.
 
         When ``with_progress`` is true and a ``progress_callback`` is
-        configured, fires ``(bytes_done, bytes_total)`` callbacks
-        throughout the streaming GET.
+        provided (or the dataclass field is set as a fallback), fires
+        ``(bytes_done, bytes_total)`` callbacks throughout the
+        streaming GET.
         """
 
         import aiohttp
 
         rate_limited: Optional[RateLimitedProgress] = None
-        if with_progress and self.progress_callback is not None:
-            rate_limited = RateLimitedProgress(self.progress_callback)
+        active_callback = progress_callback or self.progress_callback
+        if with_progress and active_callback is not None:
+            rate_limited = RateLimitedProgress(active_callback)
 
         tmp = target.with_suffix(target.suffix + ".tmp")
         try:

--- a/os_updater/events.py
+++ b/os_updater/events.py
@@ -36,6 +36,7 @@ import asyncio
 import enum
 import json
 import logging
+import threading
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -318,19 +319,69 @@ class WpsEventSink:
     be built BEFORE the first connect (it doesn't hold a reference to a
     transport that might later disconnect — it asks for the current one
     every time it sends).
+
+    Cross-thread safety (agora#219): :meth:`put` is invoked from three
+    distinct call sites with different threading characteristics:
+
+    * The FSM coroutines in :mod:`os_updater.service` — these run on the
+      service's asyncio main loop, so ``put`` is on-loop.
+    * The downloader's chunk loop — also on the main loop (``_fetch`` is
+      ``async``).
+    * The stage / extract progress callbacks — these fire from a
+      ``asyncio.to_thread`` worker (because :meth:`SlotStager.stage`
+      wraps its synchronous body in ``to_thread``) AND from a sidecar
+      polling thread (``_poll_extract_progress`` ticks fdinfo every
+      ``PROGRESS_MIN_INTERVAL_S``).  Both are off-loop.
+
+    The pre-#219 implementation called ``asyncio.get_running_loop()``
+    inside :meth:`put`, which raises ``RuntimeError`` on a worker
+    thread, so EVERY stage/extract progress event was silently dropped
+    at DEBUG level — the badge showed "Staging bundle" / "Upgrading…"
+    with no granular progress.  The fix is two-pronged:
+
+    1. The service binds the main loop via :meth:`bind_loop` once it
+       enters ``run()``, so we have a known good loop to schedule sends
+       on regardless of which thread ``put`` is called from.
+    2. :meth:`put` decides between ``loop.create_task`` (on-loop) and
+       ``asyncio.run_coroutine_threadsafe`` (off-loop) at send time.
+       Both are fire-and-forget — lifecycle events are advisory.
     """
 
     def __init__(self, transport_provider: TransportProvider) -> None:
         self._transport_provider = transport_provider
+        # The asyncio loop on which lifecycle-event sends are dispatched.
+        # Bound lazily: explicitly via :meth:`bind_loop` (preferred —
+        # called by the service at run-loop entry), or implicitly on the
+        # first on-loop :meth:`put` that finds a running loop in the
+        # caller's thread.  Once set, all subsequent puts (including
+        # those from worker threads) use this loop.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_lock = threading.Lock()
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Bind the asyncio loop used to schedule background sends.
+
+        Called once by :meth:`OSUpdaterService.run` at the top of the
+        main loop so worker-thread :meth:`put` callers can schedule
+        cross-thread via ``run_coroutine_threadsafe`` without having to
+        know about the service's loop bookkeeping.
+
+        Idempotent: re-binding the same loop is a no-op; rebinding to a
+        different loop replaces the previous one (tests routinely do
+        this when running multiple ``asyncio.run`` cycles back-to-back).
+        """
+        with self._loop_lock:
+            self._loop = loop
 
     def put(self, event: LifecycleEvent) -> None:
         """Fire ``event`` over the active transport, or drop on failure.
 
-        Schedules an async send via :func:`asyncio.get_running_loop`.
-        Must therefore be called from a coroutine context (which all of
-        the FSM's emit sites are).  If no event loop is running, the
-        event is dropped — this is the test-only "called from sync
-        teardown" case where there's no transport anyway.
+        Resolves the asyncio loop to schedule the send on (see class
+        docstring): a previously-bound loop wins; otherwise we try to
+        capture the loop from the caller's thread.  Off-loop callers
+        (extract/stage progress from worker threads) use
+        ``run_coroutine_threadsafe``; on-loop callers use
+        ``create_task``.  No loop available → DEBUG-log and drop.
         """
 
         transport = self._transport_provider()
@@ -340,16 +391,70 @@ class WpsEventSink:
                 event.event_id, event.event_type.value,
             )
             return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
+
+        loop = self._resolve_loop()
+        if loop is None:
             logger.debug(
                 "WpsEventSink: no running loop, dropping event_id=%d type=%s",
                 event.event_id, event.event_type.value,
             )
             return
+
         payload = json.dumps(event.to_jsonable())
-        loop.create_task(self._send(transport, payload, event.event_id))
+        coro = self._send(transport, payload, event.event_id)
+
+        # On-loop vs cross-thread submission.  ``get_running_loop``
+        # raises if the current thread has no running loop, which is
+        # exactly the worker-thread case we route via
+        # ``run_coroutine_threadsafe``.
+        try:
+            current = asyncio.get_running_loop()
+        except RuntimeError:
+            current = None
+
+        if current is loop:
+            loop.create_task(coro)
+            return
+
+        try:
+            asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError:
+            # Loop has stopped between resolve and submit — close the
+            # coroutine to suppress the "coroutine was never awaited"
+            # warning, then drop.  Same shape as the no-loop branch
+            # above: lifecycle events are advisory.
+            coro.close()
+            logger.debug(
+                "WpsEventSink: loop not running, dropping event_id=%d type=%s",
+                event.event_id, event.event_type.value,
+            )
+
+    def _resolve_loop(self) -> Optional[asyncio.AbstractEventLoop]:
+        """Return the loop to dispatch sends on, caching on first hit.
+
+        Order of preference:
+
+        1. An explicitly-bound loop (via :meth:`bind_loop`).  This is
+           the production path — the service calls ``bind_loop`` once
+           at startup so worker-thread puts have a loop ready before
+           the first stage_progress / extract_progress event fires.
+        2. The loop running in the caller's thread, if any.  Captured
+           lazily so that test code which constructs a sink and calls
+           ``put`` from an ``asyncio.run`` block Just Works without
+           plumbing through ``bind_loop``.
+        3. ``None`` — caller drops the event.
+        """
+
+        if self._loop is not None:
+            return self._loop
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        with self._loop_lock:
+            if self._loop is None:
+                self._loop = loop
+        return self._loop
 
     @staticmethod
     async def _send(transport: Any, payload: str, event_id: int) -> None:

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -160,10 +160,20 @@ class Downloader(Protocol):
     cleanup (plan §"Phase 2 — Deliverables"). Phase 2 default raises
     ``NotImplementedError`` so we fail loud if the sibling todo hasn't
     landed yet.
+
+    ``progress_callback`` (added in agora#219) is the per-dispatch
+    bytes-progress hook the service wires so each chunk fired by the
+    downloader becomes a ``download_progress`` lifecycle event.  Kwarg-
+    only and optional so non-progress-aware implementations (the test
+    stubs / Phase 2 ``_DefaultDownloader``) can ignore it.
     """
 
     async def run(
-        self, payload: DispatchPayload, staging_dir: Path
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
     ) -> None:  # pragma: no cover - protocol
         ...
 
@@ -238,7 +248,13 @@ def _default_unimplemented(name: str) -> Callable[..., Awaitable[None]]:
 
 @dataclass
 class _DefaultDownloader:
-    async def run(self, payload: DispatchPayload, staging_dir: Path) -> None:
+    async def run(
+        self,
+        payload: DispatchPayload,
+        staging_dir: Path,
+        *,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> None:
         raise NotImplementedError("downloader not wired; see p2-bundle-format")
 
 
@@ -447,7 +463,39 @@ class OSUpdaterService:
 
         staging_dir = self.staging_root / payload.release_id
         try:
-            await self.downloader.run(payload, staging_dir)
+            def _on_download_progress(bytes_done: int, bytes_total: int) -> None:
+                """Forward each rate-limited chunk callback from the
+                downloader into a DOWNLOAD_PROGRESS lifecycle event so
+                the CMS badge can animate as the bundle streams down
+                (agora#219).
+
+                Closure: captures ``self.state`` / ``self.event_sink`` /
+                ``self.state_path`` at the moment this dispatch is in
+                flight, not at downloader construction time.  Bound here
+                rather than passed into ``BundleDownloader(...)`` in
+                ``main.py`` because the downloader instance is reused
+                across dispatches but ``self.state`` is dispatch-scoped.
+                ``emit_event`` swallows sink failures and the downloader
+                wraps this callback in its own safe-invoke, so any
+                failure here is logged-and-ignored — DOWNLOAD_PROGRESS
+                is advisory.
+                """
+                emit_event(
+                    self.state,
+                    LifecycleEventType.DOWNLOAD_PROGRESS,
+                    self.event_sink,
+                    payload={
+                        "bytes_done": bytes_done,
+                        "bytes_total": bytes_total,
+                    },
+                    state_path=self.state_path,
+                )
+
+            await self.downloader.run(
+                payload,
+                staging_dir,
+                progress_callback=_on_download_progress,
+            )
             await self.verifier.run(payload, staging_dir)
             transition(self.state, UpdaterFSMState.STAGED)
             save_state(self.state, path=self.state_path)
@@ -718,6 +766,18 @@ class OSUpdaterService:
         """
 
         self.recover_on_start()
+
+        # Bind the main loop on the sink so worker-thread emit sites
+        # (stage_progress, extract_progress -- both fire from
+        # ``asyncio.to_thread`` workers and the fdinfo poll thread)
+        # can schedule sends via ``run_coroutine_threadsafe``.  Pre-
+        # agora#219, the sink called ``asyncio.get_running_loop`` in
+        # its own thread which raised in worker threads, silently
+        # dropping every progress event.  Duck-typed because
+        # OutboxEventSink (Phase 2 disk-only sink) doesn't need it.
+        bind_loop = getattr(self.event_sink, "bind_loop", None)
+        if callable(bind_loop):
+            bind_loop(asyncio.get_running_loop())
 
         try:
             await self._tick_promote_handshake()

--- a/tests/test_os_updater_downloader.py
+++ b/tests/test_os_updater_downloader.py
@@ -452,3 +452,68 @@ class TestBundleDownloaderProgress:
 
         assert (staging / DEFAULT_BUNDLE_FILENAME).read_bytes() == b"bundle"
         assert (staging / DEFAULT_SIGNATURE_FILENAME).read_bytes() == b"sig"
+
+    def test_run_kwarg_progress_callback_used(self, tmp_path):
+        """agora#219: the service binds a per-dispatch progress
+        callback via the ``run(progress_callback=...)`` kwarg rather
+        than mutating the downloader instance.  Pre-fix the downloader
+        only honored its dataclass field, so the wiring in
+        ``OSUpdaterService.handle_dispatch`` never reached the chunk
+        loop and every ``download_progress`` event was lost.
+        """
+        staging = tmp_path / "stage"
+        recorder = _RecordingProgress()
+        # Note: dataclass field intentionally left None -- the kwarg is
+        # the seam under test.
+        downloader = BundleDownloader()
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"xxxxx", b"yyyyy"]),
+            _AsyncIterChunks([b"sig"]),
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {"Content-Length": "10"}
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(
+                _payload(), staging, progress_callback=recorder,
+            ))
+
+        assert recorder.calls, "kwarg progress_callback should have fired"
+        assert recorder.calls[-1] == (10, 10)
+
+    def test_run_kwarg_overrides_dataclass_field(self, tmp_path):
+        """If both the dataclass field AND the run kwarg are set, the
+        kwarg wins.  Matters because the production wiring in
+        ``main.py`` constructs ``BundleDownloader()`` once (no field)
+        but the service binds a per-dispatch kwarg; if a future
+        refactor sets both, the dispatch-scoped one must take priority
+        so the lifecycle ``release_id`` is correct.
+        """
+        staging = tmp_path / "stage"
+        field_recorder = _RecordingProgress()
+        kwarg_recorder = _RecordingProgress()
+        downloader = BundleDownloader(progress_callback=field_recorder)
+
+        mock_aiohttp, mock_cls, mock_session = _mock_aiohttp_session()
+        bodies = iter([
+            _AsyncIterChunks([b"abc"]),
+            _AsyncIterChunks([b"sig"]),
+        ])
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.content.iter_chunked.side_effect = lambda _n: next(bodies)
+        mock_resp.headers = {"Content-Length": "3"}
+        mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_resp)
+
+        with patch.dict(sys.modules, {"aiohttp": mock_aiohttp}):
+            asyncio.run(downloader.run(
+                _payload(), staging, progress_callback=kwarg_recorder,
+            ))
+
+        assert kwarg_recorder.calls, "kwarg should win when both are set"
+        assert field_recorder.calls == [], "field should be ignored when kwarg given"

--- a/tests/test_os_updater_events.py
+++ b/tests/test_os_updater_events.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -508,3 +509,144 @@ class TestWpsEventSink:
         assert len(transport.sent) == 1
         decoded = json.loads(transport.sent[0])
         assert decoded["event_id"] == 2
+
+
+class TestWpsEventSinkCrossThread:
+    """Regression coverage for agora#219: ``WpsEventSink.put`` must work
+    when called from a worker thread (not just the asyncio main loop).
+
+    The original implementation called ``asyncio.get_running_loop`` in
+    ``put`` itself, which raises ``RuntimeError`` on a worker thread.
+    Result: every ``extract_progress`` / ``stage_progress`` event was
+    silently dropped at DEBUG level because those callbacks fire from
+    the ``asyncio.to_thread`` worker that runs ``SlotStager._stage_sync``
+    and the sidecar fdinfo poll thread.  See ``WpsEventSink.put`` for
+    the cross-thread scheduling fix.
+    """
+
+    def test_bind_loop_then_put_from_worker_thread(self):
+        transport = _FakeTransport()
+        sink = WpsEventSink(transport_provider=lambda: transport)
+
+        async def go():
+            sink.bind_loop(asyncio.get_running_loop())
+
+            done = threading.Event()
+
+            def worker():
+                # Off-loop call site -- mirrors the extract-poller
+                # thread.  Must not raise and must schedule the send
+                # via run_coroutine_threadsafe.
+                sink.put(_make_event(event_id=42))
+                done.set()
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join(timeout=2.0)
+            assert done.is_set()
+            # Yield enough times for the threadsafe-scheduled task to
+            # actually run through ``await transport.send``.
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+        asyncio.run(go())
+
+        assert len(transport.sent) == 1
+        decoded = json.loads(transport.sent[0])
+        assert decoded["event_id"] == 42
+
+    def test_put_from_worker_thread_without_explicit_bind_loop(self):
+        """If the caller never calls ``bind_loop`` but DOES call ``put``
+        from the main loop at least once before any worker-thread call,
+        the lazy capture in ``_resolve_loop`` should kick in and make
+        subsequent worker-thread puts work.
+        """
+        transport = _FakeTransport()
+        sink = WpsEventSink(transport_provider=lambda: transport)
+
+        async def go():
+            # First put: on-loop, captures the loop lazily.
+            sink.put(_make_event(event_id=1))
+            await asyncio.sleep(0)
+
+            # Second put: from a worker thread.  Must use the loop
+            # captured in the first call.
+            done = threading.Event()
+
+            def worker():
+                sink.put(_make_event(event_id=2))
+                done.set()
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join(timeout=2.0)
+            assert done.is_set()
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+        asyncio.run(go())
+
+        assert len(transport.sent) == 2
+        ids = sorted(json.loads(p)["event_id"] for p in transport.sent)
+        assert ids == [1, 2]
+
+    def test_worker_thread_put_with_no_bound_loop_drops(self):
+        """If the sink has never seen a loop AND the worker thread
+        doesn't have a running loop, the event is dropped (DEBUG log)
+        without raising.  This is the same defensive behavior as the
+        pre-#219 ``put`` -- we just guarantee it for worker-thread
+        callers too.
+        """
+        transport = _FakeTransport()
+        sink = WpsEventSink(transport_provider=lambda: transport)
+
+        done = threading.Event()
+        err: list[BaseException] = []
+
+        def worker():
+            try:
+                sink.put(_make_event(event_id=99))
+            except BaseException as exc:  # pragma: no cover - defensive
+                err.append(exc)
+            done.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=2.0)
+        assert done.is_set()
+        assert err == []
+        assert transport.sent == []
+
+    def test_bind_loop_idempotent_for_same_loop(self):
+        sink = WpsEventSink(transport_provider=lambda: None)
+
+        async def go():
+            loop = asyncio.get_running_loop()
+            sink.bind_loop(loop)
+            sink.bind_loop(loop)  # second bind same loop -- no-op
+            return sink._loop is loop
+
+        assert asyncio.run(go()) is True
+
+    def test_rebind_to_new_loop_replaces_previous(self):
+        """Tests that run multiple ``asyncio.run`` cycles back-to-back
+        get a fresh loop each time.  ``bind_loop`` MUST accept the new
+        loop; otherwise a stale-loop-pointer would cause every
+        subsequent run-cycle's worker-thread puts to drop.
+        """
+        sink = WpsEventSink(transport_provider=lambda: None)
+
+        async def first():
+            sink.bind_loop(asyncio.get_running_loop())
+            return id(asyncio.get_running_loop())
+
+        async def second():
+            sink.bind_loop(asyncio.get_running_loop())
+            return id(asyncio.get_running_loop())
+
+        first_id = asyncio.run(first())
+        second_id = asyncio.run(second())
+        # Sanity: two ``asyncio.run`` cycles -> two distinct loops.
+        assert first_id != second_id
+        # And bind_loop tracked the rebind.
+        assert id(sink._loop) == second_id

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -70,7 +70,7 @@ class _OkStub:
 
 
 class _BoomDownloader:
-    async def run(self, payload, staging_dir):
+    async def run(self, payload, staging_dir, *, progress_callback=None):
         raise RuntimeError("network is on fire")
 
 
@@ -1160,3 +1160,175 @@ class TestHandleDispatchExtractProgress:
 
         ids = [e.event_id for e in sink.events]
         assert ids == sorted(ids)
+
+
+# -- handle_dispatch wires DOWNLOAD_PROGRESS (agora#219) -----------------------
+
+
+class _ProgressEmittingDownloader:
+    """Downloader stub that fires the ``progress_callback`` kwarg so
+    the test can assert the service's ``_on_download_progress`` closure
+    forwards the bytes_done/bytes_total into a DOWNLOAD_PROGRESS event.
+
+    Mirrors ``_ProgressEmittingStager`` -- separate class so the
+    captured-callback assertions stay local to each test.
+    """
+
+    def __init__(self) -> None:
+        self.captured_progress_callback = None
+        self.calls: list[tuple] = []
+
+    async def run(self, payload, staging_dir, *, progress_callback=None):
+        self.calls.append(("run", payload, staging_dir))
+        self.captured_progress_callback = progress_callback
+        if progress_callback is not None:
+            # Simulate two rate-limited chunks plus the final 100% emit
+            # so the test asserts on the last (terminal) event the same
+            # way the real downloader does.
+            progress_callback(0, 1_000_000)
+            progress_callback(500_000, 1_000_000)
+            progress_callback(1_000_000, 1_000_000)
+
+
+class TestHandleDispatchDownloadProgress:
+    """The service-side ``_on_download_progress`` closure forwards each
+    rate-limited chunk emit from the downloader into a DOWNLOAD_PROGRESS
+    lifecycle event (agora#219).  Pre-#219 the service never bound a
+    download callback, so the BundleDownloader's ``progress_callback``
+    field stayed ``None`` and zero download_progress events ever fired
+    on production -- the CMS badge stayed empty during the whole
+    download phase.
+    """
+
+    def test_downloader_progress_callback_emits_lifecycle_events(self, tmp_path):
+        sink = _ListSink()
+        downloader = _ProgressEmittingDownloader()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            downloader=downloader,
+        )
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-dl")))
+
+        # Service handed the downloader a non-None progress callback.
+        assert downloader.captured_progress_callback is not None
+
+        progress = [
+            e for e in sink.events
+            if e.event_type is LifecycleEventType.DOWNLOAD_PROGRESS
+        ]
+        assert len(progress) == 3
+        assert progress[0].payload == {"bytes_done": 0, "bytes_total": 1_000_000}
+        assert progress[-1].payload == {
+            "bytes_done": 1_000_000, "bytes_total": 1_000_000,
+        }
+        # Every event must carry the dispatch's release / target metadata.
+        for evt in progress:
+            assert evt.release_id == "rel-dl"
+            assert evt.target_version == "1.1.0"
+
+    def test_download_progress_lands_between_download_started_and_staged(self, tmp_path):
+        """DOWNLOAD_PROGRESS is mid-download and must sit between
+        DOWNLOAD_STARTED and SIGNATURE_VERIFIED / STAGED so CMS
+        timeline rollups stay ordered.  Mirrors the same constraint
+        the existing EXTRACT_PROGRESS test enforces.
+        """
+        sink = _ListSink()
+        downloader = _ProgressEmittingDownloader()
+        s = _build_service(
+            tmp_path,
+            current_version="1.0.0",
+            sink=sink,
+            downloader=downloader,
+        )
+
+        asyncio.run(s.handle_dispatch(_ok_dispatch(release_id="rel-dl-ord")))
+
+        kinds = [e.event_type for e in sink.events]
+        assert LifecycleEventType.DOWNLOAD_PROGRESS in kinds
+        started_idx = kinds.index(LifecycleEventType.DOWNLOAD_STARTED)
+        first_progress_idx = kinds.index(LifecycleEventType.DOWNLOAD_PROGRESS)
+        staged_idx = kinds.index(LifecycleEventType.STAGED)
+        assert started_idx < first_progress_idx < staged_idx
+
+        ids = [e.event_id for e in sink.events]
+        assert ids == sorted(ids)
+
+
+# -- service.run binds the asyncio loop on the sink (agora#219) ---------------
+
+
+class TestServiceRunBindsLoop:
+    """``OSUpdaterService.run`` MUST bind the running asyncio loop on
+    the sink at startup so worker-thread emit sites (stage/extract
+    progress) can schedule sends via ``run_coroutine_threadsafe``.
+    Pre-#219 the sink's ``put`` called ``asyncio.get_running_loop`` in
+    the calling thread itself, which raised in worker threads, so
+    every off-loop progress event was silently dropped.
+
+    This is a regression guard against someone removing the
+    ``bind_loop`` call in a future refactor.  Duck-typed: sinks that
+    don't expose ``bind_loop`` (OutboxEventSink) MUST still work.
+    """
+
+    def test_run_calls_bind_loop_when_sink_supports_it(self, tmp_path):
+        bound: list = []
+
+        class _BindCapturingSink:
+            def __init__(self):
+                self.events = []
+
+            def bind_loop(self, loop):
+                bound.append(loop)
+
+            def put(self, event):
+                self.events.append(event)
+
+        sink = _BindCapturingSink()
+        s = _build_service(tmp_path, current_version="1.0.0", sink=sink)
+
+        async def runner():
+            task = asyncio.create_task(s.run())
+            # Yield enough for run() to reach the bind_loop call before
+            # the first long await (transport.connect()).
+            for _ in range(5):
+                await asyncio.sleep(0)
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+            return asyncio.get_running_loop()
+
+        loop_used = asyncio.run(runner())
+        assert len(bound) == 1
+        assert bound[0] is loop_used
+
+    def test_run_works_when_sink_has_no_bind_loop_method(self, tmp_path):
+        """OutboxEventSink doesn't have ``bind_loop`` -- the service
+        must duck-type the call and skip it without raising."""
+
+        class _NoBindSink:
+            def __init__(self):
+                self.events = []
+
+            def put(self, event):
+                self.events.append(event)
+
+        sink = _NoBindSink()
+        s = _build_service(tmp_path, current_version="1.0.0", sink=sink)
+
+        async def runner():
+            task = asyncio.create_task(s.run())
+            for _ in range(5):
+                await asyncio.sleep(0)
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        # Must not raise.
+        asyncio.run(runner())


### PR DESCRIPTION
Two collaborating bugs in PR #216's progress-event scaffold silently dropped EVERY `download_progress` and `extract_progress` event in production, leaving the CMS upgrade badge stuck at "Staging bundle" → "Upgrading…" with no granular percentage during the entire ~7-minute upgrade window. Found during the v0.0.33-test validation OTA against Pi100 on Goodwill CMS, after PR #217 fixed the non-progress event path.

## Symptom

- `GET /api/devices/{id}` showed `ota_phase = null` and `ota_pct = null` for the full upgrade.
- `device_events` table: `download_started`, `signature_verified`, `staged`, `slot_confirmed`, `promoted`, `migration_complete` all landed -- ZERO `download_progress` / `extract_progress` entries between them.
- Pi journal: clean, no `WpsEventSink` WARNING (the drop is at DEBUG).

## Root cause

### Bug A -- download progress was never wired

`main.py:378` constructs `BundleDownloader()` with no `progress_callback` field. `BundleDownloader._fetch` gates the rate-limiter on `if self.progress_callback is not None` and quietly skips it. The service-side wiring exists for `STAGE_PROGRESS` and `EXTRACT_PROGRESS` but `DOWNLOAD_PROGRESS` only had the boundary event (`DOWNLOAD_STARTED`); in-flight chunks were never plumbed.

**Fix:** Extend the `Downloader` protocol (and `BundleDownloader.run`) to accept `progress_callback` as a kwarg-only parameter. Bind a per-dispatch `_on_download_progress` closure in `OSUpdaterService.handle_dispatch` -- same shape as `_on_stage_progress` / `_on_extract_progress`. The closure captures `self.state` / `self.event_sink` at dispatch time so each chunk callback becomes a `DOWNLOAD_PROGRESS` lifecycle event carrying the correct `release_id` / `target_version`.

### Bug B -- cross-thread `WpsEventSink.put` silently dropped

`WpsEventSink.put` called `asyncio.get_running_loop()` in the caller's thread to schedule the send task. Two emit sites run off the main loop:

1. `SlotStager.stage()` wraps its synchronous body in `asyncio.to_thread` (`apply.py:1530`). `_on_stage_progress` therefore fires on a worker thread.
2. `_poll_extract_progress` ticks the zstd `fdinfo` in a sidecar thread. `_on_extract_progress` fires there.

Neither thread has a running asyncio loop. `get_running_loop` raised `RuntimeError`, `put` hit its except branch, and the event was dropped at DEBUG. Every stage_progress AND extract_progress event was lost in production.

**Fix:** Capture the loop once -- either explicitly via `WpsEventSink.bind_loop` (called by `OSUpdaterService.run` at startup) or lazily on the first on-loop `put`. `put` then routes via `loop.create_task` on the loop's thread and `asyncio.run_coroutine_threadsafe` from any other thread. `threading.Lock` guards the loop reference. The `bind_loop` call in `run()` is duck-typed so `OutboxEventSink` (the Phase-2 disk-only sink with no thread-affinity concerns) keeps working unchanged.

## Tests

- **`TestWpsEventSinkCrossThread` (5 cases)** covers `bind_loop` + lazy capture + worker-thread put + no-loop drop + rebind. The worker-thread path is the regression the existing `TestWpsEventSink` class missed.
- **`TestBundleDownloaderProgress`** gets two new cases for the kwarg seam: `run(progress_callback=...)` is used, and overrides the dataclass field when both are set.
- **`TestHandleDispatchDownloadProgress`** mirrors the existing `TestHandleDispatchExtractProgress` -- verifies the service binds a download callback, the emit lands in the sink with the right payload + dispatch metadata, and `DOWNLOAD_PROGRESS` sits in the correct timeline slot between `DOWNLOAD_STARTED` and `STAGED`.
- **`TestServiceRunBindsLoop`** guards the run-loop binding -- catches both "remove bind_loop" and "accidentally break duck-typing" regressions.

Existing `_BoomDownloader` test stub updated for the new protocol signature.

Full agora test suite: **1503 passed, 0 failed** (64 collection errors in `tests/test_wss_support.py` and `tests/test_cms_url_reconnect.py` are pre-existing environmental issues unrelated to this change).

## Rollout

Will be validated end-to-end on Pi100 against Goodwill CMS by chaining a vehicle OTA (v0.0.34-test gets the fix on-device) into a target OTA (v0.0.35-test exercises the new emit paths). Manual `Upgrade` click drives the final dispatch so the user can see the badge animate live. Done after this PR + APT publish complete.

Closes #215's residual; obsoletes the silent-drop path PR #217 partially addressed.
