### PR TITLE
fix(os_updater): poll the right fd for extract progress (agora#220)

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -87,6 +87,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -257,16 +258,22 @@ def _safe_emit_progress(
 _PID_OBSERVER_WAIT_S = 5.0
 
 
-def _read_fdinfo_pos(pid: int) -> Optional[int]:
-    """Return the byte position of ``/proc/<pid>/fdinfo/0`` (zstd's stdin).
+def _read_fdinfo_pos(pid: int, fd: int = 0) -> Optional[int]:
+    """Return the byte position of ``/proc/<pid>/fdinfo/<fd>``.
 
     Returns ``None`` if the file is unreadable for any reason (PID gone,
     not on Linux, malformed contents). The poller treats every ``None``
     as "stop polling" — there's nothing to recover from at this layer.
+
+    ``fd`` defaults to 0 (stdin) for back-compat with the original
+    signature, but in practice every caller resolves the real bundle fd
+    via :func:`_resolve_bundle_fd` first and passes it explicitly: zstd
+    invoked with a positional file argument reads from that fd, not
+    stdin, so polling fd 0 never advances (agora#220).
     """
 
     try:
-        with open(f"/proc/{pid}/fdinfo/0", "rt") as f:
+        with open(f"/proc/{pid}/fdinfo/{fd}", "rt") as f:
             for line in f:
                 if line.startswith("pos:"):
                     try:
@@ -278,6 +285,57 @@ def _read_fdinfo_pos(pid: int) -> Optional[int]:
         return None
 
 
+def _resolve_bundle_fd(pid: int, bundle_path: Path) -> Optional[int]:
+    """Find the file descriptor in ``/proc/<pid>/fd/`` that points to ``bundle_path``.
+
+    zstd is invoked as ``zstd -dc -f <bundle_path>`` from
+    :func:`stream_extract_subtree`, so it opens the bundle as a regular
+    fd (≥ 3), **not** stdin. The bytes-progress poller needs that fd's
+    ``pos:`` field to anchor percentage against ``compressed_size``;
+    fd 0 (stdin) is inherited from the python service and never read,
+    so its ``pos:`` stays at 0 for the entire extract — which is why
+    the badge sat at 0% through agora#219's deploy and motivated this
+    fix (agora#220).
+
+    Returns the numeric fd, or ``None`` if:
+
+    * ``/proc/<pid>/fd/`` is unreadable (process gone, non-Linux, denied),
+    * no fd's symlink target matches ``bundle_path`` yet (zstd may not
+      have called ``open()`` at the instant we have its PID — caller
+      retries within ``_PID_OBSERVER_WAIT_S``).
+
+    Match is by string equality between ``os.readlink`` and the
+    absolute (realpath) form of ``bundle_path``. ``/proc/<pid>/fd/N``
+    always shows the canonical path regardless of what relative string
+    zstd was given on argv, so we normalize bundle_path the same way
+    before comparing. Linux appends ``" (deleted)"`` to fd targets
+    after an unlink; we strip that defensively so a mid-extract unlink
+    (only seen in pathological tests) doesn't break resolution.
+    """
+    try:
+        target_str = os.path.realpath(str(bundle_path))
+    except OSError:
+        target_str = str(bundle_path)
+    fd_dir = f"/proc/{pid}/fd"
+    try:
+        entries = os.listdir(fd_dir)
+    except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+        return None
+    for fd_name in entries:
+        try:
+            link = os.readlink(f"{fd_dir}/{fd_name}")
+        except OSError:
+            continue
+        if link.endswith(" (deleted)"):
+            link = link[: -len(" (deleted)")]
+        if link == target_str:
+            try:
+                return int(fd_name)
+            except ValueError:
+                continue
+    return None
+
+
 def _poll_extract_progress(
     pid_holder: dict[str, Optional[int]],
     stop_event: threading.Event,
@@ -286,26 +344,40 @@ def _poll_extract_progress(
     *,
     interval_s: float = PROGRESS_MIN_INTERVAL_S,
     pid_wait_deadline_s: float = _PID_OBSERVER_WAIT_S,
-    fdinfo_reader: Callable[[int], Optional[int]] = _read_fdinfo_pos,
+    fdinfo_reader: Optional[Callable[[int], Optional[int]]] = None,
+    bundle_path: Optional[Path] = None,
+    bundle_fd_resolver: Callable[[int, Path], Optional[int]] = _resolve_bundle_fd,
 ) -> None:
-    """Poll ``/proc/<zstd_pid>/fdinfo/0`` and emit bytes-progress.
+    """Poll the fd zstd has open on the bundle and emit bytes-progress.
 
     Runs in a worker thread spawned by :func:`stream_extract_subtree`.
-    Reads the ``pos:`` field of zstd's stdin fdinfo (== compressed
-    bytes consumed from the .tar.zst on disk) at most every
-    ``interval_s`` seconds, then calls ``callback(bytes_read,
-    compressed_size)``.
+    Reads the ``pos:`` field of the zstd fdinfo that corresponds to the
+    bundle file (== compressed bytes consumed from the .tar.zst on
+    disk) at most every ``interval_s`` seconds, then calls
+    ``callback(bytes_read, compressed_size)``.
 
     Exits cleanly when any of these happens, in order of likelihood:
 
     * ``stop_event`` is set by the caller (pipeline completed).
     * fdinfo read returns ``None`` (zstd exited; ``/proc/<pid>/...`` gone).
     * ``pid_holder["pid"]`` is still ``None`` after ``pid_wait_deadline_s``.
+    * No fd matching ``bundle_path`` appears in ``/proc/<pid>/fd/``
+      within ``pid_wait_deadline_s`` after the PID lands (zstd hasn't
+      opened the bundle yet, or the test pipeline_runner synthesized
+      a fake PID — the latter is why every existing unit test injects
+      ``fdinfo_reader`` and bypasses this path).
+
+    When ``fdinfo_reader`` is explicitly passed, the poller uses it
+    directly and skips bundle-fd resolution — that's the test seam.
+    When ``fdinfo_reader`` is ``None`` (production default), the poller
+    resolves the bundle fd lazily via ``bundle_fd_resolver`` and binds
+    a per-fd reader internally.
 
     Callback exceptions are caught — progress is advisory, must not
     take down the extract. Test-only knobs (``interval_s``,
-    ``pid_wait_deadline_s``, ``fdinfo_reader``) are explicit kwargs so
-    unit tests can drive the poller without touching ``/proc``.
+    ``pid_wait_deadline_s``, ``fdinfo_reader``, ``bundle_fd_resolver``)
+    are explicit kwargs so unit tests can drive the poller without
+    touching ``/proc``.
     """
 
     # Wait for the pipeline runner to capture and publish zstd's PID.
@@ -322,8 +394,44 @@ def _poll_extract_progress(
 
     pid = pid_holder["pid"]
     assert pid is not None  # for type narrowing
+
+    # Resolve the reader. Explicit fdinfo_reader (tests) wins. Otherwise
+    # in production wait briefly for zstd to open the bundle and bind a
+    # reader pinned to that fd.
+    reader: Callable[[int], Optional[int]]
+    if fdinfo_reader is not None:
+        reader = fdinfo_reader
+    elif bundle_path is None:
+        # No way to find the right fd — better to emit nothing than to
+        # spam zeros from fd 0 (the bug this rewrite exists to fix).
+        logger.debug(
+            "extract progress poller: no bundle_path supplied; "
+            "skipping (caller will still emit final 100%% on success)"
+        )
+        return
+    else:
+        bundle_fd: Optional[int] = None
+        fd_deadline = time.monotonic() + pid_wait_deadline_s
+        while bundle_fd is None:
+            bundle_fd = bundle_fd_resolver(pid, bundle_path)
+            if bundle_fd is not None:
+                break
+            if stop_event.wait(0.05):
+                return
+            if time.monotonic() > fd_deadline:
+                logger.debug(
+                    "extract progress poller: bundle fd for %s never "
+                    "appeared in /proc/%d/fd within %.2fs",
+                    bundle_path, pid, pid_wait_deadline_s,
+                )
+                return
+        # Late-bind so the lambda captures the resolved fd, not the
+        # name (which would re-resolve through globals on each call).
+        resolved_fd = bundle_fd
+        reader = lambda p: _read_fdinfo_pos(p, resolved_fd)
+
     while not stop_event.is_set():
-        pos = fdinfo_reader(pid)
+        pos = reader(pid)
         if pos is None:
             return
         try:
@@ -948,6 +1056,7 @@ def stream_extract_subtree(
         poll_thread = threading.Thread(
             target=poller,
             args=(pid_holder, stop_event, compressed_size, progress_callback),
+            kwargs={"bundle_path": bundle_path},
             name=f"extract-progress-{subpath}",
             daemon=True,
         )

--- a/tests/test_os_updater_apply.py
+++ b/tests/test_os_updater_apply.py
@@ -1883,6 +1883,7 @@ import threading as _threading
 from os_updater.apply import (
     _poll_extract_progress,
     _read_fdinfo_pos,
+    _resolve_bundle_fd,
     stream_extract_subtree,
 )
 
@@ -2032,6 +2033,300 @@ class TestPollExtractProgress:
             pid_wait_deadline_s=5.0,
             fdinfo_reader=fake_reader,
         )
+
+
+class TestResolveBundleFd:
+    """zstd opens the bundle as a regular fd (not stdin) so the poller
+    has to scan /proc/<pid>/fd/ for the symlink that points back at
+    the bundle path. Real /proc is Linux-only; tests inject fakes
+    only by monkeypatching os.listdir / os.readlink for full coverage
+    of the matching logic."""
+
+    def test_finds_matching_fd(self, tmp_path, monkeypatch):
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+
+        monkeypatch.setattr(
+            "os_updater.apply.os.listdir",
+            lambda p: ["0", "1", "2", "3", "4"],
+        )
+
+        def fake_readlink(p: str) -> str:
+            # /proc/<pid>/fd/3 points at the bundle. Others are noise.
+            return {
+                "0": "/dev/null",
+                "1": "pipe:[123]",
+                "2": "pipe:[124]",
+                "3": str(bundle),
+                "4": "/tmp/something-else",
+            }[p.rsplit("/", 1)[-1]]
+
+        monkeypatch.setattr("os_updater.apply.os.readlink", fake_readlink)
+
+        assert _resolve_bundle_fd(1234, bundle) == 3
+
+    def test_returns_none_when_no_fd_matches(self, tmp_path, monkeypatch):
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        monkeypatch.setattr(
+            "os_updater.apply.os.listdir",
+            lambda p: ["0", "1", "2"],
+        )
+        monkeypatch.setattr(
+            "os_updater.apply.os.readlink",
+            lambda p: "/dev/null",
+        )
+        assert _resolve_bundle_fd(1234, bundle) is None
+
+    def test_returns_none_when_proc_unreadable(self, tmp_path, monkeypatch):
+        bundle = tmp_path / "bundle.tar.zst"
+
+        def boom(_p):
+            raise FileNotFoundError("/proc/1234/fd")
+
+        monkeypatch.setattr("os_updater.apply.os.listdir", boom)
+        assert _resolve_bundle_fd(1234, bundle) is None
+
+    def test_strips_deleted_suffix(self, tmp_path, monkeypatch):
+        """Linux appends ``" (deleted)"`` after the underlying file is
+        unlinked while still open. Defensive: still match."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        monkeypatch.setattr(
+            "os_updater.apply.os.listdir",
+            lambda p: ["3"],
+        )
+        monkeypatch.setattr(
+            "os_updater.apply.os.readlink",
+            lambda p: f"{bundle} (deleted)",
+        )
+        assert _resolve_bundle_fd(1234, bundle) == 3
+
+    def test_skips_unreadable_individual_fd(self, tmp_path, monkeypatch):
+        """One bad readlink shouldn't abort the whole scan."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        monkeypatch.setattr(
+            "os_updater.apply.os.listdir",
+            lambda p: ["3", "4"],
+        )
+
+        def fake_readlink(p: str) -> str:
+            if p.endswith("/3"):
+                raise OSError("permission denied on this one")
+            return str(bundle)
+
+        monkeypatch.setattr("os_updater.apply.os.readlink", fake_readlink)
+        assert _resolve_bundle_fd(1234, bundle) == 4
+
+    def test_matches_via_realpath_when_bundle_path_relative(
+        self, tmp_path, monkeypatch
+    ):
+        """``/proc/<pid>/fd/N`` always reports the absolute canonical
+        path, even if zstd was invoked with a relative path. The
+        resolver must normalize the caller's bundle_path the same way
+        before comparing or the match silently fails on disk layouts
+        where the working dir != the bundle's dir."""
+        from pathlib import Path as _P
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        # Pretend the caller passed a relative path (zstd would
+        # internally resolve to absolute; /proc reports the absolute).
+        rel_view = _P(bundle.name)
+        abs_view = str(bundle)
+
+        monkeypatch.setattr(
+            "os_updater.apply.os.path.realpath",
+            lambda p: abs_view if str(p) == str(rel_view) else os.path.realpath(p),
+        )
+        monkeypatch.setattr(
+            "os_updater.apply.os.listdir",
+            lambda p: ["3"],
+        )
+        monkeypatch.setattr(
+            "os_updater.apply.os.readlink",
+            lambda p: abs_view,
+        )
+        assert _resolve_bundle_fd(1234, rel_view) == 3
+
+
+class TestPollExtractProgressBundleFdResolution:
+    """When no explicit ``fdinfo_reader`` is supplied (the production
+    code path since agora#220), the poller resolves which fd zstd is
+    reading the bundle from before it starts polling. These tests drive
+    that resolution via the ``bundle_fd_resolver`` test seam."""
+
+    def test_uses_resolver_to_pick_fd_and_reads_that_fdinfo(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: resolver returns fd 5, then the poller reads
+        /proc/<pid>/fdinfo/5 (not /fdinfo/0 — the bug)."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        calls: list[tuple[int, int]] = []
+
+        # Intercept what fd _read_fdinfo_pos is called with by faking
+        # the open() that it does.
+        opens_seen: list[str] = []
+
+        class FakeFile:
+            def __init__(self, content: str) -> None:
+                self._content = content
+            def __iter__(self):
+                return iter(self._content.splitlines(keepends=True))
+            def __enter__(self):
+                return self
+            def __exit__(self, *_):
+                return False
+
+        reads_by_fd: dict[int, list[int]] = {5: [100, 200]}
+
+        def fake_open(path: str, *args, **kwargs):
+            opens_seen.append(path)
+            # parse fd out of /proc/<pid>/fdinfo/<fd>
+            fd_num = int(path.rsplit("/", 1)[-1])
+            try:
+                pos = reads_by_fd[fd_num].pop(0)
+            except (KeyError, IndexError):
+                raise FileNotFoundError(path)
+            return FakeFile(f"pos:\t{pos}\nflags:\t0\n")
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+
+        def resolver(_pid: int, _bundle: "Path") -> int:
+            return 5
+
+        def cb(d: int, t: int) -> None:
+            calls.append((d, t))
+            if len(calls) == 2:
+                stop.set()
+
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=cb,
+            interval_s=0.001,
+            pid_wait_deadline_s=0.5,
+            bundle_path=bundle,
+            bundle_fd_resolver=resolver,
+        )
+
+        assert calls == [(100, 1000), (200, 1000)]
+        # CRITICAL: fdinfo/5 was read, NOT fdinfo/0. That's the
+        # regression guard for the agora#220 fix.
+        assert all(p.endswith("/fdinfo/5") for p in opens_seen)
+        assert not any(p.endswith("/fdinfo/0") for p in opens_seen)
+
+    def test_returns_immediately_when_no_bundle_path(self):
+        """In production we'd never hit this (stream_extract_subtree
+        always passes bundle_path), but if a caller does forget, the
+        poller emits NOTHING rather than falling back to the buggy
+        fd-0 read."""
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: calls.append((d, t)),
+            interval_s=0.001,
+            pid_wait_deadline_s=0.1,
+            # No fdinfo_reader, no bundle_path.
+        )
+
+        assert calls == []
+
+    def test_bails_when_bundle_fd_never_appears(self, tmp_path):
+        """zstd had its PID published but never actually opened the
+        bundle (test pipeline_runner with a synthetic PID, or zstd
+        died on argv parse before open() — either way the resolver
+        keeps returning None). Bail within deadline, no callbacks."""
+        bundle = tmp_path / "bundle.tar.zst"
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+
+        def resolver(_pid, _bundle):
+            return None  # never resolves
+
+        import time as _time
+        t0 = _time.monotonic()
+        _poll_extract_progress(
+            pid_holder,
+            stop,
+            compressed_size=1000,
+            callback=lambda d, t: calls.append((d, t)),
+            interval_s=0.01,
+            pid_wait_deadline_s=0.15,
+            bundle_path=bundle,
+            bundle_fd_resolver=resolver,
+        )
+        elapsed = _time.monotonic() - t0
+        assert calls == []
+        assert elapsed < 1.0
+
+    def test_resolver_lazy_retry_until_fd_appears(self, tmp_path):
+        """zstd may not have called open() yet at the instant we have
+        its PID. The resolver should be polled until the fd materializes
+        (or the deadline expires)."""
+        bundle = tmp_path / "bundle.tar.zst"
+        bundle.touch()
+        calls: list[tuple[int, int]] = []
+        stop = _threading.Event()
+        pid_holder: dict[str, int] = {"pid": 1234}
+
+        attempts = {"n": 0}
+
+        def slow_resolver(_pid, _bundle):
+            attempts["n"] += 1
+            return 7 if attempts["n"] >= 3 else None
+
+        # We don't care about real fdinfo reads here — patch the reader
+        # by going through the explicit fdinfo_reader seam is not what
+        # we want (it bypasses resolution). Instead, monkeypatch the
+        # module-level _read_fdinfo_pos via a wrapping reader.
+        # Trick: hook through bundle_fd_resolver returning a known fd,
+        # then patch __builtins__.open inside the poller via... easier
+        # to drive end-to-end with builtins.open monkeypatch.
+        import builtins as _b
+        real_open = _b.open
+
+        class FakeFile:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def __iter__(self): return iter(["pos:\t999\n"])
+
+        def fake_open(path, *args, **kwargs):
+            if isinstance(path, str) and path.startswith("/proc/"):
+                if path.endswith("/fdinfo/7"):
+                    stop.set()  # one emit is enough
+                    return FakeFile()
+                raise FileNotFoundError(path)
+            return real_open(path, *args, **kwargs)
+
+        _b.open = fake_open
+        try:
+            _poll_extract_progress(
+                pid_holder,
+                stop,
+                compressed_size=1000,
+                callback=lambda d, t: calls.append((d, t)),
+                interval_s=0.001,
+                pid_wait_deadline_s=0.5,
+                bundle_path=bundle,
+                bundle_fd_resolver=slow_resolver,
+            )
+        finally:
+            _b.open = real_open
+
+        assert attempts["n"] >= 3, f"resolver retried only {attempts['n']}x"
+        assert calls == [(999, 1000)]
 
 
 class TestStreamExtractSubtreeProgressIntegration:


### PR DESCRIPTION
Fixes the OTA-progress regression user reported after agora#219 deployed: download progress now animates correctly, but the extraction phase shows `0%` for every extraction pass and just sits there until the final force-emit at the end snaps it to `100%`.

## Root cause

In `os_updater/apply.py` the bytes-progress poller read `/proc/<zstd_pid>/fdinfo/0` -- i.e. **fd 0 (stdin)**.  But `stream_extract_subtree` invokes zstd as:

\\\
zstd -dc --long=N -f <bundle_path>
\\\

-- a *positional file argument*.  zstd opens the bundle on a regular fd (>= 3); fd 0 is the inherited stdin from the python service and is never read, so its `pos:` field stays at `0` forever.  Every poll fired `callback(0, compressed_size)`.

Every existing unit test of `_poll_extract_progress` injected its own `fdinfo_reader`, so this code path was never exercised in CI -- the bug only manifested on the actual Pi.

## Fix

- New `_resolve_bundle_fd(pid, bundle_path)` scans `/proc/<pid>/fd/` for the fd whose `readlink` target matches `realpath(bundle_path)`.  Strips the trailing ` (deleted)` Linux appends after an unlink.  Returns `None` on any error so the poller exits cleanly off-Linux or when zstd is already gone.
- `_read_fdinfo_pos(pid, fd=0)` grew an `fd` arg (default kept only for the two existing test-only `_read_fdinfo_pos(1) / (999_999_999)` cases).
- `_poll_extract_progress` grew `bundle_path` + `bundle_fd_resolver` kwargs.  Control flow:
  - Explicit `fdinfo_reader` -> use it directly (preserves the existing test seam; all prior poller tests continue to pass unchanged).
  - No `fdinfo_reader`, `bundle_path` given -> wait within `pid_wait_deadline_s` for the bundle fd to materialize in `/proc` (zstd may not have called `open()` at the instant we get its PID), then bind a per-fd reader pinned to that fd.
  - Neither supplied -> emit nothing.  Better to be silent than to spam zeros from fd 0 (the original bug).
- `stream_extract_subtree` threads `bundle_path=bundle_path` into the poller thread via `kwargs=`.

## Tests

- Existing `TestPollExtractProgress` / `TestReadFdinfoPos` / `TestStreamExtractSubtreeProgressIntegration` (7) untouched, still pass.
- New `TestResolveBundleFd` (6 cases): basic match, no match, `/proc` unreadable, ` (deleted)` suffix, readlink error on individual fd, relative bundle path normalized via realpath.
- New `TestPollExtractProgressBundleFdResolution` (4 cases): end-to-end through the resolver including a direct assertion that `/fdinfo/<bundle_fd>` is opened and `/fdinfo/0` is **never** opened -- regression guard for the bug.

Targeted: `17/17`.  Full `test_os_updater_apply.py`: `102/102`.  Full agora suite: `1521 passed` (the 64 `test_wss_support.py` errors are pre-existing test-interaction issues that pass when run alone -- unrelated to this change).

Once merged, agora-os will pick up the new APT package on the next `v*` tag.
