### PR TITLE
fix(os_updater): add 24h on-boot staging sweeper

### DIFF
--- a/os_updater/apply.py
+++ b/os_updater/apply.py
@@ -79,8 +79,9 @@ Error taxonomy (the service maps each to a distinct wire code):
 Staging contents (meta.json) are **not** cleaned up on failure —
 forensics trump disk reclaim, especially for ``bundle_invalid`` cases.
 The service-level cleanup that runs on ``agora-os-updater.service``
-start (24h TTL sweep, per Phase 2 deliverable §"Partial-download
-cleanup") catches everything eventually.
+start (24h TTL sweep, see
+:meth:`os_updater.service.OSUpdaterService.sweep_stale_staging`)
+catches everything eventually.
 """
 
 from __future__ import annotations

--- a/os_updater/downloader.py
+++ b/os_updater/downloader.py
@@ -17,9 +17,10 @@ Implementation notes (Phase 2):
   atomic rename onto the final path.
 * No HTTP Range / resume in v1. A partial download from a previous crash
   is reaped by the service's 24h on-boot staging sweeper (see
-  :mod:`os_updater.service`). The Range-resume contract in the
-  ``Downloader`` protocol docstring is aspirational; revisit if real
-  bandwidth-constrained installs start failing repeatedly.
+  :meth:`os_updater.service.OSUpdaterService.sweep_stale_staging`). The
+  Range-resume contract in the ``Downloader`` protocol docstring is
+  aspirational; revisit if real bandwidth-constrained installs start
+  failing repeatedly.
 * HTTP errors (non-200), aiohttp ``ClientError``, and local ``OSError``
   are all wrapped in :class:`BundleDownloadError` (a :class:`BundleError`
   subclass) so the service's :meth:`OSUpdaterService._classify_failure`

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -52,6 +52,7 @@ import asyncio
 import logging
 import re
 import shutil
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping, Optional, Protocol
@@ -87,6 +88,21 @@ from os_updater.state import (
 #: subdirectory named after ``release_id``. Lives on ``/data`` so it
 #: survives slot switches.
 DEFAULT_STAGING_ROOT = Path("/data/.update/staging")
+
+#: TTL for stale per-dispatch staging dirs reaped on daemon start.
+#: The happy-path cleanup in :meth:`OSUpdaterService.continue_after_promote`
+#: removes the staging dir as soon as forward migrations succeed; this
+#: sweep is the safety net that mops up everything else (failed
+#: updates, crashes mid-download, abandoned tryboot dirs) so ``/data``
+#: doesn't accumulate orphaned bundles forever.
+STAGING_SWEEP_TTL_SECONDS: float = 24 * 60 * 60
+
+#: Allowed prefix for the resolved staging root. The sweep refuses to
+#: operate if :attr:`staging_root` resolves outside this prefix, which
+#: blocks a symlink-based attack that would otherwise let a botched
+#: migration redirect the root-owned sweeper at the wrong tree. Tests
+#: override via the ``staging_sweep_allowed_prefix`` kwarg.
+DEFAULT_STAGING_SWEEP_ALLOWED_PREFIX = "/data/"
 
 #: Initial / max reconnect backoff in seconds for the WPS connection.
 #: Mirrors the existing cms_client transport behavior.
@@ -323,6 +339,8 @@ class OSUpdaterService:
         staging_root: Path = DEFAULT_STAGING_ROOT,
         migration_sentinel_path: Optional[Path] = None,
         promote_handshake_tick_sec: float = _PROMOTE_HANDSHAKE_TICK_SEC,
+        staging_sweep_ttl_sec: float = STAGING_SWEEP_TTL_SECONDS,
+        staging_sweep_allowed_prefix: str = DEFAULT_STAGING_SWEEP_ALLOWED_PREFIX,
     ) -> None:
         self.transport_factory = transport_factory
         self.event_sink: EventSink = event_sink or OutboxEventSink()
@@ -335,6 +353,8 @@ class OSUpdaterService:
         self.staging_root = staging_root
         self.migration_sentinel_path = migration_sentinel_path
         self._promote_handshake_tick_sec = promote_handshake_tick_sec
+        self.staging_sweep_ttl_sec = staging_sweep_ttl_sec
+        self.staging_sweep_allowed_prefix = staging_sweep_allowed_prefix
         self.state: UpdaterState = load_state(self.state_path)
         # Phase 2 / agora#215: the per-reconnect WPS transport, set by
         # :meth:`run` after every successful ``transport_factory()`` +
@@ -350,9 +370,9 @@ class OSUpdaterService:
     # -- public API used by tests and the run loop --------------------------
 
     def recover_on_start(self) -> None:
-        """Reset the FSM on daemon startup if we crashed mid-dispatch.
+        """Reset the FSM on daemon startup AND sweep stale staging dirs.
 
-        Three cases:
+        FSM reset (three cases):
 
         * ``idle`` / ``failed`` — nothing to do.
         * ``tryboot_running`` — this is the normal post-reboot resumption
@@ -363,13 +383,22 @@ class OSUpdaterService:
           the next dispatch arriving moves us back to ``DOWNLOADING``,
           per :data:`LEGAL_TRANSITIONS`. Emit a ``failed`` lifecycle
           event so the CMS sees what happened.
+
+        Then runs :meth:`sweep_stale_staging` so the 24h-TTL filesystem
+        reaper executes once per daemon start — failures intentionally
+        leave the staging dir on disk for forensics, and this sweep is
+        the safety net that keeps ``/data`` from accumulating orphaned
+        bundles forever. Sweep errors are logged and swallowed; the FSM
+        reset is the primary responsibility of this method.
         """
 
         s = self.state
         if s.fsm in (UpdaterFSMState.IDLE, UpdaterFSMState.FAILED):
+            self._safe_sweep_stale_staging()
             return
         if s.fsm is UpdaterFSMState.TRYBOOT_RUNNING:
             # Normal post-tryboot wake — leave alone for slot-confirm.
+            self._safe_sweep_stale_staging()
             return
 
         prior = s.fsm.value
@@ -383,6 +412,120 @@ class OSUpdaterService:
             reason=reason,
             state_path=self.state_path,
         )
+        self._safe_sweep_stale_staging()
+
+    def _safe_sweep_stale_staging(self) -> None:
+        """Run :meth:`sweep_stale_staging` with errors logged-and-swallowed.
+
+        The FSM-reset half of :meth:`recover_on_start` is the contract
+        the rest of the daemon depends on; a sweep failure must not
+        prevent daemon startup.
+        """
+
+        try:
+            self.sweep_stale_staging()
+        except Exception:
+            log.exception("staging sweep failed; continuing daemon startup")
+
+    def sweep_stale_staging(self) -> None:
+        """Reap stale per-dispatch staging dirs left behind by failures.
+
+        Iterates :attr:`staging_root` and removes any entry whose mtime
+        is older than :attr:`staging_sweep_ttl_sec` (24h default). The
+        active dispatch's staging dir (``self.state.staging_dir``) is
+        skipped defensively. This is load-bearing for tryboot wakes
+        (FSM == ``TRYBOOT_RUNNING``) and tolerates one extra dispatch
+        cycle of accumulation for stale-after-crash cases (where the
+        FSM is ``FAILED`` but ``staging_dir`` still references a dir
+        older than the TTL).
+
+        Defends against a symlink-based attack: if :attr:`staging_root`
+        is itself a symlink, or resolves outside the configured allowed
+        prefix (default ``/data/``), the sweep refuses to operate. The
+        daemon runs as root, so the cost of one extra check is trivial
+        compared to the blast radius of recursively rmtree'ing the
+        wrong tree.
+
+        Designed to be called once at daemon start (from
+        :meth:`recover_on_start`). Idempotent and safe to call again.
+        """
+
+        if self.staging_root.is_symlink():
+            log.error(
+                "staging_root %s is a symlink; refusing to sweep",
+                self.staging_root,
+            )
+            return
+
+        try:
+            resolved = self.staging_root.resolve()
+        except Exception:
+            log.exception(
+                "could not resolve staging root %s", self.staging_root
+            )
+            return
+
+        if not str(resolved).startswith(self.staging_sweep_allowed_prefix):
+            log.error(
+                "staging_root %s resolves to %s outside allowed prefix %r; "
+                "refusing to sweep",
+                self.staging_root,
+                resolved,
+                self.staging_sweep_allowed_prefix,
+            )
+            return
+
+        try:
+            entries = list(self.staging_root.iterdir())
+        except FileNotFoundError:
+            return  # Staging root is created lazily on first dispatch.
+        except Exception:
+            log.exception(
+                "could not list staging root %s", self.staging_root
+            )
+            return
+
+        now = time.time()
+        cutoff = now - self.staging_sweep_ttl_sec
+        active = self.state.staging_dir  # str or None
+        try:
+            active_resolved = Path(active).resolve() if active else None
+        except Exception:
+            active_resolved = None
+
+        for entry in entries:
+            try:
+                entry_resolved = entry.resolve()
+            except Exception:
+                entry_resolved = None
+
+            if active_resolved is not None and entry_resolved == active_resolved:
+                continue  # Don't reap the in-flight dispatch.
+
+            try:
+                mtime = entry.stat().st_mtime
+            except FileNotFoundError:
+                continue  # Raced with another sweeper / OS — fine.
+            except Exception:
+                log.exception("could not stat staging entry %s", entry)
+                continue
+
+            if mtime >= cutoff:
+                continue  # Fresh enough; keep for forensics.
+
+            age = now - mtime
+            try:
+                if entry.is_dir() and not entry.is_symlink():
+                    shutil.rmtree(entry, ignore_errors=True)
+                else:
+                    entry.unlink(missing_ok=True)
+                log.info(
+                    "swept stale staging entry %s (age=%.0fs)", entry, age
+                )
+            except Exception:
+                log.exception(
+                    "failed to remove stale staging entry %s", entry
+                )
 
     async def handle_dispatch(self, raw_msg: Any) -> None:
         """Drive a single dispatch end-to-end on the happy path.

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -1332,3 +1332,309 @@ class TestServiceRunBindsLoop:
 
         # Must not raise.
         asyncio.run(runner())
+
+
+# ── sweep_stale_staging ─────────────────────────────────────────────────────
+
+
+def _build_sweep_service(tmp_path, *, ttl_sec: float = 24 * 60 * 60):
+    """Service tuned for sweep tests: tmp staging root + tmp allowed prefix."""
+
+    state_path = tmp_path / "state.json"
+    staging_root = tmp_path / "staging"
+    return OSUpdaterService(
+        transport_factory=lambda: object(),
+        event_sink=_ListSink(),
+        current_version_provider=lambda: "1.0.0",
+        downloader=_OkStub(),
+        verifier=_OkStub(),
+        stager=_OkStub(),
+        migrator=_OkStub(),
+        state_path=state_path,
+        staging_root=staging_root,
+        staging_sweep_ttl_sec=ttl_sec,
+        staging_sweep_allowed_prefix=str(tmp_path),
+    )
+
+
+def _make_stale(path, *, age_sec: float):
+    """Force ``path``'s mtime to be ``age_sec`` seconds in the past."""
+
+    import os
+    import time
+
+    when = time.time() - age_sec
+    os.utime(path, (when, when))
+
+
+class TestSweepStaleStaging:
+    """Filesystem reaper for stale per-dispatch staging dirs.
+
+    Wiring: ``recover_on_start`` calls ``sweep_stale_staging``. The
+    integration test (#1) is the load-bearing one — it confirms the
+    sweep actually runs on daemon startup. The rest are unit tests
+    of the sweep behavior itself.
+    """
+
+    def test_recover_on_start_triggers_sweep(self, tmp_path):
+        """The whole point: ``recover_on_start`` reaps stale entries."""
+
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True, exist_ok=True)
+        stale = s.staging_root / "old_release"
+        fresh = s.staging_root / "new_release"
+        stale.mkdir()
+        fresh.mkdir()
+        _make_stale(stale, age_sec=48 * 60 * 60)
+
+        s.state = UpdaterState(fsm=UpdaterFSMState.IDLE)
+        save_state(s.state, s.state_path)
+
+        s.recover_on_start()
+
+        assert not stale.exists(), "stale entry should have been reaped"
+        assert fresh.exists(), "fresh entry must survive"
+
+    def test_no_staging_root_is_noop(self, tmp_path):
+        """Missing staging_root must not raise — created lazily later."""
+
+        s = _build_sweep_service(tmp_path)
+        assert not s.staging_root.exists()
+        # Must not raise.
+        s.sweep_stale_staging()
+        # Sweep didn't accidentally create it.
+        assert not s.staging_root.exists()
+
+    def test_empty_staging_root_is_noop(self, tmp_path):
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        s.sweep_stale_staging()
+        # No errors, root still there + empty.
+        assert s.staging_root.is_dir()
+        assert list(s.staging_root.iterdir()) == []
+
+    def test_recent_entry_kept(self, tmp_path):
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        recent = s.staging_root / "rel-recent"
+        recent.mkdir()
+        # mtime is now-ish; well within TTL.
+        s.sweep_stale_staging()
+        assert recent.exists()
+
+    def test_stale_entry_removed(self, tmp_path):
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        stale = s.staging_root / "rel-stale"
+        stale.mkdir()
+        (stale / "bundle.tar.zst").write_bytes(b"x" * 1024)
+        _make_stale(stale, age_sec=48 * 60 * 60)
+
+        s.sweep_stale_staging()
+
+        assert not stale.exists()
+
+    def test_mixed_entries_only_stale_removed(self, tmp_path):
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        stale1 = s.staging_root / "rel-stale-1"
+        stale2 = s.staging_root / "rel-stale-2"
+        fresh = s.staging_root / "rel-fresh"
+        for p in (stale1, stale2, fresh):
+            p.mkdir()
+        _make_stale(stale1, age_sec=48 * 60 * 60)
+        _make_stale(stale2, age_sec=25 * 60 * 60)
+
+        s.sweep_stale_staging()
+
+        assert not stale1.exists()
+        assert not stale2.exists()
+        assert fresh.exists()
+
+    def test_skips_active_staging_dir(self, tmp_path):
+        """Even a stale dir survives if state.staging_dir points at it."""
+
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        active = s.staging_root / "rel-active"
+        active.mkdir()
+        _make_stale(active, age_sec=48 * 60 * 60)
+
+        # Production stores it as the str() of the staging path; the
+        # Path(active).resolve() == entry.resolve() comparison must
+        # tolerate this exact shape.
+        s.state.staging_dir = str(active)
+        assert str(active) == s.state.staging_dir  # comparison shape sanity
+
+        s.sweep_stale_staging()
+        assert active.exists(), "active dispatch dir must not be swept"
+
+    def test_stale_file_unlinked(self, tmp_path):
+        """Non-dir entries (stray files) get unlinked when stale."""
+
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        stray = s.staging_root / "stray.tmp"
+        stray.write_bytes(b"junk")
+        _make_stale(stray, age_sec=48 * 60 * 60)
+
+        s.sweep_stale_staging()
+
+        assert not stray.exists()
+
+    def test_symlink_in_staging_root_not_followed(self, tmp_path):
+        """A symlink CHILD pointing outside staging_root must not get
+        its target dereferenced. We unlink the link itself if stale,
+        but leave the target tree intact."""
+
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+
+        # External tree the symlink would point at.
+        external = tmp_path / "outside"
+        external.mkdir()
+        sentinel = external / "DO_NOT_DELETE"
+        sentinel.write_text("guarded")
+
+        link = s.staging_root / "evil"
+        try:
+            link.symlink_to(external)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+        # Make the symlink itself stale -- on Linux lutimes is what
+        # os.utime(follow_symlinks=False) uses; we test the bare path.
+        import os
+
+        old = 48 * 60 * 60
+        try:
+            os.utime(link, (
+                __import__("time").time() - old,
+                __import__("time").time() - old,
+            ), follow_symlinks=False)
+        except (OSError, NotImplementedError):
+            # Some platforms can't lutimes; fall back to plain utime
+            # (which would follow the link, but external dir's mtime
+            # is harmless here — we're only checking the safety
+            # property).
+            pass
+
+        s.sweep_stale_staging()
+
+        # Sentinel survives — the symlink target tree is intact.
+        assert sentinel.exists()
+        assert sentinel.read_text() == "guarded"
+
+    def test_per_entry_failure_does_not_stop_sweep(self, tmp_path, monkeypatch):
+        """One bad entry must not poison the remaining entries."""
+
+        s = _build_sweep_service(tmp_path)
+        s.staging_root.mkdir(parents=True)
+        stale1 = s.staging_root / "stale-1"
+        stale2 = s.staging_root / "stale-2"
+        stale1.mkdir()
+        stale2.mkdir()
+        _make_stale(stale1, age_sec=48 * 60 * 60)
+        _make_stale(stale2, age_sec=48 * 60 * 60)
+
+        # Force rmtree to raise on stale1; stale2 must still be swept.
+        import os_updater.service as svc_mod
+
+        real_rmtree = svc_mod.shutil.rmtree
+        blown = {"hit": False}
+
+        def fake_rmtree(path, *args, **kwargs):
+            if str(path) == str(stale1) and not blown["hit"]:
+                blown["hit"] = True
+                raise PermissionError("simulated")
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(svc_mod.shutil, "rmtree", fake_rmtree)
+
+        s.sweep_stale_staging()
+
+        assert blown["hit"], "test setup did not exercise the failure path"
+        # stale2 still got cleaned up despite the stale1 explosion.
+        assert not stale2.exists()
+
+    def test_refuses_to_sweep_when_staging_root_is_symlink(
+        self, tmp_path, caplog
+    ):
+        """A symlinked staging_root is a botched-migration/attack signal —
+        sweep must refuse and log."""
+
+        import logging
+
+        real_root = tmp_path / "real_staging"
+        real_root.mkdir()
+        sentinel = real_root / "DO_NOT_TOUCH"
+        sentinel.write_text("guarded")
+        _make_stale(sentinel, age_sec=48 * 60 * 60)
+
+        link = tmp_path / "staging"
+        try:
+            link.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
+
+        s = _build_sweep_service(tmp_path)
+        assert s.staging_root == link
+
+        with caplog.at_level(logging.ERROR, logger="os_updater.service"):
+            s.sweep_stale_staging()
+
+        # Refused → no iterdir, sentinel intact.
+        assert sentinel.exists()
+        assert any(
+            "symlink" in r.message and "refusing" in r.message
+            for r in caplog.records
+        ), f"expected refusal log, got: {[r.message for r in caplog.records]}"
+
+    def test_refuses_to_sweep_when_staging_root_escapes_allowed_prefix(
+        self, tmp_path, caplog
+    ):
+        """If staging_root resolves outside the allowed prefix, refuse.
+
+        Covers the production safety check both directions:
+        - When ``allowed_prefix='/data/'`` and staging_root is under
+          ``tmp_path`` (escape) → refuse.
+        - When ``allowed_prefix=tmp_path`` (matching) → proceed.
+        """
+
+        import logging
+
+        # Case A: prefix='/data/' rejects a tmp_path root.
+        s_reject = OSUpdaterService(
+            transport_factory=lambda: object(),
+            event_sink=_ListSink(),
+            current_version_provider=lambda: "1.0.0",
+            downloader=_OkStub(),
+            verifier=_OkStub(),
+            stager=_OkStub(),
+            migrator=_OkStub(),
+            state_path=tmp_path / "state.json",
+            staging_root=tmp_path / "staging",
+            staging_sweep_allowed_prefix="/data/",
+        )
+        s_reject.staging_root.mkdir(parents=True)
+        stale = s_reject.staging_root / "rel-stale"
+        stale.mkdir()
+        _make_stale(stale, age_sec=48 * 60 * 60)
+
+        with caplog.at_level(logging.ERROR, logger="os_updater.service"):
+            s_reject.sweep_stale_staging()
+
+        assert stale.exists(), "sweep should have refused due to prefix escape"
+        assert any(
+            "outside allowed prefix" in r.message for r in caplog.records
+        )
+        caplog.clear()
+
+        # Case B: matching prefix lets the same sweep proceed.
+        s_ok = _build_sweep_service(tmp_path)
+        s_ok.staging_root = tmp_path / "staging2"
+        s_ok.staging_root.mkdir()
+        stale2 = s_ok.staging_root / "rel-stale-2"
+        stale2.mkdir()
+        _make_stale(stale2, age_sec=48 * 60 * 60)
+        s_ok.sweep_stale_staging()
+        assert not stale2.exists(), "matching-prefix sweep should have succeeded"


### PR DESCRIPTION
## Summary

Both `os_updater/apply.py` and `os_updater/downloader.py` reference a service-level "24h on-boot staging sweeper" that **does not actually exist**. On failure paths, the per-dispatch staging dir at `/data/.update/staging/<release_id>/` is intentionally preserved for forensics, with the docstrings promising a startup sweep would mop it up eventually. The sweep was never implemented; orphan bundles (~1 GB each) accumulate on `/data` forever after every failed OTA. Postmortems for v0.0.20 and v0.0.26 went through multiple failed-update cycles, leaving stale bundles behind.

This PR makes the docstring true.

## What changed

### `os_updater/service.py`
- New constant `STAGING_SWEEP_TTL_SECONDS = 24 * 60 * 60`.
- New constant `DEFAULT_STAGING_SWEEP_ALLOWED_PREFIX = "/data/"` (test-overridable).
- New kwargs on `OSUpdaterService.__init__`: `staging_sweep_ttl_sec`, `staging_sweep_allowed_prefix`.
- New method `OSUpdaterService.sweep_stale_staging()`:
  - Refuses to operate if `staging_root.is_symlink()` (symlink-attack defense — the daemon runs as root).
  - Refuses if `staging_root.resolve()` escapes the allowed prefix.
  - Iterates `staging_root`, skips the active dispatch (resolved-Path comparison, robust to `Path` vs `str` shape), removes any entry with mtime > TTL via `shutil.rmtree` / `unlink`.
  - Per-entry exception handling: one bad entry can't stop the sweep.
- Wired into `recover_on_start()` via `_safe_sweep_stale_staging()` (errors logged and swallowed so the FSM reset is never blocked).

### `os_updater/apply.py`, `os_updater/downloader.py`
- Updated stale "Phase 2 deliverable" pointer to reference the real `OSUpdaterService.sweep_stale_staging` method.

### `tests/test_os_updater_service.py`
12 new tests in `TestSweepStaleStaging`:
1. `test_recover_on_start_triggers_sweep` — integration: confirms the wiring.
2. `test_no_staging_root_is_noop` — root missing, no error.
3. `test_empty_staging_root_is_noop` — root present, empty.
4. `test_recent_entry_kept` — mtime < TTL survives.
5. `test_stale_entry_removed` — mtime > TTL reaped.
6. `test_mixed_entries_only_stale_removed` — selectivity sanity.
7. `test_skips_active_staging_dir` — includes Path-vs-str comparison shape assertion.
8. `test_stale_file_unlinked` — non-dir entries unlinked.
9. `test_symlink_in_staging_root_not_followed` — Round-1 symlink-target test (skipped on Windows).
10. `test_per_entry_failure_does_not_stop_sweep` — failure isolation.
11. `test_refuses_to_sweep_when_staging_root_is_symlink` — Round-2 safety gate (skipped on Windows).
12. `test_refuses_to_sweep_when_staging_root_escapes_allowed_prefix` — Round-2 safety gate, both reject and accept paths.

All 60 tests in `test_os_updater_service.py` pass locally; 400 tests across the whole `os_updater` test suite pass.

## Design

Process was three rounds of duck review on the implementation plan (`files/staging-sweeper-plan.md`):

- **Round 1 (revise):** 3 blockers + 4 mediums + 2 nits. Author rejected 2 blockers after code verification (mtime IS bumped on each `.tmp` create/rename in the dir; sweep runs strictly before WPS recv loop). Accepted the third (`continue_after_promote` migrator-failure leak — documented as covered by this sweep).
- **Round 2 (revise):** Round 1 self-corrections + 1 new critical (symlink-attack vector against root-running daemon) + 1 new medium (resolved-Path comparison upgrade). Both folded in.
- **Round 3 (approve):** No drops, no new issues, ship it.

## Failure-path cleanup map

| Path | Cleanup behavior |
|------|------------------|
| Happy path (`continue_after_promote` → migrator returns) | ✅ Immediate `rmtree` at `service.py` |
| Download / verify / stage / tryboot failure | ❌ → ✅ via this sweep (24h TTL) |
| Migrator failure (`continue_after_promote` except path) | ❌ → ✅ via this sweep |
| Daemon crash mid-dispatch | ❌ → ✅ via this sweep |
| Active dispatch (FSM == `TRYBOOT_RUNNING` after reboot) | Skipped defensively |
| `staging_root` is a symlink (attack / botched migration) | Sweep refuses, logs error |
| `staging_root` resolves outside `/data/` | Sweep refuses, logs error |

## Risk

Low. The sweep:
- Runs strictly before the WPS recv loop, so no dispatch can arrive during the sweep.
- Skips the active dispatch via resolved-Path comparison.
- Refuses to operate on a symlinked or escaped root.
- Uses `shutil.rmtree(..., ignore_errors=True)` with per-entry exception isolation.
- Sweep errors are logged-and-swallowed at the `recover_on_start` call site so a sweep regression can't block daemon startup.