### PR TITLE
feat(player): replace cage with sway for webpage rendering

### DIFF
--- a/packaging/debian/control.in
+++ b/packaging/debian/control.in
@@ -24,7 +24,7 @@ Depends: python3 (>= 3.11),
  dnsmasq,
  avahi-daemon,
  mpv,
- cage,
+ sway,
  chromium
 Recommends: gstreamer1.0-v4l2
 Maintainer: sslivins

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -107,21 +107,14 @@ if command -v plymouth-set-default-theme &>/dev/null; then
     plymouth-set-default-theme splash 2>/dev/null || true
 fi
 
-# ── Transparent cursor for Cage (webpage rendering) ──
-# Cage/wlroots renders its own compositor cursor using Adwaita theme files.
-# Overwrite them with a pre-built transparent cursor shipped in the package.
-ADWAITA_DIR="/usr/share/icons/Adwaita/cursors"
-BLANK_CURSOR="${AGORA_BASE}/src/player/extensions/hide-cursor/blank_cursor"
-if [ -d "${ADWAITA_DIR}" ] && [ -f "${BLANK_CURSOR}" ]; then
-    if [ ! -f "${ADWAITA_DIR}/.agora-backup-done" ]; then
-        cp -a "${ADWAITA_DIR}" "${ADWAITA_DIR}.bak" 2>/dev/null || true
-        touch "${ADWAITA_DIR}/.agora-backup-done"
-    fi
-    for cursor_file in "${ADWAITA_DIR}"/*; do
-        [ -f "${cursor_file}" ] && [ "$(basename "${cursor_file}")" != ".agora-backup-done" ] && \
-            cp "${BLANK_CURSOR}" "${cursor_file}"
-    done
-    echo "Agora: installed transparent cursors for Cage/Wayland kiosk mode"
+# ── Mark legacy cage as auto-installed so apt autoremove can drop it ──
+# Cage was replaced by sway as the webpage-rendering compositor; existing
+# devices keep cage installed forever otherwise. Flipping the auto/manual
+# bit lets the next `apt autoremove` clean it up without forcing the
+# removal here. Held packages are unaffected — `apt-mark hold` and
+# `apt-mark auto` are orthogonal.
+if dpkg -s cage >/dev/null 2>&1; then
+    apt-mark auto cage >/dev/null 2>&1 || true
 fi
 
 # ── Kernel command line: quiet boot + splash ──

--- a/player/service.py
+++ b/player/service.py
@@ -6,11 +6,13 @@ import json
 import logging
 import os
 import queue
+import shlex
 import signal
 import socket
 import subprocess
 import threading
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -196,12 +198,13 @@ class AgoraPlayer:
 
         self.pipeline: Optional[Gst.Pipeline] = None
         self._mpv_process: Optional[subprocess.Popen] = None
-        self._cage_process: Optional[subprocess.Popen] = None
+        self._sway_process: Optional[subprocess.Popen] = None
+        self._sway_scope_unit: Optional[str] = None
         self.loop = GLib.MainLoop()
         self.current_desired: Optional[DesiredState] = None
         self._current_path: Optional[Path] = None  # file being played
         self._current_mtime: Optional[float] = None  # mtime when pipeline was built
-        # URL currently rendered by Cage (webpage mode) — None otherwise.
+        # URL currently rendered by Sway (webpage mode) — None otherwise.
         self._current_url: Optional[str] = None
         # Last desired state successfully applied to the renderer.
         # Used by ``_already_satisfied`` to avoid redundant rebuilds.
@@ -602,7 +605,7 @@ class AgoraPlayer:
         # teardown. The listener is shutdown explicitly from the run()
         # signal handler and finally clause instead.
         self._stop_mpv()
-        self._stop_cage()
+        self._stop_sway()
         if self.pipeline:
             bus = self.pipeline.get_bus()
             if bus:
@@ -616,7 +619,7 @@ class AgoraPlayer:
         self._current_path = None
         self._current_mtime = None
 
-    # ── Cage+Chromium (webpage rendering) ──
+    # ── Sway+Chromium (webpage rendering) ──
 
     # Boards where aggressive Chromium memory-saver flags are applied.
     # These boards either have ≤1 GB RAM (Zero 2 W) or are memory-constrained
@@ -624,6 +627,9 @@ class AgoraPlayer:
     # Pi 5 is excluded: it has ≥4 GB and hardware-accelerated compositing.
     # UNKNOWN is included defensively (same rationale as gstreamer fallback).
     _LOWMEM_BOARDS = frozenset({Board.ZERO_2W, Board.PI_4, Board.UNKNOWN})
+
+    _SWAY_RUNTIME_DIR = "/tmp/agora-sway-run"
+    _SWAY_CONFIG_PATH = "/tmp/agora-sway-run/sway.conf"
 
     @staticmethod
     def _chromium_lowmem_flags() -> list[str]:
@@ -657,17 +663,9 @@ class AgoraPlayer:
             "--js-flags=--max-old-space-size=96 --max-semi-space-size=2",
         ]
 
-    def _start_cage(self, url: str) -> None:
-        """Launch Cage + Chromium in kiosk mode to render a URL."""
-        self._stop_cage()
-        self._teardown()  # Stop any mpv/gstreamer pipeline
-
-        env = os.environ.copy()
-        env["XDG_RUNTIME_DIR"] = "/tmp/cage-run"
-        os.makedirs("/tmp/cage-run", exist_ok=True)
-
+    def _chromium_kiosk_argv(self, url: str) -> list[str]:
+        """Build the chromium argv for a kiosk-mode URL render."""
         cmd = [
-            "cage", "-d", "--",
             "chromium", "--no-sandbox", "--kiosk", "--noerrdialogs",
             "--disable-translate", "--disable-infobars", "--incognito",
             "--hide-scrollbars", "--autoplay-policy=no-user-gesture-required",
@@ -678,10 +676,96 @@ class AgoraPlayer:
             "--load-extension=/opt/agora/src/player/extensions/hide-cursor",
             url,
         ])
+        return cmd
 
-        logger.info("Starting Cage+Chromium for URL: %s", url)
+    def _write_sway_config(self, url: str) -> Path:
+        """Render the sway config for a URL to the 0o700 runtime dir.
+
+        The config lives inside the same private runtime directory used for
+        ``XDG_RUNTIME_DIR``. We write it with ``O_NOFOLLOW`` so a pre-existing
+        symlink at the target path can't redirect the (URL-containing) body.
+        """
+        chromium_cmd = self._chromium_kiosk_argv(url)
+        exec_line = "exec " + shlex.join(chromium_cmd)
+        body = (
+            "output * bg #000000 solid_color\n"
+            "seat * hide_cursor 1\n"
+            "default_border none\n"
+            "default_floating_border none\n"
+            "hide_edge_borders both\n"
+            'for_window [shell=".*"] fullscreen enable, border none\n'
+            "\n" + exec_line + "\n"
+        )
+        runtime_dir = Path(self._SWAY_RUNTIME_DIR)
+        runtime_dir.mkdir(mode=0o700, exist_ok=True)
         try:
-            self._cage_process = subprocess.Popen(
+            os.chmod(runtime_dir, 0o700)
+        except OSError:
+            pass
+        conf_path = Path(self._SWAY_CONFIG_PATH)
+        # O_NOFOLLOW is the meaningful safety bit (refuse to follow a
+        # symlinked target); on platforms that lack it (Windows test
+        # runners) the flag is 0 and the rest still works.
+        o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(
+            str(conf_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | o_nofollow,
+            0o600,
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(body)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        return conf_path
+
+    def _start_sway(self, url: str) -> None:
+        """Launch sway + Chromium in kiosk mode to render a URL.
+
+        sway is wrapped in a transient systemd scope so the cgroup tracks
+        the whole process tree, including chromium grandchildren that
+        sway's ``exec`` double-forks + setsids out of any pgrp. Without
+        the scope, ``killpg`` on the sway pid would leak chromium to
+        init on hung-renderer cleanup and the next start would fail to
+        acquire ``/dev/dri/cardX``.
+        """
+        self._stop_sway()
+        self._teardown()  # Stop any mpv/gstreamer pipeline
+
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self._SWAY_RUNTIME_DIR
+        # _write_sway_config ensures the runtime dir exists at 0o700.
+
+        try:
+            conf = self._write_sway_config(url)
+        except Exception as e:
+            logger.error("Failed to write sway config: %s", e)
+            self._update_current(error=f"Sway config write failed: {e}")
+            self._show_splash()
+            return
+
+        # Per-invocation unique scope unit name. A stable name would
+        # collide if a previous _stop_sway ever failed to fully reap the
+        # scope, causing systemd-run to fail with "unit already exists"
+        # and trapping the back-off retry loop indefinitely.
+        self._sway_scope_unit = f"agora-sway-{uuid.uuid4().hex[:8]}.scope"
+
+        cmd = [
+            "systemd-run", "--scope", "--quiet",
+            "--unit", self._sway_scope_unit, "--collect",
+            "sway", "-c", str(conf),
+        ]
+
+        logger.info(
+            "Starting Sway+Chromium for URL: %s (scope=%s)",
+            url, self._sway_scope_unit,
+        )
+        try:
+            self._sway_process = subprocess.Popen(
                 cmd, env=env,
                 start_new_session=True,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -690,39 +774,54 @@ class AgoraPlayer:
             self._current_mtime = None
             self._current_url = url
             self._update_current(mode=PlaybackMode.PLAY, asset=url)
-            # Schedule periodic monitoring to detect Cage/Chromium crashes
-            GLib.timeout_add_seconds(3, self._monitor_cage, url)
+            # Schedule periodic monitoring to detect sway/Chromium crashes
+            GLib.timeout_add_seconds(3, self._monitor_sway, url)
         except Exception as e:
-            logger.error("Failed to start Cage+Chromium: %s", e)
-            self._update_current(error=f"Cage startup failed: {e}")
+            logger.error("Failed to start Sway+Chromium: %s", e)
+            self._sway_process = None
+            self._sway_scope_unit = None
+            self._update_current(error=f"Sway startup failed: {e}")
             self._show_splash()
 
-    def _stop_cage(self) -> None:
-        """Stop Cage+Chromium process if running."""
-        proc = self._cage_process
-        if proc and proc.poll() is None:
-            logger.info("Stopping Cage+Chromium (PID %d)", proc.pid)
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except (OSError, ProcessLookupError):
-                pass
+    def _stop_sway(self) -> None:
+        """Stop sway+Chromium scope if running.
+
+        Tears down via ``systemctl stop`` on the transient scope so the
+        cgroup signals every descendant — including double-forked
+        chromium grandchildren that aren't reachable via the sway pgrp.
+        """
+        proc = self._sway_process
+        unit = self._sway_scope_unit
+        if proc and proc.poll() is None and unit:
+            logger.info(
+                "Stopping Sway+Chromium scope=%s pid=%d", unit, proc.pid,
+            )
+            subprocess.run(
+                ["systemctl", "stop", unit],
+                timeout=8, check=False,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
             try:
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except (OSError, ProcessLookupError):
-                    pass
+                # Cgroup KILL fallback — reaches double-forked grandchildren
+                # that pgrp-based kills can't see.
+                subprocess.run(
+                    ["systemctl", "kill", "-s", "SIGKILL", unit],
+                    timeout=5, check=False,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
                 try:
                     proc.wait(timeout=3)
                 except subprocess.TimeoutExpired:
                     pass
-        self._cage_process = None
+        self._sway_process = None
+        self._sway_scope_unit = None
         self._current_url = None
 
-    def _monitor_cage(self, url: str) -> bool:
-        """Periodic check for Cage process exit. Returns False to stop timer."""
-        if self._cage_process is None:
+    def _monitor_sway(self, url: str) -> bool:
+        """Periodic check for sway process exit. Returns False to stop timer."""
+        if self._sway_process is None:
             return False
 
         # Stop monitoring if desired state no longer wants this URL
@@ -733,15 +832,16 @@ class AgoraPlayer:
         ):
             return False
 
-        retcode = self._cage_process.poll()
+        retcode = self._sway_process.poll()
         if retcode is None:
             # Still running
             return True
 
-        # Cage exited unexpectedly
-        self._cage_process = None
-        error_msg = f"Cage exited unexpectedly (code {retcode})"
-        logger.error("Cage crashed for %s: %s", url, error_msg)
+        # sway exited unexpectedly
+        self._sway_process = None
+        self._sway_scope_unit = None
+        error_msg = f"Sway exited unexpectedly (code {retcode})"
+        logger.error("Sway crashed for %s: %s", url, error_msg)
         self._update_current(error=error_msg)
 
         # Retry with exponential backoff (same pattern as mpv)
@@ -1571,7 +1671,7 @@ class AgoraPlayer:
     def _start_stream(self, url: str) -> None:
         """Launch mpv for streaming video playback (HLS, DASH, RTMP, etc.).
 
-        Stops any existing player (mpv, Cage, GStreamer) and starts mpv
+        Stops any existing player (mpv, Sway, GStreamer) and starts mpv
         with stream-optimised settings.  Monitoring reuses _monitor_mpv
         with the URL as the asset name for retry/splash fallback.
         """
@@ -1907,7 +2007,7 @@ class AgoraPlayer:
         # Clear any armed scheduled-pending so a stale event arriving from
         # the file we're about to replace can't re-trigger _show_splash.
         self._scheduled_pending = None
-        self._stop_cage()
+        self._stop_sway()
         error = self._pending_error
         self._pending_error = None
         splash = self._find_splash()
@@ -1984,7 +2084,7 @@ class AgoraPlayer:
         started_at: Optional[datetime] = None,
     ) -> None:
         pipeline_state = "NULL"
-        if self._cage_process and self._cage_process.poll() is None:
+        if self._sway_process and self._sway_process.poll() is None:
             pipeline_state = "PLAYING"
         elif self._mpv_process and self._mpv_process.poll() is None:
             pipeline_state = "PLAYING"
@@ -2016,7 +2116,7 @@ class AgoraPlayer:
         is_active = (
             self.pipeline
             or (self._mpv_process and self._mpv_process.poll() is None)
-            or (self._cage_process and self._cage_process.poll() is None)
+            or (self._sway_process and self._sway_process.poll() is None)
         )
         if (
             not is_active
@@ -2098,15 +2198,15 @@ class AgoraPlayer:
         proc = self._mpv_process
         return bool(proc and proc.poll() is None)
 
-    def _cage_alive(self) -> bool:
-        proc = self._cage_process
+    def _sway_alive(self) -> bool:
+        proc = self._sway_process
         return bool(proc and proc.poll() is None)
 
     def _pipeline_alive(self) -> bool:
         return self.pipeline is not None
 
     def _renderer_alive(self) -> bool:
-        return self._mpv_alive() or self._cage_alive() or self._pipeline_alive()
+        return self._mpv_alive() or self._sway_alive() or self._pipeline_alive()
 
     def _is_showing_splash(self) -> bool:
         """True iff the current renderer state is the splash file."""
@@ -2215,7 +2315,7 @@ class AgoraPlayer:
         if kind == "webpage":
             return (
                 self._slideshow is None
-                and self._cage_alive()
+                and self._sway_alive()
                 and self._current_url == desired.url
             )
         if kind == "slideshow":
@@ -2309,10 +2409,10 @@ class AgoraPlayer:
                     self._applied_desired = desired.model_copy(deep=True)
                 return
 
-            # Webpage rendering via Cage+Chromium
+            # Webpage rendering via Sway+Chromium
             self.current_desired = desired
-            self._start_cage(desired.url)
-            if self._cage_alive() and self._current_url == desired.url:
+            self._start_sway(desired.url)
+            if self._sway_alive() and self._current_url == desired.url:
                 self._applied_desired = desired.model_copy(deep=True)
             return
 

--- a/tests/test_loop_count.py
+++ b/tests/test_loop_count.py
@@ -75,7 +75,8 @@ def player():
         p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
         p.pipeline = None
         p._mpv_process = None
-        p._cage_process = None
+        p._sway_process = None
+        p._sway_scope_unit = None
         p.current_desired = None
         p._loops_completed = 0
         p._health_retries = 0

--- a/tests/test_player_service.py
+++ b/tests/test_player_service.py
@@ -1,8 +1,9 @@
 """Tests for player service — pipeline selection logic."""
 
 import sys
+import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock, call
+from unittest.mock import ANY, MagicMock, patch, PropertyMock, call
 
 import pytest
 
@@ -24,7 +25,8 @@ def player():
         p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
         p.pipeline = None
         p._mpv_process = None
-        p._cage_process = None
+        p._sway_process = None
+        p._sway_scope_unit = None
         p.current_desired = None
         p._plymouth_quit = False
         p._current_path = None
@@ -56,7 +58,8 @@ def mpv_player():
         p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
         p.pipeline = None
         p._mpv_process = None
-        p._cage_process = None
+        p._sway_process = None
+        p._sway_scope_unit = None
         p.current_desired = None
         p._plymouth_quit = False
         p._current_path = None
@@ -1420,7 +1423,7 @@ class TestDisplayDetection:
         )
         write_state(state_file, initial)
 
-        # Splash: no GStreamer pipeline, no mpv or cage process.
+        # Splash: no GStreamer pipeline, no mpv or sway process.
         player.pipeline = None
         player.current_desired = DesiredState(mode=PlaybackMode.SPLASH)
         self._mock_probe(player, [("HDMI-0", True)])
@@ -2799,7 +2802,7 @@ class TestMutePolicy:
              patch.object(mpv_player, "_update_current"), \
              patch.object(mpv_player, "_teardown"), \
              patch.object(mpv_player, "_quit_plymouth"), \
-             patch.object(mpv_player, "_stop_cage"), \
+             patch.object(mpv_player, "_stop_sway"), \
              patch("player.service.subprocess") as mock_subprocess:
             mock_popen = MagicMock()
             mock_popen.pid = 999
@@ -2988,42 +2991,251 @@ class TestChromiumLowMemFlags:
         assert any(f.startswith("--js-flags=") and "max-old-space-size" in f for f in flags)
         assert any(f.startswith("--disable-features=") and "site-per-process" in f for f in flags)
 
-    def test_start_cage_applies_flags_on_zero2w(self, player, svc_module):
-        """On Zero 2 W the low-mem flag set is injected into the cage command."""
+    def test_start_sway_applies_flags_on_zero2w(self, player, svc_module, tmp_path):
+        """On Zero 2 W the low-mem flag set is injected into the sway config."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
         with patch.object(svc_module, "get_board", return_value=svc_module.Board.ZERO_2W), \
-             patch.object(player, "_stop_cage"), \
+             patch.object(player, "_stop_sway"), \
              patch.object(player, "_teardown"), \
              patch.object(player, "_update_current"), \
-             patch("player.service.subprocess.Popen") as mock_popen, \
-             patch("player.service.os.makedirs"):
+             patch.object(type(player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
             mock_popen.return_value = MagicMock()
-            player._start_cage("https://example.com")
+            player._start_sway("https://example.com")
 
-        args, _ = mock_popen.call_args
-        cmd = args[0]
-        assert "--no-memcheck" in cmd
-        assert "--process-per-site" in cmd
-        assert "--disable-gpu" in cmd
+        body = conf_path.read_text()
+        assert "--no-memcheck" in body
+        assert "--process-per-site" in body
+        assert "--disable-gpu" in body
 
-    def test_start_cage_omits_flags_on_pi5(self, mpv_player, svc_module):
-        """On Pi 5 the low-mem flag set is NOT applied."""
+    def test_start_sway_omits_flags_on_pi5(self, mpv_player, svc_module, tmp_path):
+        """On Pi 5 the low-mem flag set is NOT applied to the sway config."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
         with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
-             patch.object(mpv_player, "_stop_cage"), \
+             patch.object(mpv_player, "_stop_sway"), \
              patch.object(mpv_player, "_teardown"), \
              patch.object(mpv_player, "_update_current"), \
-             patch("player.service.subprocess.Popen") as mock_popen, \
-             patch("player.service.os.makedirs"):
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
             mock_popen.return_value = MagicMock()
-            mpv_player._start_cage("https://example.com")
+            mpv_player._start_sway("https://example.com")
+
+        body = conf_path.read_text()
+        assert "--no-memcheck" not in body
+        assert "--process-per-site" not in body
+        assert "--disable-gpu" not in body
+        # Baseline flags still present
+        assert "--kiosk" in body
+        assert "https://example.com" in body
+
+
+class TestSwayRenderer:
+    """Tests for the sway+chromium webpage-rendering path.
+
+    Covers config rendering, the systemd-run scope wrapping (so the
+    cgroup tears down double-forked chromium grandchildren), the
+    teardown contract, and the lifecycle edge cases (idempotent stop,
+    stop-old-on-start, Popen-exception splash fallback).
+    """
+
+    @pytest.fixture
+    def svc_module(self):
+        with patch.dict("sys.modules", {
+            "gi": MagicMock(),
+            "gi.repository": MagicMock(),
+        }):
+            import importlib
+            import player.service as svc
+            importlib.reload(svc)
+            yield svc
+
+    def test_start_sway_writes_config_with_url(self, mpv_player, svc_module, tmp_path):
+        """Rendered config contains the URL, kiosk flags, and hide_cursor."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_sway("https://example.com/page")
+
+        body = conf_path.read_text()
+        assert "https://example.com/page" in body
+        assert "--kiosk" in body
+        assert "seat * hide_cursor 1" in body
+        assert 'for_window [shell=".*"] fullscreen enable, border none' in body
+
+    def test_start_sway_shell_quotes_url(self, mpv_player, svc_module, tmp_path):
+        """URLs with sh metacharacters must be properly quoted in the exec line.
+
+        Sway runs ``exec`` lines through ``/bin/sh -c``, so unquoted ``&``,
+        ``;``, ``#``, ``$``, ``"`` or ``'`` in a URL would break parsing
+        and could detach a background process or comment out the URL.
+        """
+        import shlex as _shlex
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        tricky = "https://example.com/p?a=1&b=2;c=3#frag&q=$x\"y'z"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_sway(tricky)
+
+        body = conf_path.read_text()
+        exec_line = [ln for ln in body.splitlines() if ln.startswith("exec ")][0]
+        assert _shlex.quote(tricky) in exec_line
+
+    def test_start_sway_sets_xdg_runtime_dir(self, mpv_player, svc_module, tmp_path):
+        """XDG_RUNTIME_DIR points at the 0o700 runtime dir; dir is created at 0o700."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_sway("https://example.com")
+
+        _, kwargs = mock_popen.call_args
+        assert kwargs["env"]["XDG_RUNTIME_DIR"] == str(runtime_dir)
+        assert runtime_dir.is_dir()
+        # Mode check is best-effort: Windows mkdir doesn't honor mode bits.
+        if sys.platform != "win32":
+            assert (runtime_dir.stat().st_mode & 0o777) == 0o700
+
+    def test_start_sway_uses_systemd_run_scope(self, mpv_player, svc_module, tmp_path):
+        """Popen argv must wrap sway in a transient systemd scope (M1 cgroup fix).
+
+        The cgroup-tracking scope is what reaches double-forked chromium
+        grandchildren that escape sway's own pgrp; a regression here would
+        leak chromium to init on hung-renderer cleanup.
+        """
+        import re
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_sway("https://example.com")
 
         args, _ = mock_popen.call_args
         cmd = args[0]
-        assert "--no-memcheck" not in cmd
-        assert "--process-per-site" not in cmd
-        assert "--disable-gpu" not in cmd
-        # Baseline flags still present
-        assert "--kiosk" in cmd
-        assert "https://example.com" in cmd
+        assert cmd[0:4] == ["systemd-run", "--scope", "--quiet", "--unit"]
+        assert re.fullmatch(r"agora-sway-[0-9a-f]{8}\.scope", cmd[4])
+        assert cmd[5:9] == ["--collect", "sway", "-c", str(conf_path)]
+        assert mpv_player._sway_scope_unit == cmd[4]
+
+    def test_stop_sway_uses_systemctl_stop(self, mpv_player, svc_module):
+        """_stop_sway must call systemctl stop on the scope unit."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_proc.wait.return_value = 0
+        mpv_player._sway_process = mock_proc
+        mpv_player._sway_scope_unit = "agora-sway-abcdef01.scope"
+
+        with patch("player.service.subprocess.run") as mock_run:
+            mpv_player._stop_sway()
+
+        mock_run.assert_any_call(
+            ["systemctl", "stop", "agora-sway-abcdef01.scope"],
+            timeout=8, check=False,
+            stdout=ANY, stderr=ANY,
+        )
+        assert mpv_player._sway_process is None
+        assert mpv_player._sway_scope_unit is None
+
+    def test_stop_sway_kills_on_systemctl_stop_timeout(self, mpv_player, svc_module):
+        """When proc.wait times out after systemctl stop, fall back to systemctl kill."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        # First wait times out (forcing the kill path), second wait returns.
+        mock_proc.wait.side_effect = [subprocess.TimeoutExpired("sway", 5), 0]
+        mpv_player._sway_process = mock_proc
+        mpv_player._sway_scope_unit = "agora-sway-deadbeef.scope"
+
+        with patch("player.service.subprocess.run") as mock_run:
+            mpv_player._stop_sway()
+
+        kill_calls = [
+            c for c in mock_run.call_args_list
+            if c.args and c.args[0][:2] == ["systemctl", "kill"]
+        ]
+        assert kill_calls, "expected systemctl kill -s SIGKILL fallback"
+        assert kill_calls[0].args[0] == [
+            "systemctl", "kill", "-s", "SIGKILL", "agora-sway-deadbeef.scope",
+        ]
+
+    def test_stop_sway_is_noop_when_not_running(self, mpv_player, svc_module):
+        """Calling _stop_sway with no live process must not call systemctl."""
+        mpv_player._sway_process = None
+        mpv_player._sway_scope_unit = None
+        with patch("player.service.subprocess.run") as mock_run:
+            mpv_player._stop_sway()  # must not raise
+        mock_run.assert_not_called()
+        assert mpv_player._sway_process is None
+        assert mpv_player._sway_scope_unit is None
+
+    def test_start_sway_stops_previous_instance(self, mpv_player, svc_module, tmp_path):
+        """Each _start_sway must tear down a prior instance first."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway") as mock_stop, \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current"), \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            mpv_player._start_sway("https://example.com/a")
+            mpv_player._start_sway("https://example.com/b")
+        assert mock_stop.call_count == 2
+
+    def test_start_sway_popen_exception_shows_splash(self, mpv_player, svc_module, tmp_path):
+        """When systemd-run Popen raises, fall back to splash and clear state."""
+        runtime_dir = tmp_path / "run"
+        conf_path = runtime_dir / "sway.conf"
+        with patch.object(svc_module, "get_board", return_value=svc_module.Board.PI_5), \
+             patch.object(mpv_player, "_stop_sway"), \
+             patch.object(mpv_player, "_teardown"), \
+             patch.object(mpv_player, "_update_current") as mock_update, \
+             patch.object(mpv_player, "_show_splash") as mock_splash, \
+             patch.object(type(mpv_player), "_SWAY_RUNTIME_DIR", str(runtime_dir)), \
+             patch.object(type(mpv_player), "_SWAY_CONFIG_PATH", str(conf_path)), \
+             patch("player.service.subprocess.Popen", side_effect=OSError("nope")):
+            mpv_player._start_sway("https://example.com")
+
+        mock_splash.assert_called_once()
+        assert mpv_player._sway_process is None
+        assert mpv_player._sway_scope_unit is None
+        error_calls = [
+            c for c in mock_update.call_args_list
+            if c.kwargs.get("error") and "Sway startup failed" in c.kwargs["error"]
+        ]
+        assert error_calls, "expected an error-bearing _update_current call"
 
 
 class TestSplashConfigWatch:

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -33,7 +33,8 @@ def mpv_player(tmp_path):
         p = svc.AgoraPlayer.__new__(svc.AgoraPlayer)
         p.pipeline = None
         p._mpv_process = None
-        p._cage_process = None
+        p._sway_process = None
+        p._sway_scope_unit = None
         p.current_desired = None
         p._plymouth_quit = False
         p._current_path = None
@@ -509,7 +510,7 @@ class TestScheduledLoopCountIpcDriven:
             "entry_id": 1, "generation": 1, "asset_name": "a.mp4",
             "target_count": 5, "completed_count": 2,
         }
-        player._stop_cage = MagicMock()
+        player._stop_sway = MagicMock()
         player._find_splash = MagicMock(return_value=None)
         svc.AgoraPlayer._show_splash(player)
         assert player._scheduled_pending is None


### PR DESCRIPTION
## Summary

Swap the webpage-rendering compositor from **Cage** to **Sway** as a stepping stone toward a Chromium-only multi-display setup. This unblocks two features Cage can't do without ugly workarounds:

1. Hiding the cursor cleanly (`seat * hide_cursor 1`, no Adwaita-cursor hack).
2. Pinning different tabs/contents to different displays — Cage is single-output by design.

The chromium kiosk argv, low-mem flag set, and lifecycle contract are unchanged; this PR is a compositor swap, not a renderer rewrite.

## Live-tested first

Before writing any code, I shelled into a real Pi5 (pi90) and ran sway 1.10.1 with the proposed config. Verified:
- Cursor hidden via `hide_cursor 1`.
- Chromium kiosk fullscreen via `for_window [shell=".*"] fullscreen enable, border none` (chromium-on-wayland reports `app_id=(null)`, so matching on `shell` is more robust than `app_id`).
- Memory footprint within ±5 MB of cage at steady-state.
- Process tree: sway → swaybg + `sh -c "chromium ..."` → chromium tree.

Cleanup confirmed; cage restored on pi90 before opening this PR.

## What changed

### `player/service.py`

- New `_SWAY_RUNTIME_DIR = "/tmp/agora-sway-run"` (0o700) and `_SWAY_CONFIG_PATH` class constants.
- New `_write_sway_config(url)`: renders the sway config into the runtime dir using `os.open(... O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0o600)`. URLs can carry auth tokens; defeats symlink redirect on a world-writable `/tmp`.
- New `_start_sway(url)`: wraps `sway -c <conf>` in `systemd-run --scope --quiet --unit agora-sway-<uuid8>.scope --collect`. **This is the critical fix vs. Cage**: sway double-forks + `setsid` via wlroots, so chromium is reparented to init and `killpg(sway_pgid)` would no longer reach it. The transient systemd scope is a cgroup parent that tracks every descendant regardless of session/pgrp. Unit name is per-invocation unique (uuid suffix) so a failed `_stop_sway` can't trap the retry loop in "unit already exists".
- New `_stop_sway()`: `systemctl stop <unit>` (timeout 8) → wait 5s → on timeout `systemctl kill -s SIGKILL <unit>` → wait 3s. Clears process + scope-unit state.
- New `_monitor_sway(url)`: same shape as the old `_monitor_cage`.
- Renamed state attrs: `_cage_process` → `_sway_process`; added `_sway_scope_unit`.
- Updated 8 call sites across `_teardown`, `_show_splash`, `_update_current`, `_update_position`, `_renderer_alive`, `_already_satisfied`, `apply_desired`.

### Packaging

- `packaging/debian/control.in`: `cage` → `sway` in Depends.
- `packaging/debian/postinst`: dropped the Adwaita-transparent-cursor hack (cage-specific); added `apt-mark auto cage` so the next `apt autoremove` drops legacy cage from previously-upgraded devices. Existing devices keep blanked cursors — nothing in our kiosk uses them anyway.

### Tests

- Renamed fixture attributes in `test_loop_count.py` and `test_slideshow_player.py`.
- Rewrote the two TestChromiumLowMemFlags tests to read the rendered sway config body for the flag presence/absence check.
- Added a new `TestSwayRenderer` class with 9 tests covering:
  - Config content (URL, kiosk flags, `hide_cursor 1`, the `fullscreen` rule).
  - Shell-quoting for URLs with `& ; # $ " '` metacharacters (sway runs `exec` lines through `/bin/sh -c`).
  - `XDG_RUNTIME_DIR` env + 0o700 dir mode (skipped on Windows where mkdir mode is a no-op).
  - `systemd-run --scope` Popen argv shape including the uuid regex on the unit name.
  - `systemctl stop` happy path.
  - `systemctl kill -s SIGKILL` timeout fallback.
  - Idempotent stop (no-op when nothing's running).
  - Double-start tears down the previous instance.
  - Popen exception → splash fallback + state cleared.

207 player tests pass locally.

## Duck review

Drafted plan, ran two rounds of opus-4.7-xhigh code-review. Round 1 found:

- **M1 (fixed)**: cgroup tracking for sway's double-forked chromium grandchildren — became the `systemd-run --scope` design.
- **M2 (fixed)**: config in world-readable `/tmp` could leak URL auth tokens; moved into the 0o700 runtime dir with `O_NOFOLLOW`.
- **M3 (fixed)**: missing lifecycle edge cases; added 3 new tests (idempotent stop, double start, Popen exception).
- N5: cage stays installed forever; fixed via `apt-mark auto cage`.

Round 2 found one real issue: the scope unit name initially used `os.getpid()` (stable for service lifetime → collision on stop failure → "unit already exists" forever). Fixed by using `uuid.uuid4().hex[:8]`. Also dropped a dead `os.killpg` cargo fallback.

Plan v3: APPROVE WITH FIXES. All fixes are in this PR.

## Risk + rollback

Revert via the merge commit. Cage stays in apt cache so a roll-back image bake remains possible (the agora-os release.yml's `stage-agora` overlay does `apt-get install -y agora` — reverting this PR and re-publishing the .deb would restore cage as the depends target).

Pi5 was the live-test target. Pi 4 / Zero 2 W exercise the same code path with low-mem chromium flags applied; flag injection is now covered by a unit test reading the rendered config rather than mocking out `subprocess.Popen` args.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
