### PR TITLE
multi-display: slot-keyed credential store (PR 1/3)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -45,15 +45,16 @@ async def require_auth(
 ) -> str:
     """Dependency for API routes: accepts API key header OR session cookie."""
     if api_key:
-        # Check CMS-pushed key override first, fall back to boot config
+        # Check CMS-pushed key override first, fall back to boot config.
+        # Override is sourced via devices_store with legacy persist/api_key
+        # as the fallback path -- keeps PR 1 multi-display behavior-neutral
+        # against existing fleets.
+        from shared.devices_store import read_api_key_with_fallback
+
         effective_key = settings.api_key
-        override_path = settings.persist_dir / "api_key"
-        try:
-            override = override_path.read_text().strip()
-            if override:
-                effective_key = override
-        except (FileNotFoundError, OSError):
-            pass
+        override = read_api_key_with_fallback(settings.persist_dir)
+        if override:
+            effective_key = override
         if hmac.compare_digest(api_key, effective_key):
             return "api_key"
     user = get_session_user(request, settings)

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -40,6 +40,14 @@ async def factory_reset(settings: Settings = Depends(get_settings)):
     _safe_unlink(PERSIST_DIR / "device_name")
     _safe_unlink(PERSIST_DIR / "api_key")
 
+    # 2a. Multi-display slot-keyed credential store (PR 1).  Wipe alongside
+    # the legacy persist/api_key so factory reset starts clean.
+    try:
+        from shared.devices_store import wipe as _devices_wipe
+        _devices_wipe(PERSIST_DIR)
+    except Exception:
+        logger.debug("Failed to wipe devices.json on factory reset", exc_info=True)
+
     # 3. Remove state files
     _safe_unlink(STATE_DIR / "cms_status.json")
     _safe_unlink(STATE_DIR / "cms_config.json")

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -211,19 +211,17 @@ def _save_auth_token(path: Path, token: str) -> None:
 def _resolve_device_api_key(settings: Settings) -> str:
     """Return the device API key used for WPS transport auth.
 
-    Prefers ``AGORA_DEVICE_API_KEY`` (dev/test override);
-    otherwise reads ``<persist_dir>/api_key`` — the same file CMS
-    rotates into via the config message and that direct-mode
-    transport uses for asset downloads.
+    Prefers ``AGORA_DEVICE_API_KEY`` (dev/test override); otherwise
+    reads ``persist/devices.json`` slot A, falling back to the legacy
+    ``persist/api_key`` file.  PR 1 multi-display routes credential
+    reads through ``shared.devices_store`` so PR 2 can mint slot-B
+    credentials and have them picked up the same way.
     """
     key = getattr(settings, "device_api_key", "") or ""
     if key:
         return key.strip()
-    key_path = settings.persist_dir / "api_key"
-    try:
-        return key_path.read_text().strip()
-    except (FileNotFoundError, OSError):
-        return ""
+    from shared.devices_store import read_api_key_with_fallback
+    return read_api_key_with_fallback(settings.persist_dir)
 
 
 # ── Schedule evaluation helpers ──
@@ -1514,12 +1512,14 @@ class CMSClient:
     # ── Asset management ──
 
     def _read_api_key(self) -> str:
-        """Read the current device API key from the persist directory."""
-        key_path = self.settings.persist_dir / "api_key"
-        try:
-            return key_path.read_text().strip()
-        except FileNotFoundError:
-            return ""
+        """Read the current device API key from the persist directory.
+
+        Prefers ``persist/devices.json`` slot A; falls back to the legacy
+        ``persist/api_key`` file.  Used as the ``X-Device-API-Key``
+        header on asset downloads.
+        """
+        from shared.devices_store import read_api_key_with_fallback
+        return read_api_key_with_fallback(self.settings.persist_dir)
 
     def _spawn_fetch_asset(self, msg: dict, ws) -> None:
         """Dispatch ``fetch_asset`` as a background task.
@@ -2023,6 +2023,24 @@ class CMSClient:
                 os.chmod(override_path, 0o644)
             except OSError:
                 pass
+            # Dual-write: also stash the rotated key in the slot-keyed
+            # devices.json so the new credential indirection layer sees
+            # it.  PR 3 will drop the legacy persist/api_key write once
+            # the fleet has stabilised on devices.json.
+            try:
+                from shared.devices_store import SLOT_A, read_slot, write_slot
+                existing = read_slot(self.settings.persist_dir, SLOT_A) or {}
+                existing["api_key"] = new_key
+                if "device_id" not in existing:
+                    existing["device_id"] = (
+                        getattr(self.settings, "device_name", "") or ""
+                    )
+                write_slot(self.settings.persist_dir, SLOT_A, existing)
+            except Exception:
+                logger.debug(
+                    "Failed to mirror rotated api_key into devices.json slot A",
+                    exc_info=True,
+                )
             boot_config = Path("/boot/agora-config.json")
             try:
                 cfg = json.loads(boot_config.read_text())
@@ -2086,6 +2104,14 @@ class CMSClient:
         _safe_unlink(persist_dir / "device_name")
         _safe_unlink(persist_dir / "api_key")
         _safe_unlink(persist_dir / "local_api_enabled")
+
+        # Multi-display slot-keyed credential store (PR 1).  Wipe all
+        # slots; on next adoption the device starts fresh.
+        try:
+            from shared.devices_store import wipe as _devices_wipe
+            _devices_wipe(persist_dir)
+        except Exception:
+            logger.debug("Failed to wipe devices.json on factory reset", exc_info=True)
 
         # Bootstrap v2 identity + cached credentials.  These are safe to
         # always remove — on non-v2 builds the paths just don't exist.

--- a/shared/devices_store.py
+++ b/shared/devices_store.py
@@ -1,0 +1,166 @@
+"""Slot-keyed credential store for multi-display Pis.
+
+Foundation for the multi-display work: each physical Pi can host up to
+two virtual devices (one per HDMI), and each needs its own
+``device_id`` / ``api_key`` pair.  This module owns the
+``persist/devices.json`` file that stores those credentials by slot.
+
+File shape::
+
+    {
+      "A": {"device_id": "...", "api_key": "..."},
+      "B": {"device_id": "...", "api_key": "..."}     # absent if unbound
+    }
+
+File lives in ``persist_dir`` (flash) so credentials survive reboot;
+``state_dir`` is tmpfs in production and would lose them.
+
+PR 1 (multi-display) wires this module in as a dual-write layer:
+credential read sites prefer ``devices.json`` slot A and fall back to
+the legacy ``persist/api_key`` file; credential write sites update
+both.  PR 3 will drop the legacy writes once the fleet has stabilised.
+
+This module is intentionally tiny: no schema validation beyond key
+presence, no migration logic (callers handle the fallback), no
+concurrency primitives (writes are atomic via ``shared.state``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from shared.state import atomic_write
+
+DEVICES_FILENAME = "devices.json"
+
+# Slot identifiers used today.  Slot A is the default / single-display
+# case; slot B is the opt-in second HDMI on multi-display Pis.
+SLOT_A = "A"
+SLOT_B = "B"
+KNOWN_SLOTS = (SLOT_A, SLOT_B)
+
+
+def devices_path(persist_dir: Path) -> Path:
+    """Return the absolute path to the devices.json file."""
+    return Path(persist_dir) / DEVICES_FILENAME
+
+
+def _load_all(persist_dir: Path) -> Dict[str, dict]:
+    """Return the full slot->credentials dict, or {} if no file/invalid."""
+    path = devices_path(persist_dir)
+    try:
+        raw = path.read_text()
+    except (FileNotFoundError, OSError):
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    # Discard anything that isn't a dict-valued slot.
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _save_all(persist_dir: Path, slots: Dict[str, dict]) -> None:
+    """Persist the slot dict atomically to devices.json."""
+    path = devices_path(persist_dir)
+    atomic_write(path, json.dumps(slots, indent=2, sort_keys=True))
+
+
+def read_slot(persist_dir: Path, slot: str) -> Optional[dict]:
+    """Return the credentials dict for ``slot`` or ``None`` if absent.
+
+    The returned dict is a copy; callers may mutate it without affecting
+    the on-disk file.
+    """
+    slots = _load_all(persist_dir)
+    entry = slots.get(slot)
+    if entry is None:
+        return None
+    return dict(entry)
+
+
+def write_slot(persist_dir: Path, slot: str, payload: dict) -> None:
+    """Upsert credentials for ``slot``.
+
+    Any keys present in ``payload`` are persisted as-is; this is a
+    full-replace at the slot level (not a per-field merge), matching
+    the way today CMS rotates api_key by handing back the full key
+    string rather than a diff.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(f"write_slot payload must be a dict, got {type(payload).__name__}")
+    slots = _load_all(persist_dir)
+    slots[slot] = dict(payload)
+    _save_all(persist_dir, slots)
+
+
+def remove_slot(persist_dir: Path, slot: str) -> bool:
+    """Remove ``slot`` from devices.json.
+
+    Returns True if the slot was present and removed; False if it was
+    already absent or the file did not exist.  If removing the slot
+    leaves the file empty, the file itself is deleted.
+    """
+    path = devices_path(persist_dir)
+    slots = _load_all(persist_dir)
+    if slot not in slots:
+        return False
+    del slots[slot]
+    if not slots:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return True
+    _save_all(persist_dir, slots)
+    return True
+
+
+def list_slots(persist_dir: Path) -> Iterable[str]:
+    """Return the slot identifiers currently populated in devices.json."""
+    return tuple(_load_all(persist_dir).keys())
+
+
+def wipe(persist_dir: Path) -> None:
+    """Remove the entire devices.json file.
+
+    Idempotent: returns without error if the file does not exist.  Used
+    by the factory-reset path alongside the legacy api_key wipe.
+    """
+    path = devices_path(persist_dir)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+# ── Read helpers with legacy fallback ────────────────────────────────
+
+def read_api_key_with_fallback(
+    persist_dir: Path,
+    slot: str = SLOT_A,
+    legacy_key_path: Optional[Path] = None,
+) -> str:
+    """Return the api_key for ``slot``, falling back to a legacy file.
+
+    Read order:
+      1. ``devices.json`` slot's ``api_key`` (if file present and field set);
+      2. ``legacy_key_path`` (defaults to ``persist/api_key``) read as text.
+
+    Returns empty string if neither source yields a key.  Always
+    strips trailing whitespace so callers don't have to.
+    """
+    entry = read_slot(persist_dir, slot)
+    if entry:
+        key = entry.get("api_key") or ""
+        if isinstance(key, str) and key.strip():
+            return key.strip()
+    legacy = legacy_key_path if legacy_key_path is not None else Path(persist_dir) / "api_key"
+    try:
+        return legacy.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return ""

--- a/tests/test_devices_store.py
+++ b/tests/test_devices_store.py
@@ -1,0 +1,220 @@
+"""Tests for shared.devices_store -- the multi-display credential store.
+
+PR 1 of the multi-display work introduces persist/devices.json as the
+slot-keyed source of truth for device credentials.  These tests cover
+the helper module in isolation: read/write/remove/wipe semantics, plus
+the dual-read fallback to the legacy persist/api_key file.
+
+Integration tests for the wired-in call sites (api/auth, cms_client's
+_resolve_device_api_key / _read_api_key / api_key rotation handler /
+factory_reset) live in test_devices_store_integration.py.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from shared.devices_store import (
+    DEVICES_FILENAME,
+    KNOWN_SLOTS,
+    SLOT_A,
+    SLOT_B,
+    devices_path,
+    list_slots,
+    read_api_key_with_fallback,
+    read_slot,
+    remove_slot,
+    wipe,
+    write_slot,
+)
+
+
+@pytest.fixture
+def persist(tmp_path):
+    persist = tmp_path / "persist"
+    persist.mkdir()
+    return persist
+
+
+class TestKnownSlots:
+    def test_constants(self):
+        assert SLOT_A == "A"
+        assert SLOT_B == "B"
+        assert SLOT_A in KNOWN_SLOTS and SLOT_B in KNOWN_SLOTS
+
+    def test_filename(self):
+        assert DEVICES_FILENAME == "devices.json"
+
+
+class TestDevicesPath:
+    def test_joins_persist_dir(self, persist):
+        assert devices_path(persist) == persist / "devices.json"
+
+    def test_accepts_string_path(self, tmp_path):
+        p = devices_path(str(tmp_path))
+        assert isinstance(p, Path)
+        assert p == tmp_path / "devices.json"
+
+
+class TestReadSlot:
+    def test_missing_file_returns_none(self, persist):
+        assert read_slot(persist, SLOT_A) is None
+
+    def test_missing_slot_returns_none(self, persist):
+        devices_path(persist).write_text(json.dumps({"A": {"device_id": "d1"}}))
+        assert read_slot(persist, SLOT_B) is None
+
+    def test_returns_copy(self, persist):
+        devices_path(persist).write_text(
+            json.dumps({"A": {"device_id": "d1", "api_key": "k1"}})
+        )
+        entry = read_slot(persist, SLOT_A)
+        assert entry == {"device_id": "d1", "api_key": "k1"}
+        entry["api_key"] = "mutated"
+        # On-disk file unchanged
+        assert read_slot(persist, SLOT_A)["api_key"] == "k1"
+
+    def test_invalid_json_treated_as_empty(self, persist):
+        devices_path(persist).write_text("{ not json }")
+        assert read_slot(persist, SLOT_A) is None
+
+    def test_non_dict_root_treated_as_empty(self, persist):
+        devices_path(persist).write_text(json.dumps(["A", "B"]))
+        assert read_slot(persist, SLOT_A) is None
+
+    def test_non_dict_slot_value_ignored(self, persist):
+        devices_path(persist).write_text(
+            json.dumps({"A": "not-a-dict", "B": {"device_id": "d2", "api_key": "k2"}})
+        )
+        assert read_slot(persist, SLOT_A) is None
+        assert read_slot(persist, SLOT_B) == {"device_id": "d2", "api_key": "k2"}
+
+
+class TestWriteSlot:
+    def test_creates_file_if_absent(self, persist):
+        assert not devices_path(persist).exists()
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        assert devices_path(persist).exists()
+        assert read_slot(persist, SLOT_A) == {"device_id": "d1", "api_key": "k1"}
+
+    def test_upserts_without_clobbering_other_slots(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        write_slot(persist, SLOT_B, {"device_id": "d2", "api_key": "k2"})
+        assert read_slot(persist, SLOT_A) == {"device_id": "d1", "api_key": "k1"}
+        assert read_slot(persist, SLOT_B) == {"device_id": "d2", "api_key": "k2"}
+
+    def test_full_replace_at_slot_level(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1", "extra": "x"})
+        # Re-write with a different shape -- old keys are dropped.
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k2"})
+        assert read_slot(persist, SLOT_A) == {"device_id": "d1", "api_key": "k2"}
+
+    def test_payload_copy_is_independent(self, persist):
+        payload = {"device_id": "d1", "api_key": "k1"}
+        write_slot(persist, SLOT_A, payload)
+        payload["api_key"] = "mutated"
+        assert read_slot(persist, SLOT_A)["api_key"] == "k1"
+
+    def test_rejects_non_dict_payload(self, persist):
+        with pytest.raises(TypeError):
+            write_slot(persist, SLOT_A, "not-a-dict")  # type: ignore[arg-type]
+
+    def test_atomic_no_temp_left_behind(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        # Only devices.json should be present after a write -- the atomic
+        # write helper rewrites + renames its temp file.
+        entries = sorted(p.name for p in persist.iterdir())
+        assert entries == ["devices.json"]
+
+
+class TestRemoveSlot:
+    def test_returns_false_when_missing(self, persist):
+        assert remove_slot(persist, SLOT_A) is False
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        assert remove_slot(persist, SLOT_B) is False
+
+    def test_removes_present_slot(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        write_slot(persist, SLOT_B, {"device_id": "d2", "api_key": "k2"})
+        assert remove_slot(persist, SLOT_B) is True
+        assert read_slot(persist, SLOT_A) == {"device_id": "d1", "api_key": "k1"}
+        assert read_slot(persist, SLOT_B) is None
+
+    def test_removes_file_when_last_slot_gone(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        assert devices_path(persist).exists()
+        assert remove_slot(persist, SLOT_A) is True
+        assert not devices_path(persist).exists()
+
+
+class TestListSlots:
+    def test_empty_when_missing(self, persist):
+        assert tuple(list_slots(persist)) == ()
+
+    def test_returns_populated_slots(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        write_slot(persist, SLOT_B, {"device_id": "d2", "api_key": "k2"})
+        assert set(list_slots(persist)) == {SLOT_A, SLOT_B}
+
+
+class TestWipe:
+    def test_removes_file(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "k1"})
+        assert devices_path(persist).exists()
+        wipe(persist)
+        assert not devices_path(persist).exists()
+
+    def test_idempotent_when_missing(self, persist):
+        # No exception when file does not exist.
+        wipe(persist)
+        wipe(persist)
+
+
+class TestReadApiKeyWithFallback:
+    def test_devices_json_wins(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "new-key"})
+        (persist / "api_key").write_text("legacy-key")
+        assert read_api_key_with_fallback(persist) == "new-key"
+
+    def test_legacy_when_devices_json_absent(self, persist):
+        (persist / "api_key").write_text("legacy-key\n")
+        assert read_api_key_with_fallback(persist) == "legacy-key"
+
+    def test_legacy_when_devices_json_has_other_slot(self, persist):
+        write_slot(persist, SLOT_B, {"device_id": "d2", "api_key": "slot-b-key"})
+        (persist / "api_key").write_text("legacy-key")
+        # Default slot is A -- B not consulted.
+        assert read_api_key_with_fallback(persist) == "legacy-key"
+
+    def test_legacy_when_devices_json_slot_missing_api_key(self, persist):
+        # Bound but no api_key yet -- fall through to legacy file.
+        write_slot(persist, SLOT_A, {"device_id": "d1"})
+        (persist / "api_key").write_text("legacy-key")
+        assert read_api_key_with_fallback(persist) == "legacy-key"
+
+    def test_legacy_when_devices_json_api_key_is_blank(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "   "})
+        (persist / "api_key").write_text("legacy-key")
+        assert read_api_key_with_fallback(persist) == "legacy-key"
+
+    def test_returns_empty_when_no_source(self, persist):
+        assert read_api_key_with_fallback(persist) == ""
+
+    def test_slot_b_lookup(self, persist):
+        write_slot(persist, SLOT_B, {"device_id": "d2", "api_key": "slot-b-key"})
+        assert read_api_key_with_fallback(persist, slot=SLOT_B) == "slot-b-key"
+
+    def test_strips_whitespace(self, persist):
+        write_slot(persist, SLOT_A, {"device_id": "d1", "api_key": "  k1  "})
+        assert read_api_key_with_fallback(persist) == "k1"
+
+    def test_custom_legacy_path(self, tmp_path):
+        persist = tmp_path / "persist"
+        persist.mkdir()
+        legacy = tmp_path / "custom" / "legacy_api_key"
+        legacy.parent.mkdir()
+        legacy.write_text("custom-legacy")
+        assert read_api_key_with_fallback(persist, legacy_key_path=legacy) == "custom-legacy"

--- a/tests/test_devices_store_integration.py
+++ b/tests/test_devices_store_integration.py
@@ -1,0 +1,191 @@
+"""Integration tests for the wired-in call sites of shared.devices_store.
+
+PR 1 of the multi-display work routes credential reads through
+``shared.devices_store`` (with legacy ``persist/api_key`` fallback) and
+mirrors credential writes into ``persist/devices.json`` slot A.  These
+tests exercise the actual call sites in cms_client/service.py and
+api/routers/system.py to ensure:
+
+- CMS-pushed ``api_key`` rotation via ``_handle_config`` writes to BOTH
+  the legacy ``persist/api_key`` file AND ``persist/devices.json``
+  slot A.
+- The ``factory_reset`` REST endpoint wipes ``persist/devices.json``
+  alongside ``persist/api_key``.
+- The CMS-client ``_handle_factory_reset`` does the same.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock heavy deps before importing the service module (mirrors
+# test_download_auth_header.py's pattern).
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("websockets.asyncio", MagicMock())
+sys.modules.setdefault("websockets.asyncio.client", MagicMock())
+sys.modules.setdefault("aiohttp", MagicMock())
+
+from cms_client.service import CMSClient  # noqa: E402
+from shared.devices_store import (  # noqa: E402
+    SLOT_A,
+    devices_path,
+    read_slot,
+)
+
+
+# ── _handle_config api_key rotation: dual-write ──────────────────────
+
+
+@pytest.fixture
+def cms_client_for_config(tmp_path):
+    """Mirror the minimal fixture used by other CMSClient unit tests."""
+    settings = MagicMock()
+    settings.persist_dir = tmp_path / "persist"
+    settings.persist_dir.mkdir()
+    settings.state_dir = tmp_path / "state"
+    settings.state_dir.mkdir()
+    settings.device_name = "agora-node-test"
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        client = CMSClient(settings)
+    client.settings = settings
+    return client
+
+
+@pytest.mark.asyncio
+async def test_handle_config_api_key_dual_writes_to_devices_json(
+    cms_client_for_config, tmp_path
+):
+    """CMS rotates api_key -> legacy persist/api_key AND devices.json slot A
+    both updated."""
+    # Stub /boot/agora-config.json -- the handler tries to read+write it
+    # but on test hosts /boot/ doesn't exist.  We point at a tmp path
+    # via patch.
+    fake_boot = tmp_path / "boot_agora_config.json"
+    with patch("cms_client.service.Path", side_effect=lambda p: fake_boot if p == "/boot/agora-config.json" else Path(p)):
+        await cms_client_for_config._handle_config({"api_key": "rotated-key-123"})
+
+    persist = cms_client_for_config.settings.persist_dir
+
+    # Legacy file: still written.
+    assert (persist / "api_key").read_text() == "rotated-key-123"
+
+    # New slot-keyed store: slot A populated with the rotated key, plus
+    # device_id derived from settings.device_name.
+    slot_a = read_slot(persist, SLOT_A)
+    assert slot_a is not None
+    assert slot_a["api_key"] == "rotated-key-123"
+    assert slot_a["device_id"] == "agora-node-test"
+
+
+@pytest.mark.asyncio
+async def test_handle_config_api_key_preserves_existing_device_id(
+    cms_client_for_config, tmp_path
+):
+    """If devices.json already has a slot-A device_id (e.g. minted earlier),
+    a subsequent rotation must not clobber it with settings.device_name."""
+    persist = cms_client_for_config.settings.persist_dir
+    devices_path(persist).write_text(
+        json.dumps({"A": {"device_id": "previously-minted", "api_key": "old"}})
+    )
+
+    fake_boot = tmp_path / "boot_agora_config.json"
+    with patch("cms_client.service.Path", side_effect=lambda p: fake_boot if p == "/boot/agora-config.json" else Path(p)):
+        await cms_client_for_config._handle_config({"api_key": "rotated-key-456"})
+
+    slot_a = read_slot(persist, SLOT_A)
+    assert slot_a == {"device_id": "previously-minted", "api_key": "rotated-key-456"}
+
+
+@pytest.mark.asyncio
+async def test_handle_config_no_api_key_leaves_devices_json_alone(
+    cms_client_for_config, tmp_path
+):
+    """A config message without api_key must not touch devices.json."""
+    persist = cms_client_for_config.settings.persist_dir
+    devices_path(persist).write_text(
+        json.dumps({"A": {"device_id": "d1", "api_key": "untouched"}})
+    )
+
+    fake_boot = tmp_path / "boot_agora_config.json"
+    with patch("cms_client.service.Path", side_effect=lambda p: fake_boot if p == "/boot/agora-config.json" else Path(p)):
+        await cms_client_for_config._handle_config({"device_name": "new-name"})
+
+    assert read_slot(persist, SLOT_A) == {"device_id": "d1", "api_key": "untouched"}
+
+
+# ── factory_reset wipes devices.json ─────────────────────────────────
+
+
+def test_factory_reset_endpoint_wipes_devices_json(tmp_path, monkeypatch):
+    """api/routers/system.py:factory_reset removes persist/devices.json
+    alongside persist/api_key."""
+    persist = tmp_path / "persist"
+    persist.mkdir()
+    state = tmp_path / "state"
+    state.mkdir()
+
+    # Seed legacy + new credential files.
+    (persist / "api_key").write_text("k1")
+    devices_path(persist).write_text(
+        json.dumps({"A": {"device_id": "d1", "api_key": "k1"}, "B": {"device_id": "d2", "api_key": "k2"}})
+    )
+
+    # Patch the module-level PERSIST_DIR/STATE_DIR before importing.
+    from api.routers import system as system_mod
+    monkeypatch.setattr(system_mod, "PERSIST_DIR", persist)
+    monkeypatch.setattr(system_mod, "STATE_DIR", state)
+
+    # Drive the inner cleanup logic directly (skip reboot subprocess
+    # and the nmcli shell-out for forget_all_wifi).
+    with patch("api.routers.system.subprocess.Popen"), \
+         patch("provision.network.forget_all_wifi"):
+        settings = MagicMock()
+        settings.videos_dir = tmp_path / "videos"
+        settings.images_dir = tmp_path / "images"
+        settings.slideshows_dir = tmp_path / "slideshows"
+        for d in (settings.videos_dir, settings.images_dir, settings.slideshows_dir):
+            d.mkdir()
+        import asyncio
+        asyncio.run(system_mod.factory_reset(settings=settings))
+
+    assert not (persist / "api_key").exists()
+    assert not devices_path(persist).exists()
+
+
+@pytest.mark.asyncio
+async def test_cms_client_factory_reset_wipes_devices_json(
+    cms_client_for_config, tmp_path
+):
+    """cms_client/_handle_factory_reset wipes devices.json too."""
+    persist = cms_client_for_config.settings.persist_dir
+    (persist / "api_key").write_text("k1")
+    devices_path(persist).write_text(
+        json.dumps({"A": {"device_id": "d1", "api_key": "k1"}})
+    )
+
+    # Stub out the parts of _handle_factory_reset that we don't care about
+    # for this credential-wipe slice.
+    cms_client_for_config.settings.videos_dir = tmp_path / "videos"
+    cms_client_for_config.settings.images_dir = tmp_path / "images"
+    cms_client_for_config.settings.slideshows_dir = tmp_path / "slideshows"
+    for d in (
+        cms_client_for_config.settings.videos_dir,
+        cms_client_for_config.settings.images_dir,
+        cms_client_for_config.settings.slideshows_dir,
+    ):
+        d.mkdir()
+
+    fake_ws = MagicMock()
+    fake_ws.send = AsyncMock()
+
+    with patch("os.system"):  # avoid actual reboot
+        await cms_client_for_config._handle_factory_reset(fake_ws)
+
+    assert not (persist / "api_key").exists()
+    assert not devices_path(persist).exists()


### PR DESCRIPTION
## Summary

Foundation for the multi-display refactor: each Pi5 HDMI output will become its own *virtual device* in CMS, with its own credentials, group, schedule, and content. This PR is the credential indirection layer **only** -- no state path changes, no abstraction lift, no behavior change for existing single-display devices.

See `files/multi-display-design.md` in the session workspace for the full design (locked decisions + rubber-duck review + tier split). This PR implements just the first slice.

## What changed

| Area | Change |
|---|---|
| `shared/devices_store.py` (new) | Slot-keyed credential store at `persist/devices.json` with shape `{"A": {"device_id": ..., "api_key": ...}, "B": {...}}`. Atomic writes, fallback read helper. |
| `api/auth.py` | `require_auth` reads via `read_api_key_with_fallback` -- prefers slot-A in `devices.json`, falls back to legacy `persist/api_key`. |
| `cms_client/service.py` | Same dual-read at `_resolve_device_api_key` and `_read_api_key`. `_handle_config` api_key rotation dual-writes into slot A (preserving any existing `device_id`). `_handle_factory_reset` also wipes `devices.json`. |
| `api/routers/system.py` | REST `factory_reset` endpoint wipes `devices.json` alongside legacy `persist/api_key`. |

## Behavior

- **Existing single-display fleet:** zero behavior change. Legacy `persist/api_key` is still written by the rotation handler and still readable by both code paths.
- **Future PR 2 onboarding a slot-B display:** slot B credentials get minted via the new `bind_display` WS handler (not in this PR) and stored in slot B. Slot A continues to be the device's *primary* identity.
- **Factory reset:** wipes both the legacy file and the new file. Idempotent if either is missing.

## Tests

- 32 new unit tests in `tests/test_devices_store.py` covering paths, read/write/remove/list/wipe, atomic write semantics, and the dual-read fallback.
- 5 new integration tests in `tests/test_devices_store_integration.py` covering:
  - `_handle_config` api_key rotation dual-writes correctly
  - `_handle_config` preserves an existing `device_id` on rotation
  - `_handle_config` with no api_key in the payload leaves `devices.json` alone
  - `_handle_factory_reset` (cms_client) wipes `devices.json`
  - `factory_reset` REST endpoint wipes `devices.json`
- Full agora suite: **1634 pass / 33 skip** (baseline was 1597 / 33; delta = +37 new tests, no regressions).

## Roadmap

- **PR 2 (next, big):** CMS schema + adoption flow + DELETE hardening + UI + `bind_display`/`unbind_display` WS handlers + Coordinator/SlotState extraction + sway dual-output + per-slot kiosk. Likely splits further.
- **PR 3:** audio routing polish + drop legacy `persist/api_key` writes once the fleet is fully migrated.