### PR TITLE
fix(plymouth,os_updater): unmask plymouth-quit + accept multi-token prereleases

### DIFF
--- a/os_updater/dispatch.py
+++ b/os_updater/dispatch.py
@@ -38,9 +38,11 @@ class DispatchPayloadError(ValueError):
 
 
 #: Regex matching ``major.minor.patch`` semver with optional ``-prerelease``.
+#: The prerelease segment allows hyphens inside it (e.g. ``0.0.40-test-k612``)
+#: so multi-token prereleases produced by our agora-os release flow pass.
 #: Intentionally simple — we control both ends of this wire so we don't need
 #: full semver-2.0 compliance.
-_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$")
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$")
 
 #: Regex matching the allowed shape of an opaque ``release_id``: alphanumeric
 #: plus ``_-.``, length 1..128. Mirrors what the CMS will generate.

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -179,12 +179,20 @@ fi
 # ── Disable console login on HDMI (tty1) ──
 systemctl disable getty@tty1 2>/dev/null || true
 
-# ── Plymouth: player controls quit, not systemd ──
-# The player calls `plymouth quit --retain-splash` right before building the first
-# GStreamer pipeline, keeping the boot splash visible until content takes over.
-# These units are "static" so they must be masked, not just disabled.
-systemctl mask plymouth-quit.service 2>/dev/null || true
-systemctl mask plymouth-quit-wait.service 2>/dev/null || true
+# ── Plymouth: let systemd quit it at multi-user.target ──
+# Previously these units were masked because the player itself called
+# `plymouth quit --retain-splash` right before its first GStreamer pipeline.
+# That left no fallback when the player's kiosk child (mpv / chromium / sway)
+# crashed early in boot — plymouth would keep animating forever with nothing
+# to overdraw it, and the device looked hung. We now let the standard
+# Debian plymouth-quit.service fire on multi-user.target reached, which
+# kills plymouth (and frees the framebuffer / DRM master) even if the
+# player never comes up. The player still calls `plymouth quit
+# --retain-splash` itself — that's idempotent and a no-op once systemd
+# has already quit plymouth.
+# Defensive: unmask in case a previous version of this package masked them.
+systemctl unmask plymouth-quit.service 2>/dev/null || true
+systemctl unmask plymouth-quit-wait.service 2>/dev/null || true
 
 # ── Rebuild initramfs with new splash theme ──
 update-initramfs -u 2>/dev/null || true

--- a/tests/test_os_updater_dispatch.py
+++ b/tests/test_os_updater_dispatch.py
@@ -58,6 +58,15 @@ class TestHappyPath:
         assert p.target_version == "1.1.0-rc1"
         assert p.min_from_version == "1.0.0-beta.2"
 
+    def test_multi_token_prerelease_accepted(self):
+        """Tags like ``v0.0.40-test-k612`` produce a multi-hyphen prerelease
+        when stripped of the leading ``v``. The dispatch regex must accept
+        that or every multi-token test build looks invalid to the device."""
+        p = parse_dispatch_payload(
+            _ok_msg(target_version="0.0.40-test-k612", min_from_version="0.0.0")
+        )
+        assert p.target_version == "0.0.40-test-k612"
+
     def test_extra_field_ignored(self):
         """Phase 3 adds ``not_before`` etc. — older daemons must ignore
         anything they don't recognize so a CMS-side schema bump doesn't


### PR DESCRIPTION
Two unrelated boot-pipeline fixes that bit us validating the kernel-pin agora-os build today.

## 1) Plymouth: stop masking plymouth-quit.service

`packaging/debian/postinst` was masking `plymouth-quit.service` + `plymouth-quit-wait.service` by design — the comment said *"the player calls `plymouth quit --retain-splash` right before building the first GStreamer pipeline."*

That's true on the happy path. But when the player's kiosk child (mpv on main; chromium on `feat/chromium-player`) crashes during early boot — which it currently does on Pi5 6.18.29 — that explicit quit never fires, plymouth keeps running, and the device looks hung with an animated splash forever.

This PR removes the mask and adds a defensive unmask for upgrade. plymouth-quit now fires at `multi-user.target reached` like every other Debian system. The player's own `_quit_plymouth()` call is idempotent and stays in place (it just becomes a no-op once systemd already quit plymouth).

## 2) os_updater: accept multi-token prerelease tags

`_VERSION_RE` was `^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$` — no hyphens allowed in the prerelease segment. Today's agora-os tag `v0.0.40-test-k612` strips to `0.0.40-test-k612`, which has two hyphens, so every device rejected it with `invalid_payload` and the upgrade never even started staging.

Regex relaxed to allow `[A-Za-z0-9.-]+` in the prerelease. Added a regression test pinning the new acceptance. All 31 dispatch tests pass.

Auto-merge enabled — once green, the apt repo update kicks in automatically and the next agora-os build picks up both fixes.