### PR TITLE
feat(slideshow): parse manifest_schema_version, persist on disk (Phase 0)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1745,6 +1745,11 @@ class CMSClient:
         asset_name = msg.get("asset_name", "")
         expected_checksum = msg.get("checksum", "")
         slides = msg.get("slides") or []
+        # Slideshow manifest schema version (agora#226 Phase 0).  Missing on
+        # the wire = pre-versioning CMS = treat as "1.0".  Persisted into the
+        # manifest dict on disk so the player sees the same value whether the
+        # manifest came from a fresh fetch or a reboot-time read.
+        manifest_schema_version = msg.get("manifest_schema_version") or "1.0"
 
         if not asset_name:
             logger.warning("Invalid slideshow fetch_asset: missing asset_name")
@@ -1857,6 +1862,7 @@ class CMSClient:
         manifest_payload = {
             "name": asset_name,
             "checksum": expected_checksum,
+            "manifest_schema_version": manifest_schema_version,
             "slides": [
                 {
                     "name": s["asset_name"],

--- a/player/service.py
+++ b/player/service.py
@@ -31,6 +31,31 @@ from shared.state import read_state, write_state  # noqa: E402
 logger = logging.getLogger("agora.player")
 
 
+def _parse_schema_version(version: str) -> tuple[int, int]:
+    """Parse a ``major.minor`` (or ``major.minor.patch``) version string.
+
+    Returns ``(major, minor)``.  Anything unparseable is treated as
+    ``(0, 0)`` — i.e. older than every real version — so a corrupted
+    or unexpected value never trips the "forward" comparison.  We only
+    care about major+minor; patch-level differences are below the
+    granularity of the manifest schema.
+    """
+    try:
+        parts = version.split(".")
+        return int(parts[0]), int(parts[1])
+    except (AttributeError, IndexError, ValueError):
+        return (0, 0)
+
+
+def _is_forward_schema(observed: str, player_max: str) -> bool:
+    """True iff ``observed`` is strictly greater than ``player_max``.
+
+    Used to decide whether to log the once-per-manifest "CMS is ahead of
+    this player" INFO message.  Equal versions are NOT forward.
+    """
+    return _parse_schema_version(observed) > _parse_schema_version(player_max)
+
+
 def _build_video_pipeline_str(board: Board) -> str:
     """Return the GStreamer pipeline string for video playback with audio.
 
@@ -149,6 +174,21 @@ class AgoraPlayer:
     and mpv subprocess on Pi 4/Pi 5 for video playback with hardware decoding.
     """
 
+    # ── Slideshow manifest schema version (agora#226 Phase 0) ──
+    #
+    # The CMS now tags every slideshow manifest with a
+    # ``manifest_schema_version`` semver string ("1.0", "1.1", …).  This
+    # player understands up to ``PLAYER_MAX_MANIFEST_SCHEMA_VERSION``.
+    # A higher version on the wire just means the CMS may emit fields
+    # this player doesn't know about — they're silently ignored, and we
+    # log INFO once-per-content-hash so the fleet dashboard can spot
+    # devices lagging behind a CMS rollout.
+    #
+    # Phase 0 ships the plumbing but does not yet bump the supported
+    # ceiling above 1.0 — Phase 2 lifts it to "1.1" once wall-clock
+    # resync lands.
+    PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.0"
+
     # Class-level default so tests that bypass __init__ still see this
     # attribute as None (matches "not in a slideshow").
     _slideshow: Optional[dict] = None
@@ -157,6 +197,14 @@ class AgoraPlayer:
     _applied_desired: Optional[DesiredState] = None
     _current_url: Optional[str] = None
     _slideshow_manifest_digest: Optional[str] = None
+    # SHA-256 prefixes of slideshow manifests for which a forward
+    # ``manifest_schema_version`` has already been logged.  Bounded by
+    # the number of distinct slideshows the device sees; cleared on
+    # process restart.  Used purely for log-spam suppression.  Defined
+    # as an instance attribute in ``__init__``; declared here only so
+    # tests that build instances via ``__new__`` still see the
+    # attribute name.
+    _forward_schema_logged: Optional[set] = None
 
     IMAGE_PIPELINE_JPEG = (
         'filesrc location="{path}" ! '
@@ -234,6 +282,9 @@ class AgoraPlayer:
         # Slideshow sequencer state. None when not playing a slideshow.
         # Populated by _start_slideshow; cleared by _clear_slideshow.
         self._slideshow: Optional[dict] = None
+        # Dedup set for forward-schema-version INFO logs (Phase 0).  Keyed
+        # by manifest content digest so we log once per distinct manifest.
+        self._forward_schema_logged: set[str] = set()
 
         # ── mpv IPC event listener (Phase 1) ──
         #
@@ -326,6 +377,25 @@ class AgoraPlayer:
         manifest, digest = result
         self._cancel_slide_timeout()
         slides = manifest["slides"]
+        # Slideshow manifest schema version (agora#226 Phase 0).  Missing
+        # from disk = pre-versioning manifest = treat as "1.0".  We log
+        # once-per-content-digest when the CMS is emitting a version
+        # higher than this player understands; the manifest still plays
+        # because unknown fields are ignored (additive evolution).
+        schema_version = str(manifest.get("manifest_schema_version") or "1.0")
+        if self._forward_schema_logged is None:
+            self._forward_schema_logged = set()
+        if (
+            _is_forward_schema(schema_version, self.PLAYER_MAX_MANIFEST_SCHEMA_VERSION)
+            and digest not in self._forward_schema_logged
+        ):
+            logger.info(
+                "Slideshow %s manifest_schema_version=%s exceeds player max=%s "
+                "— unknown fields will be ignored (digest=%s)",
+                name, schema_version, self.PLAYER_MAX_MANIFEST_SCHEMA_VERSION,
+                digest[:8],
+            )
+            self._forward_schema_logged.add(digest)
         # ``epoch`` is bumped each time a slideshow starts so a stale
         # play_to_end watchdog or late mpv event from a prior slideshow
         # cannot drive the new one.
@@ -342,6 +412,9 @@ class AgoraPlayer:
             # Misses-this-cycle counter guards against runaway recursion
             # when every slide in the manifest is missing on disk.
             "misses_this_cycle": 0,
+            # Manifest schema version observed (Phase 0).  Phase 2 will
+            # branch on this to choose legacy vs anchored playback.
+            "schema_version": schema_version,
         }
         self._slideshow_manifest_digest = digest
         self._loops_completed = 0

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -184,6 +184,58 @@ class TestSlideshowFetch:
         assert not [m for m in sent if m["type"] == "fetch_failed"]
 
     @pytest.mark.asyncio
+    async def test_manifest_schema_version_defaults_to_1_0_when_absent(self, cms_client):
+        """agora#226 Phase 0: pre-versioning CMS payloads (no
+        ``manifest_schema_version`` on the wire) get persisted as "1.0".
+        """
+        b1 = b"only-slide-bytes"
+        slides = [_make_slide("a.png", b1, asset_type="image", duration_ms=2000)]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "NoVer.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "slides": slides,
+            # NOTE: no manifest_schema_version
+        }
+        mapping = {slides[0]["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest_path = cms_client.settings.slideshows_dir / "NoVer.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["manifest_schema_version"] == "1.0"
+
+    @pytest.mark.asyncio
+    async def test_manifest_schema_version_propagated_from_wire(self, cms_client):
+        """agora#226 Phase 0: when CMS sends a versioned manifest, the
+        version is persisted verbatim so the player can branch on it.
+        """
+        b1 = b"only-slide-bytes"
+        slides = [_make_slide("a.png", b1, asset_type="image", duration_ms=2000)]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Versioned.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.1",
+            "slides": slides,
+        }
+        mapping = {slides[0]["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest_path = cms_client.settings.slideshows_dir / "Versioned.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["manifest_schema_version"] == "1.1"
+
+    @pytest.mark.asyncio
     async def test_already_cached_short_circuits(self, cms_client):
         """Slideshow + every slide already cached → ACK without re-downloading."""
         b1, b2 = b"already-have-1", b"already-have-2"

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -127,6 +127,154 @@ class TestStartSlideshow:
         assert player._slideshow["timeout_id"] == 42
 
 
+class TestManifestSchemaVersion:
+    """Phase 0 of agora#226: parse manifest_schema_version, default to 1.0,
+    warn-once on forward versions, store on runtime state for Phase 2.
+    """
+
+    def _write_versioned_manifest(self, player, name, slides, version):
+        import json
+        path = player.assets_dir / "slideshows" / f"{name}.json"
+        payload = {"name": name, "slides": slides}
+        if version is not None:
+            payload["manifest_schema_version"] = version
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_v1_0_default_when_field_absent(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        self._write_versioned_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 1000, "play_to_end": False},
+        ], version=None)
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        assert player._slideshow["schema_version"] == "1.0"
+
+    def test_v1_0_explicit(self, mpv_player):
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        self._write_versioned_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 1000, "play_to_end": False},
+        ], version="1.0")
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        assert player._slideshow["schema_version"] == "1.0"
+
+    def test_forward_version_logs_info_and_still_plays(self, mpv_player, caplog):
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        self._write_versioned_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 1000, "play_to_end": False},
+        ], version="1.1")
+        with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
+            player._start_slideshow("Show", None)
+        assert player._slideshow is not None
+        assert player._slideshow["schema_version"] == "1.1"
+        # INFO logged, mentions both the observed and the player-max version.
+        assert any(
+            "manifest_schema_version=1.1" in rec.getMessage()
+            and "player max=1.0" in rec.getMessage()
+            for rec in caplog.records
+        ), f"forward-version INFO not logged: {[r.getMessage() for r in caplog.records]}"
+
+    def test_forward_version_logged_only_once_per_digest(self, mpv_player, caplog):
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        self._write_versioned_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 1000, "play_to_end": False},
+        ], version="1.1")
+        with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
+            player._start_slideshow("Show", None)
+            player._clear_slideshow()
+            player._start_slideshow("Show", None)
+        forward_logs = [
+            r for r in caplog.records
+            if "manifest_schema_version=1.1" in r.getMessage()
+        ]
+        assert len(forward_logs) == 1, (
+            f"forward-version INFO should fire once per digest, got "
+            f"{len(forward_logs)} entries"
+        )
+
+    def test_unknown_envelope_fields_ignored(self, mpv_player):
+        """Forward-compat: a manifest sprouting an unrecognised top-level
+        field (e.g. cycle_duration_ms from Phase 1b) doesn't break the
+        legacy reader.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        import json
+        path = player.assets_dir / "slideshows" / "Show.json"
+        path.write_text(json.dumps({
+            "name": "Show",
+            "manifest_schema_version": "1.1",
+            "cycle_duration_ms": 1000,
+            "started_at": "2026-05-17T00:00:00Z",
+            "slides": [{"name": "a.png", "asset_type": "image",
+                        "duration_ms": 1000, "play_to_end": False}],
+        }))
+        with patch.object(svc, "GLib"):
+            player._start_slideshow("Show", None)
+        assert player._slideshow is not None
+        assert player._slideshow["schema_version"] == "1.1"
+        # Legacy timer chain still in charge — Phase 0 does not consume
+        # cycle_duration_ms/started_at yet.
+
+    def test_corrupt_schema_version_treated_as_pre_1_0(self, mpv_player, caplog):
+        """A garbage value (e.g. ``"abc"``) is parsed as (0,0) which is
+        NOT forward of (1,0), so no warning fires.  It just gets stored
+        verbatim for diagnostic purposes.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        self._write_versioned_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 1000, "play_to_end": False},
+        ], version="abc")
+        with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
+            player._start_slideshow("Show", None)
+        assert player._slideshow["schema_version"] == "abc"
+        # No forward-version warning for unparseable values.
+        assert not any(
+            "manifest_schema_version=abc" in r.getMessage()
+            for r in caplog.records
+        )
+
+
+class TestSchemaVersionHelpers:
+    """Pure-function unit tests for the version comparator."""
+
+    @pytest.fixture
+    def svc(self, mpv_player):
+        """Reuse the gi-mocked module that mpv_player already imported."""
+        _, svc = mpv_player
+        return svc
+
+    def test_parse_basic(self, svc):
+        assert svc._parse_schema_version("1.0") == (1, 0)
+        assert svc._parse_schema_version("1.1") == (1, 1)
+        assert svc._parse_schema_version("2.5") == (2, 5)
+        assert svc._parse_schema_version("1.0.3") == (1, 0)  # patch ignored
+
+    def test_parse_invalid(self, svc):
+        assert svc._parse_schema_version("abc") == (0, 0)
+        assert svc._parse_schema_version("") == (0, 0)
+        assert svc._parse_schema_version("1") == (0, 0)  # need major.minor
+        assert svc._parse_schema_version(None) == (0, 0)  # type: ignore[arg-type]
+
+    def test_forward(self, svc):
+        assert svc._is_forward_schema("1.1", "1.0") is True
+        assert svc._is_forward_schema("2.0", "1.5") is True
+        assert svc._is_forward_schema("1.0", "1.0") is False  # equal not forward
+        assert svc._is_forward_schema("0.9", "1.0") is False
+        assert svc._is_forward_schema("abc", "1.0") is False
+
+
 class TestSlideAdvance:
     def test_advance_loops_back_until_count_exceeded(self, mpv_player):
         player, svc = mpv_player


### PR DESCRIPTION
Phase 0 of agora#226. Pure plumbing: device learns about the new `manifest_schema_version` field, persists it into the on-disk manifest so a post-reboot read sees the same value, and warns once when CMS is ahead of the player. **No playback behavior change.**

## What this changes

* `cms_client/service.py` (`_handle_fetch_slideshow`): read `manifest_schema_version` from the incoming `FetchAssetMessage` (default `"1.0"` when absent) and include it in the persisted manifest payload.
* `player/service.py`:
  * `PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.0"`.
  * `_parse_schema_version` / `_is_forward_schema` helpers (corrupt values fall back to `(0,0)` so they never trip the forward check).
  * `_start_slideshow` extracts the version, stashes it on `self._slideshow["schema_version"]` for Phase 2 to branch on, and logs INFO once-per-content-digest if the CMS is emitting a newer schema than this player understands.
* Tests cover: default-when-absent, propagation from wire, forward-version logging, log-dedup per digest, unknown-envelope-field tolerance, corrupt-value handling, and the version comparator helpers.

## Paired CMS PR

[sslivins/agora-cms#feat/slideshow-manifest-schema-version](https://github.com/sslivins/agora-cms/pull/new/feat/slideshow-manifest-schema-version) -- adds the field on the wire. Either PR can merge first; they're mutually forward-compat.