### PR TITLE
feat(slideshow): persist transition fields in on-disk manifest (Phase 1a)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1871,6 +1871,12 @@ class CMSClient:
                     "size_bytes": s.get("size_bytes", 0),
                     "duration_ms": s.get("duration_ms", 0),
                     "play_to_end": bool(s.get("play_to_end", False)),
+                    # Per-slide transition (Phase 1a of agora#226).  Persisted
+                    # verbatim so the chromium-player branch can read it back;
+                    # the mpv player ignores anything other than ``cut``.
+                    # Defaults match the wire schema defaults.
+                    "transition": s.get("transition", "cut"),
+                    "transition_ms": int(s.get("transition_ms", 600)),
                 }
                 for s in slides
             ],

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -236,6 +236,63 @@ class TestSlideshowFetch:
         assert manifest["manifest_schema_version"] == "1.1"
 
     @pytest.mark.asyncio
+    async def test_transition_fields_default_when_absent_on_wire(self, cms_client):
+        """agora#226 Phase 1a: CMS may omit ``transition``/``transition_ms``
+        on a slide (older CMS, default-asset path) → persist as cut/600 so
+        the chromium player sees a sane default and the mpv player ignores
+        the cut as a no-op.
+        """
+        b1 = b"slide-bytes"
+        slides = [_make_slide("a.png", b1, asset_type="image", duration_ms=2000)]
+        # NOTE: no transition/transition_ms keys
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "NoTrans.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "slides": slides,
+        }
+        mapping = {slides[0]["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest_path = cms_client.settings.slideshows_dir / "NoTrans.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["slides"][0]["transition"] == "cut"
+        assert manifest["slides"][0]["transition_ms"] == 600
+
+    @pytest.mark.asyncio
+    async def test_transition_fields_propagated_from_wire(self, cms_client):
+        """agora#226 Phase 1a: when CMS provides transition/transition_ms,
+        they are persisted verbatim for the chromium player to consume.
+        """
+        b1 = b"slide-bytes"
+        slide = _make_slide("a.png", b1, asset_type="image", duration_ms=2000)
+        slide["transition"] = "fade"
+        slide["transition_ms"] = 850
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "WithTrans.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "slides": [slide],
+        }
+        mapping = {slide["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest_path = cms_client.settings.slideshows_dir / "WithTrans.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["slides"][0]["transition"] == "fade"
+        assert manifest["slides"][0]["transition_ms"] == 850
+
+    @pytest.mark.asyncio
     async def test_already_cached_short_circuits(self, cms_client):
         """Slideshow + every slide already cached → ACK without re-downloading."""
         b1, b2 = b"already-have-1", b"already-have-2"


### PR DESCRIPTION
Phase 1a of agora#226. Pairs with sslivins/agora-cms#621.

The CMS now emits `transition` and `transition_ms` on each `SlideDescriptor`. This commit makes the device persist them verbatim into the on-disk slideshow manifest JSON so the `feat/chromium-player` branch can consume them.

- Defaults to `cut` / 600 ms when the CMS omits the fields (older-CMS / default-asset path). Matches the wire schema defaults.
- mpv-based player ignores anything other than `cut` — silently hard-cuts, which is the conservative behavior the v1.0 fleet has always exhibited. Phase 3 (chromium-player branch) wires the real transition rendering.

## Tests

- `test_transition_fields_default_when_absent_on_wire`
- `test_transition_fields_propagated_from_wire`

Plus all existing `test_slideshow_fetch.py` tests still pass (16 total, all green locally).