### PR TITLE
fix(chromium-player): quit plymouth before launching sway kiosk

### DIFF
--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -63,6 +63,42 @@ SHELL_DIR = Path(__file__).resolve().parent / "shell"
 _SHELL_SWAY_RUNTIME_DIR = "/tmp/agora-sway-shell-run"
 _SHELL_SWAY_CONFIG_PATH = "/tmp/agora-sway-shell-run/sway.conf"
 
+# Process-wide flag so we only fire `plymouth quit` once per agora-player
+# lifetime. Subsequent kiosk restarts (e.g. after a webpage-mode bounce)
+# don't need to re-quit a plymouth that already exited.
+_plymouth_quit_done = False
+
+
+def _quit_plymouth() -> None:
+    """Tell Plymouth to release the DRM device before sway claims it.
+
+    Mirrors ``AgoraPlayer._quit_plymouth`` in player/service.py: under the
+    mpv backend that helper is called before every GStreamer/mpv pipeline
+    build, but the chromium backend never went through those code paths,
+    so plymouth was left holding DRM master and sway would silently fail
+    to come up — visible as a long-running splash that never advances.
+
+    ``--retain-splash`` keeps plymouth's last frame on the framebuffer
+    until chromium paints its first frame so there is no flash to black
+    during the handoff.
+    """
+    global _plymouth_quit_done
+    if _plymouth_quit_done:
+        return
+    _plymouth_quit_done = True
+    try:
+        subprocess.run(
+            ["/usr/bin/plymouth", "quit", "--retain-splash"],
+            timeout=5,
+            capture_output=True,
+        )
+        logger.info("ChromiumPlayer: plymouth quit (retained splash)")
+    except FileNotFoundError:
+        # Plymouth not installed (e.g. dev workstation, unit-test host).
+        pass
+    except Exception as e:
+        logger.debug("ChromiumPlayer: plymouth quit skipped: %s", e)
+
 
 class ChromiumPlayer:
     """Manage a persistent sway+chromium kiosk + shell control channel.
@@ -443,6 +479,12 @@ class ChromiumPlayer:
         sway's ``exec`` double-forks + setsids out of any process group.
         """
         self._stop_sway_kiosk()
+
+        # Plymouth holds DRM master across boot; sway will silently fail
+        # to acquire /dev/dri/cardX (looking like a frozen splash) until
+        # plymouth is told to release it. Idempotent across kiosk
+        # restarts.
+        _quit_plymouth()
 
         env = os.environ.copy()
         env["XDG_RUNTIME_DIR"] = _SHELL_SWAY_RUNTIME_DIR

--- a/tests/test_chromium_backend.py
+++ b/tests/test_chromium_backend.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from player.chromium_backend import ChromiumPlayer, _WebSocketState
+import player.chromium_backend as chromium_backend
 
 
 # ── Command JSON shape ──────────────────────────────────────────────
@@ -366,3 +367,69 @@ def test_root_serves_shell_index(routing_cp):
     resp = client.get("/")
     assert resp.status_code == 200
     assert "shell-root" in resp.text
+
+
+# ── Plymouth quit on sway-kiosk launch ───────────────────────────────
+
+
+def test_start_sway_kiosk_quits_plymouth_before_launching_sway(cp, monkeypatch):
+    """Regression: the chromium backend MUST call `plymouth quit` before
+    spawning sway, otherwise plymouth keeps DRM master and sway silently
+    fails to come up (visible as a frozen boot splash).
+    """
+    chromium_backend._plymouth_quit_done = False  # reset module-level flag
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    fake_popen = MagicMock()
+    fake_popen.return_value.poll.return_value = None
+    fake_popen.return_value.pid = 12345
+
+    monkeypatch.setattr(chromium_backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(chromium_backend.subprocess, "Popen", fake_popen)
+
+    cp._start_sway_kiosk()
+
+    # plymouth must have been invoked, and BEFORE Popen (which spawns sway).
+    plymouth_invocations = [c for c in calls if c and "plymouth" in c[0]]
+    assert plymouth_invocations, "plymouth quit was never called"
+    assert plymouth_invocations[0][1:] == ["quit", "--retain-splash"], (
+        f"unexpected plymouth args: {plymouth_invocations[0]}"
+    )
+    # Popen called exactly once (the sway launch).
+    assert fake_popen.call_count == 1
+    sway_argv = fake_popen.call_args.args[0]
+    assert "sway" in sway_argv, f"sway not in argv: {sway_argv}"
+
+
+def test_quit_plymouth_is_idempotent(monkeypatch):
+    """Second call should be a no-op so repeated kiosk restarts don't
+    keep firing /usr/bin/plymouth."""
+    chromium_backend._plymouth_quit_done = False
+    calls = []
+    monkeypatch.setattr(
+        chromium_backend.subprocess, "run",
+        lambda cmd, *a, **kw: (calls.append(list(cmd)) or MagicMock(returncode=0)),
+    )
+
+    chromium_backend._quit_plymouth()
+    chromium_backend._quit_plymouth()
+    chromium_backend._quit_plymouth()
+
+    assert len(calls) == 1, f"plymouth quit fired {len(calls)} times, want 1"
+
+
+def test_quit_plymouth_swallows_missing_binary(monkeypatch):
+    """Dev hosts without plymouth installed must not crash the player."""
+    chromium_backend._plymouth_quit_done = False
+
+    def raises(cmd, *args, **kwargs):
+        raise FileNotFoundError("/usr/bin/plymouth")
+
+    monkeypatch.setattr(chromium_backend.subprocess, "run", raises)
+    # Must not raise.
+    chromium_backend._quit_plymouth()


### PR DESCRIPTION
## Problem

When booting a device on `feat/chromium-player`, the plymouth boot splash
runs for a long time and then sits frozen. Looks like a hang; recovery
requires a hard reboot. Hits every boot.

## Root cause

`player/service.py` (the mpv backend) calls `_quit_plymouth()` before
every pipeline build/launch so plymouth releases DRM master and sway/mpv
can take over (see `service.py` lines 1016, 1793, 1835, 2198).

`player/chromium_backend.py` (the new sway+chromium kiosk backend)
spawns sway via `systemd-run` in `_start_sway_kiosk` but **never** calls
plymouth quit. Plymouth keeps holding `/dev/dri/cardX`, sway silently
fails to acquire it, and the boot splash stays on screen forever.

Confirmed by grepping `player/chromium_backend.py` for `plymouth`:
zero matches.

## Fix

Add a module-level `_quit_plymouth()` helper in `chromium_backend.py`
that mirrors `AgoraPlayer._quit_plymouth` (with `--retain-splash` so
plymouth's last frame stays on the framebuffer until chromium paints
its first frame -- no flash to black during the handoff) and call it
once from `_start_sway_kiosk` before spawning sway. Idempotent across
kiosk restarts via a module-level flag.

## Tests

3 new tests in `tests/test_chromium_backend.py`:

- `test_start_sway_kiosk_quits_plymouth_before_launching_sway` --
  regression for this bug. Mocks subprocess and asserts plymouth was
  invoked before sway Popen.
- `test_quit_plymouth_is_idempotent` -- repeated kiosk restarts should
  not keep firing `/usr/bin/plymouth`.
- `test_quit_plymouth_swallows_missing_binary` -- dev hosts without
  plymouth installed must not crash the player.

`pytest tests/test_chromium_backend.py tests/test_player_service.py
tests/test_slideshow_player.py tests/test_loop_count.py` -- **250
passed** locally.

## Out of scope / follow-ups

- This fix doesn't change the mpv backend; `service.py._quit_plymouth`
  stays as-is.
- The two `_quit_plymouth` helpers could be factored to a shared
  utility module later, but the chromium backend is still labelled "demo"
  and the existing one is tightly coupled to `AgoraPlayer` state -- a
  surgical fix is the lower-risk move right now.
