### PR TITLE
Phase 2: mpv wall-clock-anchored slideshow playback (#226)

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -56,6 +56,88 @@ def _is_forward_schema(observed: str, player_max: str) -> bool:
     return _parse_schema_version(observed) > _parse_schema_version(player_max)
 
 
+# ── Wall-clock anchor helpers (agora#226 Phase 2) ──
+
+# How far in the past we'll tolerate the wall clock being relative to a
+# manifest anchor before assuming NTP hasn't converged yet.  A Pi without
+# an RTC boots near the Unix epoch; once NTP syncs, the clock jumps
+# forward by several decades.  We don't want to drive playback from a
+# 1970 timestamp.
+_CLOCK_SKEW_TOLERANCE_S = 3600  # 1h
+
+# The biggest gap we ever sleep between resync evaluations.  The "next
+# advance" timer is always armed at min(remaining_ms, RESYNC_CAP_MS) so
+# we re-check the anchor at least this often — that's how a Pi that
+# fell behind catches up without needing a separate watchdog tick.
+_RESYNC_CAP_MS = 5000
+
+
+def _parse_iso8601_utc(value: str) -> Optional[datetime]:
+    """Parse an ISO-8601 UTC timestamp (``...Z`` or ``+00:00`` suffix).
+
+    Returns ``None`` if the value is missing, the wrong type, or
+    unparseable — callers must treat ``None`` as "no anchor available"
+    and fall back to legacy relative-timer playback.  We intentionally
+    do not raise; bad manifest data should not crash the player.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # ``fromisoformat`` accepts ``+00:00`` but not the ``Z`` suffix
+        # until 3.11.  Normalize the suffix.
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _locate_slide_at(
+    elapsed_ms: int, slides: list[dict],
+) -> tuple[int, int]:
+    """Locate the active slide given ``elapsed_ms`` into the cycle.
+
+    Returns ``(target_idx, remaining_ms)`` where ``target_idx`` is the
+    0-based slide index that should be on screen right now, and
+    ``remaining_ms`` is the wall-clock time until the next slide
+    boundary (always > 0 and <= that slide's duration_ms).
+
+    ``elapsed_ms`` is normalized into ``[0, cycle_duration_ms)``, so
+    negative values (clock skew) or values past the cycle wrap around
+    correctly.  Empty slide lists raise ``ValueError`` — callers must
+    not invoke the anchored path on a degenerate manifest.
+
+    Slides with ``duration_ms <= 0`` are treated as 0-duration: the
+    function still returns a valid ``(idx, remaining_ms)`` by walking
+    past them.  If every slide is 0-duration the function returns
+    ``(0, 1)`` so the caller schedules a 1ms re-evaluation rather than
+    blocking forever.
+    """
+    if not slides:
+        raise ValueError("_locate_slide_at: slides must be non-empty")
+    durations = [max(int(s.get("duration_ms") or 0), 0) for s in slides]
+    cycle_ms = sum(durations)
+    if cycle_ms <= 0:
+        return (0, 1)
+    pos = elapsed_ms % cycle_ms
+    if pos < 0:
+        pos += cycle_ms
+    for idx, dur in enumerate(durations):
+        if dur <= 0:
+            continue
+        if pos < dur:
+            remaining = dur - pos
+            if remaining <= 0:
+                remaining = dur
+            return (idx, remaining)
+        pos -= dur
+    # ``pos < cycle_ms`` guarantees this is unreachable, but a defensive
+    # fallback keeps mypy happy and prevents UB on a bug elsewhere.
+    return (len(slides) - 1, max(durations[-1], 1))
+
+
 def _build_video_pipeline_str(board: Board) -> str:
     """Return the GStreamer pipeline string for video playback with audio.
 
@@ -174,7 +256,7 @@ class AgoraPlayer:
     and mpv subprocess on Pi 4/Pi 5 for video playback with hardware decoding.
     """
 
-    # ── Slideshow manifest schema version (agora#226 Phase 0) ──
+    # ── Slideshow manifest schema version (agora#226 Phase 0 + Phase 2) ──
     #
     # The CMS now tags every slideshow manifest with a
     # ``manifest_schema_version`` semver string ("1.0", "1.1", …).  This
@@ -184,10 +266,12 @@ class AgoraPlayer:
     # log INFO once-per-content-hash so the fleet dashboard can spot
     # devices lagging behind a CMS rollout.
     #
-    # Phase 0 ships the plumbing but does not yet bump the supported
-    # ceiling above 1.0 — Phase 2 lifts it to "1.1" once wall-clock
-    # resync lands.
-    PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.0"
+    # Phase 2 lifts the supported ceiling to "1.1": this player can
+    # consume the wall-clock anchor fields (``cycle_duration_ms`` /
+    # ``started_at``) and use them to land on the correct slide after a
+    # mid-cycle reboot.  Legacy 1.0 manifests still take the
+    # relative-timer path.
+    PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.1"
 
     # Class-level default so tests that bypass __init__ still see this
     # attribute as None (matches "not in a slideshow").
@@ -396,6 +480,17 @@ class AgoraPlayer:
                 digest[:8],
             )
             self._forward_schema_logged.add(digest)
+        # Wall-clock anchor (agora#226 Phase 2).  Only meaningful when
+        # the manifest is schema 1.1+ AND carries a parseable
+        # ``started_at`` AND the local wall clock is plausibly past it
+        # (clock-skew guard for pre-NTP boot).  If any precondition
+        # fails we fall back to the legacy relative-timer path; the
+        # anchor is rechecked each tick so a Pi whose clock syncs
+        # mid-playback transitions into anchored mode at the next tick.
+        anchor_dt = _parse_iso8601_utc(manifest.get("started_at") or "")
+        if anchor_dt is not None and _parse_schema_version(schema_version) < (1, 1):
+            # Defensive: ``started_at`` is only meaningful for 1.1+.
+            anchor_dt = None
         # ``epoch`` is bumped each time a slideshow starts so a stale
         # play_to_end watchdog or late mpv event from a prior slideshow
         # cannot drive the new one.
@@ -415,6 +510,19 @@ class AgoraPlayer:
             # Manifest schema version observed (Phase 0).  Phase 2 will
             # branch on this to choose legacy vs anchored playback.
             "schema_version": schema_version,
+            # Phase 2: wall-clock anchor (timezone-aware UTC) or None
+            # for legacy / unparseable manifests.  ``cycle_duration_ms``
+            # is cached on the dict so resync ticks don't have to
+            # re-sum slide durations each time.
+            "anchor": anchor_dt,
+            "cycle_duration_ms": sum(
+                max(int(s.get("duration_ms") or 0), 0) for s in slides
+            ),
+            # Phase 2: when set, indicates we're currently in the
+            # clock-skew guard window — anchor exists but ``now < anchor
+            # - tolerance``, so we play via legacy timers and re-check
+            # the wall clock each tick.
+            "clock_skew_active": False,
         }
         self._slideshow_manifest_digest = digest
         self._loops_completed = 0
@@ -424,16 +532,238 @@ class AgoraPlayer:
         )
         self._play_next_slide()
 
+    def _resolve_anchored_target(
+        self, ss: dict,
+    ) -> Optional[tuple[int, int]]:
+        """Return ``(target_idx, remaining_ms)`` for the anchored path,
+        or ``None`` if we should take the legacy relative-timer path.
+
+        Falls back to legacy when:
+
+        * The manifest has no ``anchor`` (schema < 1.1, or 1.1 without
+          a parseable ``started_at``).
+        * The cycle is degenerate (no slides with positive duration).
+        * The wall clock is more than ``_CLOCK_SKEW_TOLERANCE_S`` before
+          the anchor — implies NTP hasn't converged yet.  We toggle
+          ``ss["clock_skew_active"]`` so the next tick re-evaluates and
+          we log the transition exactly once per slideshow start.
+
+        Note this is called from BOTH ``_play_next_slide`` (initial
+        dispatch and natural advance) AND ``_on_resync_tick`` (mid-slide
+        re-evaluation).  The function is pure w.r.t. ``ss`` (it only
+        mutates ``clock_skew_active`` for telemetry).
+        """
+        anchor: Optional[datetime] = ss.get("anchor")
+        if anchor is None:
+            return None
+        slides = ss.get("slides") or []
+        cycle_ms = int(ss.get("cycle_duration_ms") or 0)
+        if not slides or cycle_ms <= 0:
+            return None
+
+        now = datetime.now(timezone.utc)
+        skew_s = (anchor - now).total_seconds()
+        if skew_s > _CLOCK_SKEW_TOLERANCE_S:
+            # Wall clock is too far behind the anchor — likely a freshly
+            # booted Pi without an RTC, before NTP syncs.  Run the
+            # legacy relative-timer path until the clock catches up.
+            if not ss.get("clock_skew_active"):
+                logger.info(
+                    "Slideshow %s: clock-skew guard ACTIVE "
+                    "(now=%s anchor=%s skew_s=%.0f) — using legacy timer chain",
+                    ss["name"], now.isoformat(), anchor.isoformat(), skew_s,
+                )
+                ss["clock_skew_active"] = True
+            return None
+        if ss.get("clock_skew_active"):
+            logger.info(
+                "Slideshow %s: clock-skew guard CLEARED (now=%s anchor=%s) "
+                "— switching to anchored playback",
+                ss["name"], now.isoformat(), anchor.isoformat(),
+            )
+            ss["clock_skew_active"] = False
+
+        elapsed_ms = int((now - anchor).total_seconds() * 1000)
+        return _locate_slide_at(elapsed_ms, slides)
+
+    def _play_anchored_slide(
+        self, ss: dict, target_idx: int, remaining_ms: int,
+    ) -> bool:
+        """Wall-clock-anchored slide dispatch (Phase 2 of agora#226).
+
+        Plays ``slides[target_idx]`` and arms a single resync timer at
+        ``min(remaining_ms, _RESYNC_CAP_MS)``.  On fire, the tick
+        re-evaluates the anchor:
+
+        * Same target as last time → natural advance to ``target_idx+1``
+          via ``_play_next_slide``.
+        * Different target → snap to the new index (corrects for the
+          case where the player drifted behind or the wall clock just
+          jumped forward).
+
+        ``play_to_end`` videos in the anchored path still use mpv's
+        natural ``end-file`` event for the common case, but the resync
+        tick will force-advance if the cycle has drifted past the
+        video's expected end by more than the overrun tolerance
+        (``max(2 × _RESYNC_CAP_MS, 0.25 × cycle_duration_ms, 10s)``).
+        """
+        slides = ss["slides"]
+        slide = slides[target_idx]
+        slide_name = slide.get("name") or ""
+        path = self._resolve_asset(slide_name)
+        if not path:
+            logger.error(
+                "Slideshow %s: anchored slide %d (%s) missing on disk "
+                "— skipping ahead",
+                ss["name"], target_idx, slide_name,
+            )
+            ss["misses_this_cycle"] = ss.get("misses_this_cycle", 0) + 1
+            if ss["misses_this_cycle"] >= len(slides):
+                logger.error(
+                    "Slideshow %s: all %d slides missing on disk — "
+                    "aborting → splash",
+                    ss["name"], len(slides),
+                )
+                self._clear_slideshow()
+                self._show_splash()
+                return False
+            # Advance the cursor past the missing slide and let the next
+            # tick (or recursion) pick up the next target.
+            ss["index"] = (target_idx + 1) % len(slides)
+            return self._play_next_slide()
+
+        ss["misses_this_cycle"] = 0
+        # Track the index so ``_play_next_slide``'s natural-advance
+        # branch keeps working for legacy callers (mpv ``ended`` events,
+        # tests poking at ``ss["index"]``).
+        ss["index"] = target_idx + 1
+        ss["anchored_current_idx"] = target_idx
+
+        self._cancel_slide_timeout()
+        is_video_slide = (slide.get("asset_type") == "video")
+        play_to_end = bool(slide.get("play_to_end")) and is_video_slide
+
+        logger.info(
+            "Slideshow %s: anchored slide %d/%d %s "
+            "(play_to_end=%s remaining_ms=%d)",
+            ss["name"], target_idx + 1, len(slides),
+            slide_name, play_to_end, remaining_ms,
+        )
+
+        if play_to_end:
+            # Reuse the existing IPC/respawn machinery — its watchdog
+            # already covers the "mpv silently misbehaves" case.  The
+            # resync tick below covers the wall-clock overrun case.
+            self._play_slide_to_end(slide, slide_name, path, ss)
+        else:
+            if not self._loadfile_mpv(path, loop=True, muted=False):
+                self._start_mpv(path, loop=True)
+            self._update_current(
+                mode=PlaybackMode.PLAY,
+                asset=ss["name"],
+                started_at=datetime.now(timezone.utc),
+            )
+
+        tick_ms = min(max(remaining_ms, 1), _RESYNC_CAP_MS)
+        epoch = ss["epoch"]
+        ss["timeout_id"] = GLib.timeout_add(
+            tick_ms, self._on_anchored_resync_tick, epoch,
+        )
+        return False
+
+    def _on_anchored_resync_tick(self, epoch: int) -> bool:
+        """GLib timeout for the wall-clock-anchored resync tick.
+
+        Fired at most every ``_RESYNC_CAP_MS`` ms.  Re-evaluates the
+        anchor and decides whether to natural-advance, snap, or
+        force-advance an overrunning ``play_to_end`` video.
+        """
+        ss = self._slideshow
+        if not ss or ss.get("epoch") != epoch:
+            return False  # one-shot, stale tick
+        ss["timeout_id"] = None
+
+        target = self._resolve_anchored_target(ss)
+        if target is None:
+            # Anchor became unusable (e.g. someone replaced the manifest
+            # mid-flight).  Fall back to a legacy natural advance so
+            # playback keeps moving.
+            return self._play_next_slide()
+
+        target_idx, remaining_ms = target
+        current_idx = ss.get("anchored_current_idx", -1)
+
+        if target_idx != current_idx:
+            logger.info(
+                "Slideshow %s: anchored resync SNAP from idx=%d to idx=%d "
+                "(remaining_ms=%d)",
+                ss["name"], current_idx, target_idx, remaining_ms,
+            )
+            return self._play_anchored_slide(ss, target_idx, remaining_ms)
+
+        # Same target slide.  If this is a play_to_end video that has
+        # overrun the cycle by more than the tolerance, force-advance.
+        pending = ss.get("pending_play_to_end")
+        cycle_ms = int(ss.get("cycle_duration_ms") or 0)
+        if pending is not None and cycle_ms > 0:
+            overrun_tolerance = max(
+                2 * _RESYNC_CAP_MS, cycle_ms // 4, 10_000,
+            )
+            armed_at: Optional[datetime] = pending.get("armed_at")
+            slide = ss["slides"][current_idx] if 0 <= current_idx < len(ss["slides"]) else None
+            slide_dur = int((slide or {}).get("duration_ms") or 0)
+            if armed_at is not None and slide_dur > 0:
+                elapsed_since_arm = (
+                    datetime.now(timezone.utc) - armed_at
+                ).total_seconds() * 1000
+                if elapsed_since_arm > slide_dur + overrun_tolerance:
+                    logger.warning(
+                        "Slideshow %s: play_to_end overrun (slide=%s "
+                        "elapsed_ms=%.0f slide_dur=%d tolerance=%d) "
+                        "— force-advancing",
+                        ss["name"], pending.get("slide_name"),
+                        elapsed_since_arm, slide_dur, overrun_tolerance,
+                    )
+                    self._stop_mpv()
+                    ss["pending_play_to_end"] = None
+                    # Advance by re-running the anchored math at "now".
+                    new_target = self._resolve_anchored_target(ss)
+                    if new_target is not None:
+                        return self._play_anchored_slide(ss, *new_target)
+                    return self._play_next_slide()
+
+        # Same target, no overrun — just arm another tick.
+        tick_ms = min(max(remaining_ms, 1), _RESYNC_CAP_MS)
+        ss["timeout_id"] = GLib.timeout_add(
+            tick_ms, self._on_anchored_resync_tick, epoch,
+        )
+        return False
+
     def _play_next_slide(self) -> bool:
         """Advance to the next slide in the active slideshow.
 
         Loops back to the first slide when end is reached, honouring the
         slideshow-level loop_count.  Returns False so it can also be used
         as a one-shot GLib timeout callback.
+
+        For schema 1.1+ manifests with a usable wall-clock anchor this
+        dispatches to the anchored path (``_play_anchored_slide``) which
+        computes the target slide from ``now - anchor`` rather than just
+        incrementing the index.  Legacy 1.0 manifests (or anchored ones
+        where the wall clock hasn't caught up yet) take the original
+        relative-timer path below.
         """
         ss = self._slideshow
         if not ss:
             return False
+
+        # Phase 2: try the anchored path first when the manifest supports
+        # it.  ``_resolve_anchored_target`` returns None if we should fall
+        # back to the legacy chain — e.g. clock-skew guard active, no
+        # anchor, or degenerate cycle.
+        anchored = self._resolve_anchored_target(ss)
+        if anchored is not None:
+            return self._play_anchored_slide(ss, *anchored)
 
         if ss["index"] >= len(ss["slides"]):
             ss["loops_completed"] += 1

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -169,15 +169,15 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.1")
+        ], version="1.2")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
         assert player._slideshow is not None
-        assert player._slideshow["schema_version"] == "1.1"
+        assert player._slideshow["schema_version"] == "1.2"
         # INFO logged, mentions both the observed and the player-max version.
         assert any(
-            "manifest_schema_version=1.1" in rec.getMessage()
-            and "player max=1.0" in rec.getMessage()
+            "manifest_schema_version=1.2" in rec.getMessage()
+            and "player max=1.1" in rec.getMessage()
             for rec in caplog.records
         ), f"forward-version INFO not logged: {[r.getMessage() for r in caplog.records]}"
 
@@ -187,14 +187,14 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.1")
+        ], version="1.2")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
             player._clear_slideshow()
             player._start_slideshow("Show", None)
         forward_logs = [
             r for r in caplog.records
-            if "manifest_schema_version=1.1" in r.getMessage()
+            if "manifest_schema_version=1.2" in r.getMessage()
         ]
         assert len(forward_logs) == 1, (
             f"forward-version INFO should fire once per digest, got "
@@ -203,8 +203,8 @@ class TestManifestSchemaVersion:
 
     def test_unknown_envelope_fields_ignored(self, mpv_player):
         """Forward-compat: a manifest sprouting an unrecognised top-level
-        field (e.g. cycle_duration_ms from Phase 1b) doesn't break the
-        legacy reader.
+        field (from a hypothetical schema_version above the current
+        player max) doesn't break the reader.
         """
         player, svc = mpv_player
         (player.assets_dir / "images" / "a.png").touch()
@@ -212,18 +212,15 @@ class TestManifestSchemaVersion:
         path = player.assets_dir / "slideshows" / "Show.json"
         path.write_text(json.dumps({
             "name": "Show",
-            "manifest_schema_version": "1.1",
-            "cycle_duration_ms": 1000,
-            "started_at": "2026-05-17T00:00:00Z",
+            "manifest_schema_version": "1.2",
+            "future_field": "ignored",
             "slides": [{"name": "a.png", "asset_type": "image",
                         "duration_ms": 1000, "play_to_end": False}],
         }))
         with patch.object(svc, "GLib"):
             player._start_slideshow("Show", None)
         assert player._slideshow is not None
-        assert player._slideshow["schema_version"] == "1.1"
-        # Legacy timer chain still in charge — Phase 0 does not consume
-        # cycle_duration_ms/started_at yet.
+        assert player._slideshow["schema_version"] == "1.2"
 
     def test_corrupt_schema_version_treated_as_pre_1_0(self, mpv_player, caplog):
         """A garbage value (e.g. ``"abc"``) is parsed as (0,0) which is
@@ -888,3 +885,231 @@ class TestSlideshowShortCircuitRegression:
         assert player._slideshow is None
         assert player._slideshow_manifest_digest is None
         player._show_splash.assert_called_once()
+
+
+
+# ── agora#226 Phase 2: wall-clock-anchored playback ──
+
+
+class TestLocateSlideAt:
+    """Pure-function tests for the ``_locate_slide_at`` helper.
+
+    Each test names the (elapsed_ms, slide-durations) input and the
+    expected (target_idx, remaining_ms) output. ``_locate_slide_at`` is
+    the math kernel of the anchored playback path — everything else in
+    Phase 2 is plumbing around it.
+    """
+
+    def _locate(self, *durations):
+        # Just builds a slides list with the given durations; field
+        # names match the on-disk manifest shape.
+        return [{"name": f"s{i}", "duration_ms": d}
+                for i, d in enumerate(durations)]
+
+    def test_start_of_cycle(self, mpv_player):
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(0, self._locate(1000, 2000, 3000))
+        assert idx == 0
+        assert remaining == 1000
+
+    def test_mid_first_slide(self, mpv_player):
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(400, self._locate(1000, 2000, 3000))
+        assert idx == 0
+        assert remaining == 600
+
+    def test_exact_boundary_to_second_slide(self, mpv_player):
+        """Cycle position == 1000 lands the start of slide 1, not the
+        end of slide 0 (half-open intervals).
+        """
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(1000, self._locate(1000, 2000, 3000))
+        assert idx == 1
+        assert remaining == 2000
+
+    def test_mid_last_slide(self, mpv_player):
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(4500, self._locate(1000, 2000, 3000))
+        assert idx == 2
+        assert remaining == 1500
+
+    def test_wraps_around_cycle(self, mpv_player):
+        """elapsed_ms past one full cycle wraps cleanly."""
+        _, svc = mpv_player
+        # cycle = 6000; elapsed = 6500 -> pos = 500 -> slide 0, 500ms left.
+        idx, remaining = svc._locate_slide_at(6500, self._locate(1000, 2000, 3000))
+        assert idx == 0
+        assert remaining == 500
+
+    def test_negative_elapsed_wraps(self, mpv_player):
+        """A small clock-skew (anchor slightly in the future) wraps to
+        the end of the cycle instead of crashing."""
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(-200, self._locate(1000, 2000, 3000))
+        # -200 % 6000 == 5800 -> 5800-3000(slide0)=2800, 2800-2000(slide1)=800
+        # actually: pos=5800; slide0 dur=1000, pos>=1000 -> pos=4800;
+        # slide1 dur=2000, pos>=2000 -> pos=2800; slide2 dur=3000, pos<3000
+        # -> idx=2, remaining = 3000-2800 = 200.
+        assert idx == 2
+        assert remaining == 200
+
+    def test_single_slide(self, mpv_player):
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(500, self._locate(2000))
+        assert idx == 0
+        assert remaining == 1500
+
+    def test_empty_slides_raises(self, mpv_player):
+        _, svc = mpv_player
+        with pytest.raises(ValueError):
+            svc._locate_slide_at(0, [])
+
+    def test_all_zero_duration_returns_safe_default(self, mpv_player):
+        """Degenerate manifest: every slide has zero duration. Return
+        (0, 1) so the caller schedules a 1ms re-eval rather than dividing
+        by zero or sleeping forever.
+        """
+        _, svc = mpv_player
+        idx, remaining = svc._locate_slide_at(100, self._locate(0, 0, 0))
+        assert idx == 0
+        assert remaining == 1
+
+
+class TestParseIso8601Utc:
+    def test_z_suffix(self, mpv_player):
+        _, svc = mpv_player
+        dt = svc._parse_iso8601_utc("2026-05-23T19:39:45.000Z")
+        from datetime import timezone
+        assert dt is not None
+        assert dt.tzinfo is timezone.utc
+
+    def test_plus_zero_suffix(self, mpv_player):
+        _, svc = mpv_player
+        dt = svc._parse_iso8601_utc("2026-05-23T19:39:45+00:00")
+        assert dt is not None
+
+    def test_invalid_returns_none(self, mpv_player):
+        _, svc = mpv_player
+        assert svc._parse_iso8601_utc("not-a-date") is None
+        assert svc._parse_iso8601_utc("") is None
+        assert svc._parse_iso8601_utc(None) is None  # type: ignore[arg-type]
+
+
+class TestAnchoredPlayback:
+    """Mid-cycle reboot → land on the right slide."""
+
+    def _write_anchored(self, player, name, slides, started_at,
+                        schema="1.1"):
+        import json
+        path = player.assets_dir / "slideshows" / f"{name}.json"
+        path.write_text(json.dumps({
+            "name": name,
+            "manifest_schema_version": schema,
+            "started_at": started_at,
+            "cycle_duration_ms": sum(s["duration_ms"] for s in slides),
+            "slides": slides,
+        }))
+        return path
+
+    def test_anchor_in_past_lands_on_mid_cycle_slide(self, mpv_player):
+        """Anchor = 12 min ago, cycle = 5 min, three 100s slides. We
+        should land 2 min into cycle 3 → slide index 1.
+        """
+        player, svc = mpv_player
+        from datetime import datetime, timedelta, timezone
+        for n in ("a.png", "b.png", "c.png"):
+            (player.assets_dir / "images" / n).touch()
+        anchor = datetime.now(timezone.utc) - timedelta(minutes=12)
+        self._write_anchored(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 100_000,
+             "play_to_end": False},
+            {"name": "b.png", "asset_type": "image", "duration_ms": 100_000,
+             "play_to_end": False},
+            {"name": "c.png", "asset_type": "image", "duration_ms": 100_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        # 12 min = 720_000 ms; cycle = 300_000 ms; pos = 720_000 % 300_000
+        # = 120_000 ms = 2 min in -> slide index 1.
+        ss = player._slideshow
+        assert ss is not None
+        assert ss.get("anchored_current_idx") == 1
+        # Resync tick armed at the cap, not the full remaining 180s.
+        tick_ms = glib.timeout_add.call_args[0][0]
+        assert tick_ms == 5000  # _RESYNC_CAP_MS
+
+    def test_clock_skew_active_falls_back_to_legacy(self, mpv_player, caplog):
+        """Anchor far in the future (NTP hasn't synced yet) → use the
+        legacy relative-timer chain until the wall clock catches up.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        from datetime import datetime, timedelta, timezone
+        future = datetime.now(timezone.utc) + timedelta(days=365)
+        self._write_anchored(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 5000,
+             "play_to_end": False},
+        ], started_at=future.isoformat().replace("+00:00", "Z"))
+        with patch.object(svc, "GLib") as glib, \
+                caplog.at_level("INFO", logger="agora.player"):
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        ss = player._slideshow
+        assert ss is not None
+        assert ss.get("clock_skew_active") is True
+        # No anchored_current_idx set — went through legacy path.
+        assert "anchored_current_idx" not in ss
+        assert any(
+            "clock-skew guard ACTIVE" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_legacy_manifest_takes_legacy_path(self, mpv_player):
+        """schema 1.0 manifest with no anchor → existing index-driven
+        chain runs unchanged.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        _write_manifest(player, "Show", [
+            {"name": "a.png", "asset_type": "image",
+             "duration_ms": 5000, "play_to_end": False},
+        ])
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 7
+            player._start_slideshow("Show", None)
+        ss = player._slideshow
+        assert ss is not None
+        # Legacy path advances ss["index"] in lockstep with dispatch.
+        assert ss["index"] == 1
+        assert "anchored_current_idx" not in ss
+
+    def test_resync_tick_advances_naturally(self, mpv_player):
+        """When the resync tick fires and computes the same idx as we
+        last dispatched, it just arms the next tick — no snap, no
+        re-loadfile.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        (player.assets_dir / "images" / "b.png").touch()
+        from datetime import datetime, timezone
+        anchor = datetime.now(timezone.utc)
+        self._write_anchored(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 60_000,
+             "play_to_end": False},
+            {"name": "b.png", "asset_type": "image", "duration_ms": 60_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 42
+            player._start_slideshow("Show", None)
+            ss = player._slideshow
+            assert ss["anchored_current_idx"] == 0
+            # Fire the resync tick — same epoch, slide 0 still active.
+            player._loadfile_mpv.reset_mock()
+            result = player._on_anchored_resync_tick(ss["epoch"])
+        assert result is False
+        # Still on slide 0; no extra loadfile call.
+        assert ss["anchored_current_idx"] == 0
+        player._loadfile_mpv.assert_not_called()


### PR DESCRIPTION
Phase 2 of agora#226 — mpv player wall-clock-anchored slideshow playback.

Bumps `PLAYER_MAX_MANIFEST_SCHEMA_VERSION` from `1.0` to `1.1` and adds the wall-clock-anchored playback path so that a Pi rebooting mid-cycle lands on the slide that **should** be on screen right now, not slide 0.

### Mechanism

- `_locate_slide_at(elapsed_ms, slides)` — pure function that returns the active slide index and ms-until-next-boundary given `now - anchor`. Handles cycle wrap-around, negative skew, and degenerate inputs.
- `_resolve_anchored_target(ss)` — picks anchored vs legacy. Falls back to legacy when the manifest has no anchor, the cycle is degenerate, or when the wall clock is more than 1 h before the anchor (NTP-not-yet-synced guard, re-checked every tick).
- `_play_anchored_slide` — dispatches the target slide and arms a single resync timer at `min(remaining_ms, 5 s)`. On tick: same target → arm next; different → snap; `play_to_end` overrun by `max(2 × 5 s, cycle/4, 10 s)` → force-stop and re-evaluate.

### Backward compat

- Schema 1.0 manifests with no `started_at` → existing relative-timer chain, unchanged.
- v1.1 manifest in the clock-skew guard window → legacy path until NTP syncs, then automatic transition into anchored mode on the next tick.

### Tests

Full agora pytest suite is green locally (1564 passed). New coverage:

- `TestLocateSlideAt` (9 cases): boundary, mid-slide, wrap, negative, single-slide, all-zero-duration, empty.
- `TestParseIso8601Utc` (3 cases): Z, +00:00, bad input.
- `TestAnchoredPlayback`:
  - Anchor 12 min ago + 5 min cycle (three 100 s slides) → lands on slide 1, resync timer armed at the 5 s cap (not the full remaining 180 s).
  - Anchor 1 year in the future → clock-skew guard active, legacy path, INFO log emitted.
  - 1.0 manifest → still takes legacy path.
  - Resync tick with same target → no extra loadfile.

Forward-version tests bumped from `1.1` → `1.2` (since `1.1` is now inside the player's supported range).

### Version

1.11.79 → 1.11.80 (bump-main pushed this on Phase 1b's post-merge).

### Doesn't change

- CMS — Phase 1b already shipped the wire fields this consumes.
- Direct/WPS transport, OS image, splash, default-asset paths.
- `play_to_end` natural-completion behavior — only adds an overrun bound.

### Closes

Part of agora#226. Phase 3 (chromium-player parity) and Phase 4 (softplayer) still pending.