### PR TITLE
refactor(player): extract manifest read + anchor resolve into engine (Phase 4 PR-2)

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -29,6 +29,7 @@ from shared.models import CurrentState, DesiredState, PlaybackMode  # noqa: E402
 from shared.state import read_state, write_state  # noqa: E402
 from player.chromium_backend import ChromiumPlayer  # noqa: E402
 from player.slideshow_engine import (  # noqa: E402
+    AnchorStatus as _AnchorStatus,
     CLOCK_SKEW_TOLERANCE_S as _CLOCK_SKEW_TOLERANCE_S,
     PLAYER_MAX_MANIFEST_SCHEMA_VERSION as _PLAYER_MAX_MANIFEST_SCHEMA_VERSION,
     RESYNC_CAP_MS as _RESYNC_CAP_MS,
@@ -36,6 +37,8 @@ from player.slideshow_engine import (  # noqa: E402
     locate_slide_at as _locate_slide_at,
     parse_iso8601_utc as _parse_iso8601_utc,
     parse_schema_version as _parse_schema_version,
+    read_slideshow_manifest as _read_slideshow_manifest_pure,
+    resolve_anchored_target as _resolve_anchored_target_pure,
 )
 
 logger = logging.getLogger("agora.player")
@@ -340,25 +343,21 @@ class AgoraPlayer:
     def _read_slideshow_manifest(self, name: str) -> Optional[tuple[dict, str]]:
         """Read and validate a slideshow manifest from the assets dir.
 
-        Returns ``(parsed_dict, digest_hex)`` or ``None`` if missing/invalid.
-        ``digest_hex`` is the SHA-256 hex digest of the raw manifest bytes
-        and is used by ``_already_satisfied`` to detect manifest edits
-        between apply_desired calls (which would otherwise be invisible
-        because manifest contents are not part of DesiredState).
+        Thin wrapper around
+        :func:`player.slideshow_engine.read_slideshow_manifest` that
+        plugs in this instance's ``assets_dir`` and emits the existing
+        log message on unreadable / malformed manifests (the pure
+        helper is silent so softplayer can surface failures
+        differently).
         """
-        path = self.assets_dir / "slideshows" / f"{name}.json"
-        try:
-            raw = path.read_bytes()
-            data = json.loads(raw.decode("utf-8"))
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
-            logger.error("Slideshow manifest %s unreadable: %s", path, e)
-            return None
-        if not isinstance(data, dict):
-            return None
-        slides = data.get("slides")
-        if not isinstance(slides, list) or not slides:
-            return None
-        return data, hashlib.sha256(raw).hexdigest()
+        result = _read_slideshow_manifest_pure(self.assets_dir, name)
+        if result is None:
+            # Re-derive the path for the log message so behaviour matches
+            # the previous version exactly when the manifest is missing
+            # or malformed.
+            path = self.assets_dir / "slideshows" / f"{name}.json"
+            logger.error("Slideshow manifest %s unreadable or invalid", path)
+        return result
 
     def _cancel_slide_timeout(self) -> None:
         """Cancel any pending GLib slide-advance timeout."""
@@ -471,53 +470,49 @@ class AgoraPlayer:
         """Return ``(target_idx, remaining_ms)`` for the anchored path,
         or ``None`` if we should take the legacy relative-timer path.
 
-        Falls back to legacy when:
+        Thin wrapper around
+        :func:`player.slideshow_engine.resolve_anchored_target` that:
 
-        * The manifest has no ``anchor`` (schema < 1.1, or 1.1 without
-          a parseable ``started_at``).
-        * The cycle is degenerate (no slides with positive duration).
-        * The wall clock is more than ``_CLOCK_SKEW_TOLERANCE_S`` before
-          the anchor — implies NTP hasn't converged yet.  We toggle
-          ``ss["clock_skew_active"]`` so the next tick re-evaluates and
-          we log the transition exactly once per slideshow start.
-
-        Note this is called from BOTH ``_play_next_slide`` (initial
-        dispatch and natural advance) AND ``_on_resync_tick`` (mid-slide
-        re-evaluation).  The function is pure w.r.t. ``ss`` (it only
-        mutates ``clock_skew_active`` for telemetry).
+        * extracts the slides/cycle/anchor from ``ss`` so callers can
+          continue passing the existing slideshow-state dict, and
+        * owns the clock-skew telemetry (mutates
+          ``ss["clock_skew_active"]`` and logs the transition exactly
+          once per direction).  The pure helper is silent so softplayer
+          can surface skew differently.
         """
-        anchor: Optional[datetime] = ss.get("anchor")
-        if anchor is None:
-            return None
-        slides = ss.get("slides") or []
-        cycle_ms = int(ss.get("cycle_duration_ms") or 0)
-        if not slides or cycle_ms <= 0:
-            return None
+        resolution = _resolve_anchored_target_pure(
+            slides=ss.get("slides") or [],
+            cycle_duration_ms=int(ss.get("cycle_duration_ms") or 0),
+            anchor=ss.get("anchor"),
+            clock_skew_tolerance_s=_CLOCK_SKEW_TOLERANCE_S,
+        )
 
-        now = datetime.now(timezone.utc)
-        skew_s = (anchor - now).total_seconds()
-        if skew_s > _CLOCK_SKEW_TOLERANCE_S:
-            # Wall clock is too far behind the anchor — likely a freshly
-            # booted Pi without an RTC, before NTP syncs.  Run the
-            # legacy relative-timer path until the clock catches up.
+        if resolution.status is _AnchorStatus.CLOCK_SKEW_BEHIND:
             if not ss.get("clock_skew_active"):
+                now = datetime.now(timezone.utc)
                 logger.info(
                     "Slideshow %s: clock-skew guard ACTIVE "
                     "(now=%s anchor=%s skew_s=%.0f) — using legacy timer chain",
-                    ss["name"], now.isoformat(), anchor.isoformat(), skew_s,
+                    ss["name"], now.isoformat(),
+                    ss["anchor"].isoformat() if ss.get("anchor") else "<none>",
+                    resolution.skew_s,
                 )
                 ss["clock_skew_active"] = True
             return None
-        if ss.get("clock_skew_active"):
+
+        if ss.get("clock_skew_active") and resolution.status is _AnchorStatus.OK:
+            now = datetime.now(timezone.utc)
             logger.info(
                 "Slideshow %s: clock-skew guard CLEARED (now=%s anchor=%s) "
                 "— switching to anchored playback",
-                ss["name"], now.isoformat(), anchor.isoformat(),
+                ss["name"], now.isoformat(),
+                ss["anchor"].isoformat() if ss.get("anchor") else "<none>",
             )
             ss["clock_skew_active"] = False
 
-        elapsed_ms = int((now - anchor).total_seconds() * 1000)
-        return _locate_slide_at(elapsed_ms, slides)
+        if resolution.status is _AnchorStatus.OK:
+            return resolution.target
+        return None
 
     def _play_anchored_slide(
         self, ss: dict, target_idx: int, remaining_ms: int,

--- a/player/slideshow_engine.py
+++ b/player/slideshow_engine.py
@@ -5,9 +5,18 @@ mpv / Linux-path dependencies so it can be re-used unchanged by the
 agora-softplayer (Windows host) and any future non-Pi platform that
 runs the same chromium-shell slideshow logic.
 
-Phase 4 (incremental) of agora#226: PR-1 lifts the helpers that were
-already pure; the slideshow state machine itself stays in
-``player/service.py`` for now and will move in PR-2.
+Phase 4 of agora#226 lifts these in two steps:
+
+* PR-1 — pure helpers (``parse_schema_version``, ``is_forward_schema``,
+  ``parse_iso8601_utc``, ``locate_slide_at``) + constants.
+* PR-2 — adds ``read_slideshow_manifest`` (file IO + parse + digest)
+  and ``resolve_anchored_target`` (pure anchor → target-slide math
+  with an ``AnchorStatus`` enum for callers to drive their own
+  telemetry).
+
+The full slideshow state machine itself stays in ``player/service.py``
+for now — extracting it requires a Renderer/Timer/StateSink protocol
+design with broader test churn and is tracked as a future epic.
 
 The helpers are also re-exported from ``player/service.py`` as
 module-level aliases (``_parse_schema_version``, ``_is_forward_schema``,
@@ -17,7 +26,12 @@ modification.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
 from typing import Optional
 
 
@@ -136,3 +150,117 @@ def locate_slide_at(
     # ``pos < cycle_ms`` guarantees this is unreachable, but a defensive
     # fallback keeps mypy happy and prevents UB on a bug elsewhere.
     return (len(slides) - 1, max(durations[-1], 1))
+
+
+# ── Manifest reading (agora#226 Phase 4 PR-2) ──
+
+
+def read_slideshow_manifest(
+    assets_dir: Path, name: str,
+) -> Optional[tuple[dict, str]]:
+    """Read, parse, and digest a slideshow manifest from disk.
+
+    Returns ``(parsed_dict, sha256_hex)`` or ``None`` if the manifest is
+    missing, unreadable, malformed JSON, or has no slides list.  Pure
+    w.r.t. ``assets_dir``: callers pass the directory they want to read
+    from, so the same function serves both the Pi (``/opt/agora/assets``)
+    and the softplayer (Windows app-data dir).
+
+    The SHA-256 digest is used to detect manifest edits between
+    apply_desired calls — manifest contents are not part of
+    DesiredState, so without the digest a CMS-side edit is invisible to
+    the player.
+
+    Exceptions (``OSError``, ``json.JSONDecodeError``,
+    ``UnicodeDecodeError``) are swallowed and turned into ``None`` so
+    callers can take a "manifest missing → show splash" path without
+    sprinkling try/except everywhere.
+    """
+    path = assets_dir / "slideshows" / f"{name}.json"
+    try:
+        raw = path.read_bytes()
+        data = json.loads(raw.decode("utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    slides = data.get("slides")
+    if not isinstance(slides, list) or not slides:
+        return None
+    return data, hashlib.sha256(raw).hexdigest()
+
+
+# ── Anchored-playback resolution (agora#226 Phase 2 + Phase 4 PR-2) ──
+
+
+class AnchorStatus(Enum):
+    """Outcome of evaluating whether anchored playback should drive the
+    next slide dispatch.  ``OK`` means the caller should use
+    ``AnchorResolution.target``; everything else means fall back to the
+    legacy relative-timer chain.
+    """
+
+    OK = "ok"
+    NO_ANCHOR = "no_anchor"            # schema < 1.1 or missing started_at
+    DEGENERATE_CYCLE = "degenerate"    # no slides / total duration <= 0
+    CLOCK_SKEW_BEHIND = "skew_behind"  # now < anchor - tolerance (pre-NTP)
+
+
+@dataclass(frozen=True)
+class AnchorResolution:
+    """Result of :func:`resolve_anchored_target`.
+
+    * ``status`` — see :class:`AnchorStatus`.
+    * ``target`` — ``(target_idx, remaining_ms)`` iff ``status == OK``.
+    * ``skew_s`` — ``(anchor - now).total_seconds()``; informational,
+      useful for the one-shot clock-skew telemetry message.  ``0.0``
+      when no anchor was supplied.
+    """
+
+    status: AnchorStatus
+    target: Optional[tuple[int, int]] = None
+    skew_s: float = 0.0
+
+
+def resolve_anchored_target(
+    slides: list[dict],
+    cycle_duration_ms: int,
+    anchor: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+    clock_skew_tolerance_s: int = CLOCK_SKEW_TOLERANCE_S,
+) -> AnchorResolution:
+    """Compute the wall-clock-anchored target slide.
+
+    Pure function — does not mutate inputs, does not log, does not read
+    the wall clock unless ``now`` is left as ``None``.  Callers own all
+    telemetry (the player logs the clock-skew-guard transitions; the
+    softplayer might surface them differently).
+
+    Inputs:
+
+    * ``slides`` — the manifest's slide list (each dict has at least
+      ``duration_ms``).  Empty/missing produces ``DEGENERATE_CYCLE``.
+    * ``cycle_duration_ms`` — pre-computed sum of slide durations; passed
+      in so callers can cache it on their slideshow-state dict instead
+      of re-summing each tick.
+    * ``anchor`` — UTC ``datetime`` parsed from ``manifest.started_at``,
+      or ``None`` if the manifest is pre-1.1 or has no parseable
+      ``started_at``.  ``None`` → ``NO_ANCHOR``.
+    * ``now`` — override for testing; defaults to ``datetime.now(UTC)``.
+    * ``clock_skew_tolerance_s`` — how far the wall clock may lag the
+      anchor before we punt to legacy playback.  Default matches
+      :data:`CLOCK_SKEW_TOLERANCE_S`.
+    """
+    if anchor is None:
+        return AnchorResolution(AnchorStatus.NO_ANCHOR)
+    if not slides or cycle_duration_ms <= 0:
+        return AnchorResolution(AnchorStatus.DEGENERATE_CYCLE)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    skew_s = (anchor - now).total_seconds()
+    if skew_s > clock_skew_tolerance_s:
+        return AnchorResolution(AnchorStatus.CLOCK_SKEW_BEHIND, skew_s=skew_s)
+    elapsed_ms = int((now - anchor).total_seconds() * 1000)
+    target = locate_slide_at(elapsed_ms, slides)
+    return AnchorResolution(AnchorStatus.OK, target=target, skew_s=skew_s)

--- a/tests/test_slideshow_engine.py
+++ b/tests/test_slideshow_engine.py
@@ -1,0 +1,220 @@
+"""Unit tests for the pure helpers in ``player.slideshow_engine``.
+
+These tests do not touch GLib / GStreamer / mpv / Linux paths, so they
+also serve as a portability sanity-check for agora-softplayer's
+upcoming consumption of the same module.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from player.slideshow_engine import (
+    AnchorStatus,
+    CLOCK_SKEW_TOLERANCE_S,
+    PLAYER_MAX_MANIFEST_SCHEMA_VERSION,
+    RESYNC_CAP_MS,
+    is_forward_schema,
+    locate_slide_at,
+    parse_iso8601_utc,
+    parse_schema_version,
+    read_slideshow_manifest,
+    resolve_anchored_target,
+)
+
+
+class TestParseSchemaVersion:
+    def test_major_minor(self):
+        assert parse_schema_version("1.0") == (1, 0)
+        assert parse_schema_version("1.1") == (1, 1)
+        assert parse_schema_version("2.5") == (2, 5)
+
+    def test_patch_ignored(self):
+        assert parse_schema_version("1.0.3") == (1, 0)
+
+    def test_unparseable(self):
+        assert parse_schema_version("abc") == (0, 0)
+        assert parse_schema_version("") == (0, 0)
+        assert parse_schema_version("1") == (0, 0)
+        assert parse_schema_version(None) == (0, 0)  # type: ignore[arg-type]
+
+
+class TestIsForwardSchema:
+    def test_strictly_forward(self):
+        assert is_forward_schema("1.1", "1.0") is True
+        assert is_forward_schema("2.0", "1.5") is True
+
+    def test_equal_not_forward(self):
+        assert is_forward_schema("1.1", "1.1") is False
+
+    def test_backward_not_forward(self):
+        assert is_forward_schema("1.0", "1.1") is False
+
+
+class TestParseIso8601Utc:
+    def test_z_suffix(self):
+        dt = parse_iso8601_utc("2026-05-23T12:00:00Z")
+        assert dt is not None
+        assert dt.tzinfo is timezone.utc
+        assert dt.year == 2026 and dt.hour == 12
+
+    def test_offset_suffix(self):
+        dt = parse_iso8601_utc("2026-05-23T12:00:00+00:00")
+        assert dt is not None
+        assert dt.tzinfo is timezone.utc
+
+    def test_returns_none_on_garbage(self):
+        assert parse_iso8601_utc("not a date") is None
+        assert parse_iso8601_utc("") is None
+        assert parse_iso8601_utc(None) is None  # type: ignore[arg-type]
+        assert parse_iso8601_utc(123) is None  # type: ignore[arg-type]
+
+
+class TestLocateSlideAt:
+    def test_first_slide(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        idx, remaining = locate_slide_at(500, slides)
+        assert idx == 0
+        assert remaining == 2500
+
+    def test_second_slide(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        idx, remaining = locate_slide_at(5000, slides)
+        assert idx == 1
+        assert remaining == 2000
+
+    def test_wraps_modulo_cycle(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        # 7000ms is one full cycle; 7500 -> 500ms into slide 0
+        idx, remaining = locate_slide_at(7500, slides)
+        assert idx == 0
+        assert remaining == 2500
+
+    def test_negative_elapsed_wraps(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        idx, remaining = locate_slide_at(-500, slides)
+        # -500 % 7000 = 6500 -> slide 1, 500ms remaining
+        assert idx == 1
+        assert remaining == 500
+
+    def test_zero_duration_skipped(self):
+        slides = [
+            {"duration_ms": 0},
+            {"duration_ms": 1000},
+            {"duration_ms": 0},
+            {"duration_ms": 2000},
+        ]
+        idx, remaining = locate_slide_at(500, slides)
+        assert idx == 1
+        assert remaining == 500
+
+    def test_all_zero_returns_degenerate(self):
+        slides = [{"duration_ms": 0}, {"duration_ms": 0}]
+        assert locate_slide_at(0, slides) == (0, 1)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            locate_slide_at(0, [])
+
+
+class TestReadSlideshowManifest:
+    def test_happy_path(self, tmp_path: Path):
+        manifest = {
+            "manifest_schema_version": "1.1",
+            "slides": [{"asset": "a.jpg", "duration_ms": 1000}],
+        }
+        (tmp_path / "slideshows").mkdir()
+        (tmp_path / "slideshows" / "ss.json").write_text(json.dumps(manifest))
+        result = read_slideshow_manifest(tmp_path, "ss")
+        assert result is not None
+        data, digest = result
+        assert data["manifest_schema_version"] == "1.1"
+        assert len(digest) == 64  # sha256 hex
+        # Digest is deterministic for the same byte content
+        result2 = read_slideshow_manifest(tmp_path, "ss")
+        assert result2 is not None and result2[1] == digest
+
+    def test_missing_returns_none(self, tmp_path: Path):
+        assert read_slideshow_manifest(tmp_path, "nope") is None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path):
+        (tmp_path / "slideshows").mkdir()
+        (tmp_path / "slideshows" / "ss.json").write_text("{not json")
+        assert read_slideshow_manifest(tmp_path, "ss") is None
+
+    def test_non_dict_returns_none(self, tmp_path: Path):
+        (tmp_path / "slideshows").mkdir()
+        (tmp_path / "slideshows" / "ss.json").write_text("[1,2,3]")
+        assert read_slideshow_manifest(tmp_path, "ss") is None
+
+    def test_empty_slides_returns_none(self, tmp_path: Path):
+        (tmp_path / "slideshows").mkdir()
+        (tmp_path / "slideshows" / "ss.json").write_text('{"slides": []}')
+        assert read_slideshow_manifest(tmp_path, "ss") is None
+
+    def test_missing_slides_returns_none(self, tmp_path: Path):
+        (tmp_path / "slideshows").mkdir()
+        (tmp_path / "slideshows" / "ss.json").write_text('{"foo": "bar"}')
+        assert read_slideshow_manifest(tmp_path, "ss") is None
+
+
+def _anchor(offset_s: float = 0.0) -> datetime:
+    """Return an anchor ``offset_s`` seconds before/after a fixed ``now``."""
+    return _NOW - timedelta(seconds=offset_s)
+
+
+_NOW = datetime(2026, 5, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestResolveAnchoredTarget:
+    def test_no_anchor(self):
+        slides = [{"duration_ms": 1000}]
+        result = resolve_anchored_target(slides, 1000, None, now=_NOW)
+        assert result.status is AnchorStatus.NO_ANCHOR
+        assert result.target is None
+
+    def test_degenerate_empty_slides(self):
+        result = resolve_anchored_target([], 0, _anchor(0), now=_NOW)
+        assert result.status is AnchorStatus.DEGENERATE_CYCLE
+
+    def test_degenerate_zero_cycle(self):
+        slides = [{"duration_ms": 0}]
+        result = resolve_anchored_target(slides, 0, _anchor(0), now=_NOW)
+        assert result.status is AnchorStatus.DEGENERATE_CYCLE
+
+    def test_clock_skew_behind(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        # anchor is 2h in the future relative to now → wall clock too
+        # far behind.
+        future_anchor = _NOW + timedelta(hours=2)
+        result = resolve_anchored_target(slides, 7000, future_anchor, now=_NOW)
+        assert result.status is AnchorStatus.CLOCK_SKEW_BEHIND
+        assert result.skew_s > CLOCK_SKEW_TOLERANCE_S
+
+    def test_ok_first_slide(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        anchor = _NOW - timedelta(milliseconds=500)  # 500ms into slide 0
+        result = resolve_anchored_target(slides, 7000, anchor, now=_NOW)
+        assert result.status is AnchorStatus.OK
+        assert result.target == (0, 2500)
+
+    def test_ok_wraps_after_full_cycle(self):
+        slides = [{"duration_ms": 3000}, {"duration_ms": 4000}]
+        # 12 minutes into a 7s cycle wraps cleanly back to slide 0 +offset
+        anchor = _NOW - timedelta(minutes=12)
+        result = resolve_anchored_target(slides, 7000, anchor, now=_NOW)
+        assert result.status is AnchorStatus.OK
+        idx, _ = result.target  # type: ignore[misc]
+        assert idx in (0, 1)
+
+
+class TestConstants:
+    def test_constants_match_documented_values(self):
+        # Lock the documented behaviour: changing these requires updating
+        # docs and the CMS-side scheduler.
+        assert CLOCK_SKEW_TOLERANCE_S == 3600
+        assert RESYNC_CAP_MS == 5000
+        assert PLAYER_MAX_MANIFEST_SCHEMA_VERSION == "1.1"


### PR DESCRIPTION
Phase 4 PR-2 of agora#226. Continues lifting slideshow logic into `player/slideshow_engine.py` so agora-softplayer can share it.

## Rescoped (vs the original `SlideshowEngine class` plan)

The original plan was to extract a full `SlideshowEngine` class with `Renderer` / `Timer` / `StateSink` protocols in a single PR.  Closer inspection showed that's a multi-day refactor — the 117 existing tests reach directly into `AgoraPlayer`'s slideshow state, and the dispatch logic is tightly coupled to mpv-vs-chromium backend selection, watchdogs, GLib timers, and a dozen other player methods.

Instead, this PR lifts the **two remaining pure pieces** that are clearly shareable.  Softplayer's de-duplication in PR-3 can consume these directly while keeping its own thin sequencer adapter for now.  The full state-machine extraction is deferred to a follow-up epic.

## What

- **`read_slideshow_manifest(assets_dir, name)`** — pure file IO + JSON parse + sha256 digest.  Takes `assets_dir` as a parameter so softplayer can call it against its Windows app-data dir.  Returns `(data, digest_hex)` or `None`.
- **`resolve_anchored_target(slides, cycle_ms, anchor, *, now=, ...)`** — pure anchor → `(target_idx, remaining_ms)` math.  Returns an `AnchorResolution` with a four-way `AnchorStatus` enum (`OK` / `NO_ANCHOR` / `DEGENERATE_CYCLE` / `CLOCK_SKEW_BEHIND`) so callers drive their own telemetry.  The agora-side wrapper continues to log the clock-skew-guard transitions exactly as before; softplayer can surface them differently.

## service.py changes

- `_read_slideshow_manifest` → thin wrapper that plugs in `self.assets_dir` and emits the existing log on read failure.
- `_resolve_anchored_target` → thin wrapper that maps `AnchorStatus` back to the previous `Optional[(idx, remaining)]` API and owns the once-per-direction clock-skew INFO log + `ss['clock_skew_active']` mutation.

## Tests

- New `tests/test_slideshow_engine.py` — 29 direct tests of the pure helpers.
- All 117 existing tests still pass (`test_slideshow_player` + `test_chromium_backend` + `test_slideshow_fetch`).
- **Total: 146 passing.**

## What this unblocks

- **PR-3 (in agora-softplayer)**: replace softplayer's duplicated manifest reader + anchor resolver with the shared helpers, bumping the submodule pin to this commit.  Softplayer inherits Phase 2 (wall-clock-anchored playback) automatically.  The dispatch state machine stays in `windows_player.py`/`_slideshow.py` for now, but the file shrinks substantially.

Targets `feat/chromium-player` (same as PR-1).