### PR TITLE
Merge feat/multi-display-coordinator into feat/chromium-player

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -715,6 +715,10 @@ class CMSClient:
                         await self._handle_wipe_assets(msg, ws)
                     elif msg_type == "request_logs":
                         await self._handle_request_logs(msg, ws)
+                    elif msg_type == "bind_display":
+                        await self._handle_bind_display(msg, ws)
+                    elif msg_type == "unbind_display":
+                        await self._handle_unbind_display(msg, ws)
                     elif msg_type == "os_update_dispatch":
                         # Routed independently by agora-os-updater.service,
                         # which opens its own WPS connection. We see it on
@@ -891,6 +895,14 @@ class CMSClient:
 
         _, used_mb = _get_storage_mb(self.settings.assets_dir)
 
+        try:
+            from shared.board import hdmi_port_count
+            n_ports = hdmi_port_count()
+            available_slots = ["A", "B"] if n_ports >= 2 else ["A"]
+        except Exception:
+            logger.exception("Failed to read HDMI port count for heartbeat")
+            available_slots = ["A"]
+
         status_msg = {
             "type": "status",
             "protocol_version": PROTOCOL_VERSION,
@@ -909,6 +921,7 @@ class CMSClient:
             "local_api_enabled": _is_local_api_enabled(self.settings.persist_dir),
             "display_connected": current_data.get("display_connected"),
             "display_ports": current_data.get("display_ports"),
+            "available_slots": available_slots,
         }
         await self._ws.send(json.dumps(status_msg))
 
@@ -2079,6 +2092,96 @@ class CMSClient:
             pass
         await asyncio.sleep(1)
         os.system("sudo reboot")
+
+    async def _handle_bind_display(self, msg: dict, ws) -> None:
+        """Persist slot-B credentials so the player can activate slot B.
+
+        CMS sends ``bind_display`` over slot A's WS when an operator
+        clicks "Add second display" in the CMS UI. The message carries
+        the freshly minted slot-B credentials. Our job: persist them to
+        ``devices.json`` and acknowledge. The player process watches the
+        same file and brings up SlotState[B] on its next reconciliation
+        tick.
+
+        Expected message shape::
+
+            {
+              "type": "bind_display",
+              "slot": "B",
+              "device_id": "<slot-B device_id>",
+              "api_key": "<slot-B api_key>"
+            }
+        """
+        from shared.devices_store import KNOWN_SLOTS, write_slot
+
+        slot = msg.get("slot")
+        device_id = msg.get("device_id")
+        api_key = msg.get("api_key")
+
+        ack: dict = {"type": "bind_ack", "slot": slot}
+        if slot not in KNOWN_SLOTS or slot == "A":
+            ack["status"] = "error"
+            ack["error"] = f"invalid slot {slot!r}; must be 'B'"
+        elif not device_id or not api_key:
+            ack["status"] = "error"
+            ack["error"] = "missing device_id or api_key"
+        else:
+            try:
+                write_slot(
+                    self.settings.persist_dir,
+                    slot,
+                    {"device_id": device_id, "api_key": api_key},
+                )
+            except Exception as exc:
+                logger.exception("bind_display: failed to persist slot %s", slot)
+                ack["status"] = "error"
+                ack["error"] = str(exc)
+            else:
+                logger.info("bind_display: slot %s credentials persisted", slot)
+                ack["status"] = "ok"
+
+        try:
+            await ws.send(json.dumps(ack))
+        except Exception:
+            logger.exception("bind_display: failed to send bind_ack")
+
+    async def _handle_unbind_display(self, msg: dict, ws) -> None:
+        """Clear slot-B credentials so the player tears slot B down.
+
+        CMS sends ``unbind_display`` when an operator removes the second
+        virtual device (or as a precursor to deleting it). We clear slot
+        B from ``devices.json`` and acknowledge; the player reconciles
+        on its next tick.
+
+        Expected message shape::
+
+            {"type": "unbind_display", "slot": "B"}
+        """
+        from shared.devices_store import KNOWN_SLOTS, remove_slot
+
+        slot = msg.get("slot")
+        ack: dict = {"type": "unbind_ack", "slot": slot}
+        if slot not in KNOWN_SLOTS or slot == "A":
+            ack["status"] = "error"
+            ack["error"] = f"invalid slot {slot!r}; must be 'B'"
+        else:
+            try:
+                existed = remove_slot(self.settings.persist_dir, slot)
+            except Exception as exc:
+                logger.exception("unbind_display: failed to remove slot %s", slot)
+                ack["status"] = "error"
+                ack["error"] = str(exc)
+            else:
+                logger.info(
+                    "unbind_display: slot %s %s",
+                    slot, "removed" if existed else "was already absent",
+                )
+                ack["status"] = "ok"
+
+        try:
+            await ws.send(json.dumps(ack))
+        except Exception:
+            logger.exception("unbind_display: failed to send unbind_ack")
 
     async def _handle_factory_reset(self, ws) -> None:
         """Factory reset: wipe all data and reboot into AP mode.

--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -33,7 +33,10 @@ import threading
 import uuid
 from collections import deque
 from pathlib import Path
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+    from player.sway_manager import SwayManager  # noqa: F401  (forward ref)
 
 logger = logging.getLogger("agora.player.chromium")
 
@@ -87,6 +90,24 @@ class ChromiumPlayer:
           process group. Without the scope, ``killpg`` on the sway pid
           would leak chromium and the next start would fail to acquire
           ``/dev/dri/cardX``.
+
+    Two operating modes:
+
+      * **Standalone (single-display, legacy)**: ``sway_manager`` is
+        ``None``. This instance owns its own sway scope and chromium
+        runs as an ``exec`` line inside that sway. Existing single-
+        display callers stay on this path.
+
+      * **External sway (multi-display)**: ``sway_manager`` is a
+        :class:`player.sway_manager.SwayManager` that has already been
+        started by the ``Coordinator``. This instance does NOT spawn
+        sway; instead it launches its chromium subprocess directly as
+        a transient systemd scope, attached to the running sway as a
+        Wayland client via ``WAYLAND_DISPLAY`` / ``XDG_RUNTIME_DIR``.
+        ``app_id`` is passed to chromium as ``--class=<app_id>`` so the
+        sway config's ``for_window`` rules can pin the kiosk to its
+        target HDMI output. ``stop()`` only tears down the chromium
+        scope -- the shared sway stays up.
     """
 
     def __init__(
@@ -97,6 +118,8 @@ class ChromiumPlayer:
         port: int = DEFAULT_BIND_PORT,
         on_event: Optional[Callable[[dict], None]] = None,
         spawn_kiosk: bool = True,
+        sway_manager: Optional["SwayManager"] = None,
+        app_id: Optional[str] = None,
     ) -> None:
         self.assets_dir = Path(assets_dir)
         self.shell_dir = Path(shell_dir)
@@ -104,6 +127,8 @@ class ChromiumPlayer:
         self.port = port
         self._on_event = on_event
         self._spawn_kiosk = spawn_kiosk
+        self._sway_manager = sway_manager
+        self._app_id = app_id
 
         self._server_thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -111,6 +136,10 @@ class ChromiumPlayer:
         self._stop_event: Optional[asyncio.Event] = None
         self._ws_state = _WebSocketState()
 
+        # Process handle: either the standalone sway scope (when this
+        # instance owns sway) or the chromium-only scope (when external
+        # sway is provided). ``_scope_unit`` always names whichever
+        # scope is alive.
         self._sway_process: Optional[subprocess.Popen] = None
         self._sway_scope_unit: Optional[str] = None
 
@@ -139,10 +168,19 @@ class ChromiumPlayer:
             self.host, self.port,
         )
         if self._spawn_kiosk:
-            self._start_sway_kiosk()
+            if self._sway_manager is not None:
+                self._start_chromium_client_scope()
+            else:
+                self._start_sway_kiosk()
 
     def stop(self) -> None:
-        """Stop sway+chromium and the shell server."""
+        """Stop sway+chromium and the shell server.
+
+        In external-sway mode, ``_stop_sway_kiosk`` stops *our* scope
+        (the chromium-only one). The shared sway is owned by the
+        ``SwayManager`` -- callers there are responsible for shutting
+        it down independently.
+        """
         self._stop_sway_kiosk()
         if self._loop and self._stop_event:
             try:
@@ -386,21 +424,38 @@ class ChromiumPlayer:
 
     # ── Sway kiosk subprocess ──
 
+    def _chromium_argv(self, *, app_id: Optional[str] = None) -> list[str]:
+        """Build the chromium command line used by both launch modes.
+
+        ``--class=<app_id>`` is set when ``app_id`` is provided so the
+        wayland xdg-shell ``app_id`` matches the ``for_window`` rules in
+        the external sway's baked config. (Yes, ``--class`` on Wayland
+        sets the app_id, despite the X11-era flag name.)
+        """
+        argv = [
+            "chromium", "--no-sandbox", "--kiosk", "--noerrdialogs",
+            "--disable-translate", "--disable-infobars", "--incognito",
+            "--hide-scrollbars",
+            "--autoplay-policy=no-user-gesture-required",
+            "--load-extension=/opt/agora/src/player/extensions/hide-cursor",
+        ]
+        if app_id:
+            argv.append(f"--class={app_id}")
+        argv.append(self.shell_url())
+        return argv
+
     def _write_shell_sway_config(self) -> Path:
         """Render a minimal sway config that execs chromium at the shell URL.
 
         Lives inside the same 0o700 runtime dir used for ``XDG_RUNTIME_DIR``,
         written with ``O_NOFOLLOW`` so a pre-existing symlink can't redirect
         the (URL-containing) config body.
+
+        Only used in standalone (legacy) mode. In external-sway mode
+        the ``SwayManager`` writes its own config; this method is never
+        called.
         """
-        chromium_cmd = [
-            "chromium", "--no-sandbox", "--kiosk", "--noerrdialogs",
-            "--disable-translate", "--disable-infobars", "--incognito",
-            "--hide-scrollbars",
-            "--autoplay-policy=no-user-gesture-required",
-            "--load-extension=/opt/agora/src/player/extensions/hide-cursor",
-            self.shell_url(),
-        ]
+        chromium_cmd = self._chromium_argv(app_id=None)
         exec_line = "exec " + shlex.join(chromium_cmd)
         body = (
             "output * bg #000000 solid_color\n"
@@ -488,6 +543,10 @@ class ChromiumPlayer:
         Tears down via ``systemctl stop`` on the transient scope so the
         cgroup signals every descendant — including double-forked
         chromium grandchildren that pgrp-based kills can't see.
+
+        Works for both standalone and external-sway modes: the scope
+        contains different processes (sway+chromium vs chromium-only)
+        but the scope-teardown logic is identical.
         """
         proc = self._sway_process
         unit = self._sway_scope_unit
@@ -517,6 +576,58 @@ class ChromiumPlayer:
                     pass
         self._sway_process = None
         self._sway_scope_unit = None
+
+    def _start_chromium_client_scope(self) -> None:
+        """Launch chromium as a wayland client of the external SwayManager.
+
+        Used only when ``sway_manager`` is provided (multi-display
+        mode). Skips sway entirely -- the chromium subprocess connects
+        to the running sway via ``WAYLAND_DISPLAY`` /
+        ``XDG_RUNTIME_DIR`` from :meth:`SwayManager.env_for_client`.
+
+        Sets ``--class=<app_id>`` on chromium so the sway config's
+        ``for_window`` rules can pin the kiosk window to the correct
+        HDMI output. Wrapped in a transient systemd scope (same
+        rationale as standalone mode) so cgroup teardown reaches
+        chromium's double-forked grandchildren.
+        """
+        # Idempotency: if a previous client scope is still alive,
+        # tear it down first so we never have two chromiums fighting
+        # for the same shell URL.
+        self._stop_sway_kiosk()
+
+        assert self._sway_manager is not None  # checked by caller
+        env = os.environ.copy()
+        env.update(self._sway_manager.env_for_client())
+
+        self._sway_scope_unit = (
+            f"agora-shell-{(self._app_id or 'kiosk').replace('agora-shell-', '')}"
+            f"-{uuid.uuid4().hex[:8]}.scope"
+        )
+
+        argv = self._chromium_argv(app_id=self._app_id)
+        cmd = [
+            "systemd-run", "--scope", "--quiet",
+            "--unit", self._sway_scope_unit, "--collect",
+            *argv,
+        ]
+        logger.info(
+            "ChromiumPlayer: launching chromium client kiosk → %s "
+            "(app_id=%s, scope=%s)",
+            self.shell_url(), self._app_id, self._sway_scope_unit,
+        )
+        try:
+            self._sway_process = subprocess.Popen(
+                cmd, env=env,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, OSError) as e:
+            logger.error(
+                "ChromiumPlayer: failed to launch chromium client: %s", e,
+            )
+            self._sway_process = None
+            self._sway_scope_unit = None
 
 
 class _WebSocketState:

--- a/player/coordinator.py
+++ b/player/coordinator.py
@@ -1,0 +1,236 @@
+"""Top-level orchestrator for the multi-display chromium-backend player.
+
+The Coordinator owns:
+  * The shared :class:`SwayManager` (one sway instance, declares both
+    HDMI-A-1 and HDMI-A-2 at boot).
+  * A ``dict[slot, SlotState]`` mapping slot id ("A" / "B") to its
+    live :class:`SlotState`.
+
+Slot lifecycle:
+  * Slot A is always activated at ``start()`` -- the primary display.
+  * Slot B is activated at ``start()`` if ``persist/devices.json`` has
+    slot B credentials (set by a prior :func:`bind_display` WebSocket
+    message), and at runtime by :meth:`activate_slot` from the
+    ``bind_display`` handler.
+  * :meth:`deactivate_slot` tears a slot down. ``unbind_display`` calls
+    this then wipes slot B credentials.
+
+This module is the integration seam between the WebSocket message
+handlers in ``cms_client`` and the per-slot playback machinery in
+``SlotState``. It deliberately does NOT own:
+  * The GLib main loop (still :class:`AgoraPlayer`'s).
+  * inotify watchers / file-change callbacks (still :class:`AgoraPlayer`'s).
+  * The CMS WebSocket client (still :class:`cms_client.CMSClient`'s).
+
+Those stay where they are for PR 2a; ``AgoraPlayer`` plumbs slot
+dispatch into its existing callbacks. A future refactor may move them
+here, but this commit keeps the blast radius small.
+
+Pure scaffolding: nothing instantiates ``Coordinator`` yet. The wiring
+into :class:`AgoraPlayer` lands in the next commit.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Optional
+
+from player.slot_state import SlotPaths, SlotState
+from player.sway_manager import SwayManager, app_id_for_slot
+
+logger = logging.getLogger("agora.player.coordinator")
+
+
+# Per-slot shell server ports. Slot A keeps the historical port (8780)
+# so the legacy code paths that hard-coded it stay correct. Slot B
+# gets the next port.
+PORT_FOR_SLOT = {
+    "A": 8780,
+    "B": 8781,
+}
+
+
+def _port_for_slot(slot: str) -> int:
+    try:
+        return PORT_FOR_SLOT[slot]
+    except KeyError as exc:
+        raise ValueError(f"Unknown slot {slot!r}; expected one of {list(PORT_FOR_SLOT)}") from exc
+
+
+# Type alias for the chromium event callback: invoked as
+#   on_chromium_event(slot: str, payload: dict)
+# whenever a slot's shell WebSocket emits an event (ended, error, etc.).
+OnChromiumEvent = Callable[[str, dict], None]
+
+
+class Coordinator:
+    """Singleton orchestrator for sway + per-slot SlotStates.
+
+    Constructed once per :class:`AgoraPlayer` instance when the
+    chromium backend is enabled (``AGORA_PLAYER_BACKEND=chromium``).
+    """
+
+    def __init__(
+        self,
+        base_path: Path,
+        assets_dir: Path,
+        available_slots: tuple[str, ...] = ("A",),
+        slot_a_paths_mode: str = "legacy",
+        on_chromium_event: Optional[OnChromiumEvent] = None,
+    ) -> None:
+        """Initialise the Coordinator.
+
+        :param base_path: ``/opt/agora`` (or test fixture root).
+        :param assets_dir: shared asset cache; ALL slots read from here.
+        :param available_slots: which slots this hardware supports
+            (typically ``("A",)`` on single-output boards, ``("A", "B")``
+            on Pi5 / CM5). Determines sway config + which slot ids can
+            be activated.
+        :param slot_a_paths_mode: ``"legacy"`` (slot A uses pre-multi-
+            display path layout for back-compat) or ``"per_slot"`` (slot
+            A also writes under ``state/displays/A/``). The transition
+            from legacy → per_slot happens in a separate commit; until
+            then, default is ``"legacy"``.
+        :param on_chromium_event: callback invoked as
+            ``on_chromium_event(slot, payload)`` for each shell event.
+        """
+        if slot_a_paths_mode not in ("legacy", "per_slot"):
+            raise ValueError(
+                f"slot_a_paths_mode must be 'legacy' or 'per_slot', got {slot_a_paths_mode!r}"
+            )
+        self.base_path = Path(base_path)
+        self.assets_dir = Path(assets_dir)
+        self.available_slots = tuple(available_slots)
+        self.slot_a_paths_mode = slot_a_paths_mode
+        self._on_chromium_event = on_chromium_event
+
+        # SwayManager is constructed for the *available* slot set so
+        # its config only emits for_window pin lines for slots that
+        # might actually have a kiosk window. Outputs (HDMI-A-1 and
+        # HDMI-A-2) are always declared regardless -- see SwayManager.
+        self.sway_manager = SwayManager(slots=self.available_slots)
+
+        self.slots: dict[str, SlotState] = {}
+
+    # ── Lifecycle ──
+
+    def start(self) -> None:
+        """Start sway and activate slot A. Conditionally activate slot B.
+
+        Slot B is activated only if (a) it's in ``available_slots`` and
+        (b) ``persist/devices.json`` has slot B credentials. The
+        ``bind_display`` WS handler activates slot B at runtime if it
+        was not yet present.
+        """
+        self.sway_manager.start()
+        self.activate_slot("A")
+        if "B" in self.available_slots and self._slot_b_creds_present():
+            self.activate_slot("B")
+
+    def stop(self) -> None:
+        """Tear down all active slots, then stop sway."""
+        for slot in list(self.slots):
+            self.deactivate_slot(slot)
+        self.sway_manager.stop()
+
+    # ── Slot management ──
+
+    def activate_slot(self, slot: str) -> Optional[SlotState]:
+        """Bring a slot online. Idempotent: returns existing state if already up.
+
+        Returns ``None`` if ``slot`` is not in ``available_slots`` (e.g.
+        a bind_display targets slot B on a single-output board) -- the
+        caller is responsible for NACKing the bind in that case.
+        """
+        if slot in self.slots:
+            return self.slots[slot]
+        if slot not in self.available_slots:
+            logger.warning(
+                "Coordinator: cannot activate slot %s; not in available_slots %s",
+                slot, self.available_slots,
+            )
+            return None
+        paths = self._paths_for_slot(slot)
+        chromium_player = self._build_chromium_player(slot)
+        state = SlotState(
+            slot=slot,
+            paths=paths,
+            chromium_player=chromium_player,
+        )
+        logger.info(
+            "Coordinator: activating slot %s (port=%d, paths_mode=%s)",
+            slot, chromium_player.port,
+            "legacy" if (slot == "A" and self.slot_a_paths_mode == "legacy") else "per_slot",
+        )
+        state.start()
+        self.slots[slot] = state
+        return state
+
+    def deactivate_slot(self, slot: str) -> None:
+        """Tear a slot down. No-op if the slot was never active."""
+        state = self.slots.pop(slot, None)
+        if state is None:
+            return
+        logger.info("Coordinator: deactivating slot %s", slot)
+        state.stop()
+
+    def has_slot(self, slot: str) -> bool:
+        return slot in self.slots
+
+    # ── Internals ──
+
+    def _paths_for_slot(self, slot: str) -> SlotPaths:
+        """Pick the right SlotPaths factory for this slot."""
+        if slot == "A" and self.slot_a_paths_mode == "legacy":
+            return SlotPaths.legacy(self.base_path)
+        return SlotPaths.for_slot(self.base_path, slot)
+
+    def _build_chromium_player(self, slot: str) -> "ChromiumPlayer":  # noqa: F821  (lazy import)
+        """Construct the per-slot ChromiumPlayer wired to the shared sway."""
+        # Lazy import keeps importing this module cheap in tests that
+        # mock out the chromium backend entirely.
+        from player.chromium_backend import ChromiumPlayer
+        return ChromiumPlayer(
+            assets_dir=self.assets_dir,
+            port=_port_for_slot(slot),
+            sway_manager=self.sway_manager,
+            app_id=app_id_for_slot(slot),
+            on_event=self._make_event_callback(slot),
+        )
+
+    def _make_event_callback(self, slot: str) -> Optional[Callable[[dict], None]]:
+        """Adapt the slot-aware Coordinator callback to ChromiumPlayer's contract.
+
+        ``ChromiumPlayer`` expects ``Callable[[dict], None]``; the
+        Coordinator's caller wants ``Callable[[slot, dict], None]`` so it
+        can route events to the right SlotState. We close over the slot
+        id here.
+        """
+        cb = self._on_chromium_event
+        if cb is None:
+            return None
+        slot_id = slot
+        def _cb(payload: dict) -> None:
+            try:
+                cb(slot_id, payload)
+            except Exception:
+                logger.exception(
+                    "Coordinator: chromium event callback for slot %s raised",
+                    slot_id,
+                )
+        return _cb
+
+    def _slot_b_creds_present(self) -> bool:
+        """True iff persist/devices.json has slot B credentials.
+
+        Late import so the Coordinator stays decoupled from
+        ``shared.devices_store`` at module load time (and so tests can
+        construct a Coordinator without setting up a fake devices.json).
+        """
+        try:
+            from shared.devices_store import SLOT_B, read_slot
+            creds = read_slot(self.base_path / "persist", SLOT_B)
+        except Exception:
+            logger.exception("Coordinator: error reading devices.json slot B")
+            return False
+        return creds is not None and bool(creds.get("api_key"))

--- a/player/service.py
+++ b/player/service.py
@@ -218,10 +218,13 @@ class AgoraPlayer:
         self._coordinator: Optional["Coordinator"] = None
         if self._use_chromium_backend:
             from player.coordinator import Coordinator
+            from shared.board import hdmi_port_count
+            n_ports = hdmi_port_count()
+            available_slots: tuple[str, ...] = ("A", "B") if n_ports >= 2 else ("A",)
             self._coordinator = Coordinator(
                 base_path=self.base,
                 assets_dir=self.assets_dir,
-                available_slots=("A",),
+                available_slots=available_slots,
                 slot_a_paths_mode="legacy",
                 on_chromium_event=self._on_chromium_event_for_slot,
             )
@@ -2425,6 +2428,37 @@ class AgoraPlayer:
             return
         self._on_chromium_event(payload)
 
+    def _reconcile_slots_tick(self) -> bool:
+        """Periodic reconciliation of slot B against ``persist/devices.json``.
+
+        The cms_client persists bind/unbind decisions to that file; we
+        reflect them into the Coordinator here. Idempotent.
+
+        Always returns True so GLib re-arms the timeout.
+        """
+        try:
+            self._reconcile_slot_b()
+        except Exception:
+            logger.exception("slot reconciliation failed")
+        return True
+
+    def _reconcile_slot_b(self) -> None:
+        """Bring slot B up iff devices.json[B] has credentials, down otherwise."""
+        if not self._coordinator:
+            return
+        if "B" not in self._coordinator.available_slots:
+            return
+        from shared.devices_store import SLOT_B, read_slot
+        creds = read_slot(self.persist_dir, SLOT_B)
+        has_creds = creds is not None and bool(creds.get("api_key"))
+        currently_up = self._coordinator.has_slot("B")
+        if has_creds and not currently_up:
+            logger.info("slot reconciliation: activating slot B")
+            self._coordinator.activate_slot("B")
+        elif not has_creds and currently_up:
+            logger.info("slot reconciliation: deactivating slot B")
+            self._coordinator.deactivate_slot("B")
+
     def _handle_chromium_event_on_main(self, payload: dict) -> bool:
         """GLib idle callback: dispatch a single shell event.
 
@@ -3174,6 +3208,12 @@ class AgoraPlayer:
         # Periodic display probe: runs regardless of playback state so
         # display_connected in current.json stays fresh during splash/idle.
         GLib.timeout_add_seconds(10, self._probe_display_tick)
+
+        # Periodic slot-B reconciliation: cms_client persists bind/unbind
+        # decisions to devices.json; we read that on a tick and bring
+        # slot B up/down to match. Cheap (one stat + maybe one read).
+        if self._coordinator:
+            GLib.timeout_add_seconds(5, self._reconcile_slots_tick)
 
         # Signal handlers for clean shutdown
         def on_shutdown(signum, frame):

--- a/player/service.py
+++ b/player/service.py
@@ -164,6 +164,7 @@ class AgoraPlayer:
     # defaults and the existing mpv code paths remain untouched.
     _use_chromium_backend: bool = False
     _chromium_player = None  # type: ignore[var-annotated]
+    _coordinator = None  # type: ignore[var-annotated]
 
     IMAGE_PIPELINE_JPEG = (
         'filesrc location="{path}" ! '
@@ -214,10 +215,15 @@ class AgoraPlayer:
             os.environ.get("AGORA_PLAYER_BACKEND") == "chromium"
         )
         self._chromium_player: Optional[ChromiumPlayer] = None
+        self._coordinator: Optional["Coordinator"] = None
         if self._use_chromium_backend:
-            self._chromium_player = ChromiumPlayer(
+            from player.coordinator import Coordinator
+            self._coordinator = Coordinator(
+                base_path=self.base,
                 assets_dir=self.assets_dir,
-                on_event=self._on_chromium_event,
+                available_slots=("A",),
+                slot_a_paths_mode="legacy",
+                on_chromium_event=self._on_chromium_event_for_slot,
             )
         # Armed when ``apply_desired`` dispatches a scheduled finite-loop
         # video through the chromium shell. ``_on_chromium_event`` clears
@@ -2404,6 +2410,21 @@ class AgoraPlayer:
         except Exception:  # pragma: no cover — defensive
             logger.exception("Failed to schedule chromium event handling")
 
+    def _on_chromium_event_for_slot(self, slot: str, payload: dict) -> None:
+        """Coordinator → daemon shell event callback (slot-aware).
+
+        For PR 2a only slot A is active, so we drop the slot id and
+        delegate to the existing single-slot callback. Future commits
+        that activate slot B will route by slot here.
+        """
+        if slot != "A":
+            logger.debug(
+                "chromium shell event for slot %s ignored (slot B not yet wired): %s",
+                slot, payload,
+            )
+            return
+        self._on_chromium_event(payload)
+
     def _handle_chromium_event_on_main(self, payload: dict) -> bool:
         """GLib idle callback: dispatch a single shell event.
 
@@ -3127,9 +3148,16 @@ class AgoraPlayer:
 
         # Chromium player demo: bring up shell server + kiosk early so
         # the first apply_desired can hand off image/video without
-        # falling back to mpv.
-        if self._chromium_player:
-            self._chromium_player.start()
+        # falling back to mpv. The Coordinator handles sway + per-slot
+        # chromium kiosks; slot A is always activated at start(). For
+        # back-compat with the (large) existing call surface that
+        # references ``self._chromium_player``, we alias it to slot A's
+        # ChromiumPlayer after start.
+        if self._coordinator:
+            self._coordinator.start()
+            slot_a = self._coordinator.slots.get("A")
+            if slot_a is not None:
+                self._chromium_player = slot_a.chromium_player
 
         # Apply initial state (may show splash, which can take seconds)
         self.apply_desired()
@@ -3153,8 +3181,9 @@ class AgoraPlayer:
             self._running = False
             self._stop_mpv_event_listener()
             self._teardown()
-            if self._chromium_player:
-                self._chromium_player.stop()
+            if self._coordinator:
+                self._coordinator.stop()
+                self._chromium_player = None
             self.loop.quit()
 
         signal.signal(signal.SIGTERM, on_shutdown)
@@ -3167,6 +3196,7 @@ class AgoraPlayer:
         finally:
             self._stop_mpv_event_listener()
             self._teardown()
-            if self._chromium_player:
-                self._chromium_player.stop()
+            if self._coordinator:
+                self._coordinator.stop()
+                self._chromium_player = None
             logger.info("Agora Player stopped")

--- a/player/slot_state.py
+++ b/player/slot_state.py
@@ -1,0 +1,164 @@
+"""Per-slot state for the multi-display chromium-backend player.
+
+A ``SlotState`` represents the runtime state of one virtual device --
+i.e. one HDMI output's playback pipeline. The Pi5 (and CM5) can host
+two of these (slots "A" and "B"); other boards host only "A".
+
+What lives in a SlotState:
+  * A :class:`ChromiumPlayer` instance (one per slot, on its own port,
+    pinned to its target HDMI output by ``app_id``).
+  * A :class:`SlotPaths` describing where this slot's volatile state
+    (desired / current / cms_status / schedule) and durable per-slot
+    config (splash) live on disk.
+
+What does NOT live in a SlotState:
+  * Sway -- shared across slots, owned by the ``Coordinator``.
+  * The CMS WebSocket -- one per *device*, owned by ``cms_client``.
+    Each CMS message names its target slot in its envelope (added in
+    a later PR).
+  * The asset cache (``assets_dir``) -- fleet-wide; slots share it.
+
+Path layouts:
+  * ``SlotPaths.legacy(base)`` -- the pre-multi-display layout, where
+    a single device's state lived directly under ``state/`` and
+    ``persist/``. Used for slot A during the transition so existing
+    code paths keep working.
+  * ``SlotPaths.for_slot(base, slot)`` -- the new per-slot layout
+    under ``state/displays/<slot>/`` and ``persist/displays/<slot>/``.
+    Used for slot B always; slot A will move here once dual-write is
+    in place.
+
+This module is pure scaffolding: nothing instantiates ``SlotState`` yet.
+The ``Coordinator`` (see ``player/coordinator.py``) will be the only
+caller, wired in by a subsequent commit.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from player.chromium_backend import ChromiumPlayer
+
+logger = logging.getLogger("agora.player.slot_state")
+
+
+@dataclass(frozen=True)
+class SlotPaths:
+    """Per-slot file path constants for the chromium-backend player.
+
+    Five paths only; everything else (asset cache, auth tokens, board
+    config, etc.) is fleet-wide / device-wide and lives outside the
+    per-slot tree.
+    """
+
+    desired: Path        # current playback intent (state/)
+    current: Path        # what is actually playing (state/)
+    cms_status: Path     # last heartbeat-shape status snapshot (state/)
+    schedule: Path       # schedule overlay (state/)
+    splash: Path         # configured splash image path/value (persist/)
+
+    @classmethod
+    def legacy(cls, base_path: Path) -> "SlotPaths":
+        """Pre-multi-display layout used for slot A during the transition.
+
+        Slot A keeps writing to these legacy locations until the
+        ``state/displays/A/`` re-rooting commit lands (with dual-write
+        so a future rollback can still find the legacy files).
+        """
+        base = Path(base_path)
+        return cls(
+            desired=base / "state" / "desired.json",
+            current=base / "state" / "current.json",
+            cms_status=base / "state" / "cms_status.json",
+            schedule=base / "state" / "schedule.json",
+            splash=base / "persist" / "splash",
+        )
+
+    @classmethod
+    def for_slot(cls, base_path: Path, slot: str) -> "SlotPaths":
+        """Per-slot layout: state/displays/<slot>/ + persist/displays/<slot>/.
+
+        Used for slot B always, and for slot A after re-rooting lands.
+        """
+        base = Path(base_path)
+        state = base / "state" / "displays" / slot
+        persist = base / "persist" / "displays" / slot
+        return cls(
+            desired=state / "desired.json",
+            current=state / "current.json",
+            cms_status=state / "cms_status.json",
+            schedule=state / "schedule.json",
+            splash=persist / "splash",
+        )
+
+
+class SlotState:
+    """Per-slot ChromiumPlayer + state-paths bundle.
+
+    Constructed by the ``Coordinator`` -- callers should not build one
+    directly. See :meth:`Coordinator.activate_slot`.
+
+    Lifecycle:
+        state = SlotState(slot="A", paths=..., chromium_player=...)
+        state.start()
+        # ... daemon drives playback by writing to state.paths.desired,
+        # and by calling state.chromium_player.show_image(...)
+        state.stop()
+    """
+
+    def __init__(
+        self,
+        slot: str,
+        paths: SlotPaths,
+        chromium_player: "ChromiumPlayer",
+    ) -> None:
+        self.slot = slot
+        self.paths = paths
+        self.chromium_player = chromium_player
+
+    # ── Lifecycle ──
+
+    def ensure_dirs(self) -> None:
+        """Create the state/persist parent dirs for this slot.
+
+        Idempotent. Safe to call at every start (slot bind/unbind may
+        recreate the SlotState in place).
+        """
+        for p in (
+            self.paths.desired.parent,
+            self.paths.current.parent,
+            self.paths.cms_status.parent,
+            self.paths.schedule.parent,
+            self.paths.splash.parent,
+        ):
+            try:
+                p.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                logger.warning(
+                    "SlotState[%s]: could not create %s: %s", self.slot, p, e,
+                )
+
+    def start(self) -> None:
+        """Bring this slot online: ensure dirs + start its ChromiumPlayer."""
+        self.ensure_dirs()
+        self.chromium_player.start()
+
+    def stop(self) -> None:
+        """Tear this slot down: stop its ChromiumPlayer.
+
+        Does NOT delete state files -- those are the daemon's
+        rollback / restart safety net.
+        """
+        self.chromium_player.stop()
+
+    def is_alive(self) -> bool:
+        return self.chromium_player.is_alive()
+
+    def __repr__(self) -> str:
+        return (
+            f"SlotState(slot={self.slot!r}, port={self.chromium_player.port}, "
+            f"alive={self.is_alive()})"
+        )

--- a/player/sway_manager.py
+++ b/player/sway_manager.py
@@ -1,0 +1,319 @@
+"""Shared sway compositor lifecycle for the chromium-backend player.
+
+Before multi-display, ``ChromiumPlayer`` owned its own sway scope; sway
+ran with a single output declared and a single chromium kiosk wrapped
+inside it. That model breaks down when we want two chromium kiosks --
+one per HDMI output -- on the same Pi5: sway can only own the DRM
+device once, and ``swaymsg reload`` does NOT pick up a hot-added
+``output`` block. The fix is to bake **both** ``output HDMI-A-1`` and
+``output HDMI-A-2`` blocks into the sway config at boot and never
+restart sway at runtime. Per-slot chromium kiosks are then launched as
+separate systemd scopes that connect to the running sway as wayland
+clients; sway pins each kiosk's window to the correct output via
+``for_window [app_id="agora-shell-<slot>"] move container to output
+HDMI-A-<n>``.
+
+This module owns:
+  * Rendering the sway config with both outputs + per-slot ``for_window``
+    pins baked in.
+  * Starting / stopping the single sway scope.
+  * Exposing the ``XDG_RUNTIME_DIR`` + ``WAYLAND_DISPLAY`` env vars that
+    per-slot chromium subprocesses need to connect to the running sway.
+  * Running ``swaymsg`` commands against the live sway (e.g. to move a
+    window between outputs if a runtime re-pin is ever needed).
+
+The per-slot ``ChromiumPlayer`` no longer launches sway when a
+``SwayManager`` is provided -- it just runs its chromium kiosk as a
+client of the sway managed here. See ``ChromiumPlayer.__init__``.
+
+Single sway instance only. This class is **not** thread safe at the
+start/stop boundary; treat it as a singleton owned by the
+``Coordinator``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Iterable, Optional
+
+logger = logging.getLogger("agora.player.sway_manager")
+
+DEFAULT_RUNTIME_DIR = "/tmp/agora-sway-shell-run"
+DEFAULT_CONFIG_PATH = "/tmp/agora-sway-shell-run/sway.conf"
+DEFAULT_WAYLAND_DISPLAY = "wayland-1"
+
+# Map slot id -> sway output name. The CM5 / Pi5 wire HDMI-0 to
+# ``HDMI-A-1`` and HDMI-1 to ``HDMI-A-2`` (see ``shared/board.py``).
+# Slot A always corresponds to the primary HDMI; slot B to the
+# secondary.
+SLOT_OUTPUT_MAP = {
+    "A": "HDMI-A-1",
+    "B": "HDMI-A-2",
+}
+
+
+def app_id_for_slot(slot: str) -> str:
+    """Return the wayland app_id used to identify a slot's chromium kiosk.
+
+    Chromium picks up its wayland app_id from the ``--class`` flag (yes,
+    despite the X11-sounding name -- on Wayland this maps to xdg-shell
+    ``app_id``). We pin each kiosk to its target output by app_id in the
+    baked sway config, so the same string must be used here, on the
+    chromium command line, and inside the sway config.
+    """
+    return f"agora-shell-{slot}"
+
+
+class SwayManager:
+    """Single sway compositor with both HDMI outputs declared at boot.
+
+    Lifecycle::
+
+        mgr = SwayManager(slots=("A", "B"))
+        mgr.start()
+        # ... chromium kiosks launched as separate scopes here ...
+        mgr.stop()
+
+    The runtime dir + wayland display socket are exposed via
+    :meth:`env_for_client` so per-slot kiosk subprocesses can connect
+    to this sway instance as wayland clients.
+
+    ``slots`` controls which ``for_window`` pin lines are emitted; declare
+    both ``("A", "B")`` on dual-HDMI Pi5 boards, just ``("A",)`` on
+    single-output boards. The corresponding ``output`` blocks are always
+    emitted for both HDMIs regardless -- sway happily ignores a declared
+    output that the kernel doesn't expose, and this lets us bake one
+    config that works on either board (a missing HDMI-A-2 just stays
+    "disconnected" until something is plugged in).
+    """
+
+    def __init__(
+        self,
+        slots: Iterable[str] = ("A", "B"),
+        runtime_dir: str = DEFAULT_RUNTIME_DIR,
+        config_path: str = DEFAULT_CONFIG_PATH,
+        wayland_display: str = DEFAULT_WAYLAND_DISPLAY,
+    ) -> None:
+        self._slots = tuple(slots)
+        self._runtime_dir = runtime_dir
+        self._config_path = config_path
+        self._wayland_display = wayland_display
+
+        self._process: Optional[subprocess.Popen] = None
+        self._scope_unit: Optional[str] = None
+
+    # ── Public lifecycle ──
+
+    def start(self) -> None:
+        """Start sway in a transient systemd scope.
+
+        Idempotent: a successful call followed by another (without
+        ``stop()``) is a no-op.
+        """
+        if self.is_alive():
+            logger.debug("SwayManager.start: already running")
+            return
+        # If a previous run left a dead process handle, clear it first
+        # so the scope unit gets a fresh uuid suffix.
+        self._process = None
+        self._scope_unit = None
+
+        try:
+            conf = self._write_config()
+        except OSError as e:
+            logger.error("SwayManager: could not write sway config: %s", e)
+            return
+
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self._runtime_dir
+        env["WAYLAND_DISPLAY"] = self._wayland_display
+
+        self._scope_unit = f"agora-sway-shell-{uuid.uuid4().hex[:8]}.scope"
+        cmd = [
+            "systemd-run", "--scope", "--quiet",
+            "--unit", self._scope_unit, "--collect",
+            "sway", "-c", str(conf),
+        ]
+        logger.info(
+            "SwayManager: launching sway scope=%s (slots=%s, outputs=%s)",
+            self._scope_unit,
+            ",".join(self._slots),
+            ",".join(SLOT_OUTPUT_MAP[s] for s in self._slots if s in SLOT_OUTPUT_MAP),
+        )
+        try:
+            self._process = subprocess.Popen(
+                cmd, env=env,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, OSError) as e:
+            logger.error("SwayManager: failed to launch sway: %s", e)
+            self._process = None
+            self._scope_unit = None
+
+    def stop(self) -> None:
+        """Stop the sway scope if running.
+
+        Uses ``systemctl stop`` on the transient scope so the cgroup
+        signals every descendant -- including any chromium kiosks that
+        were started as separate scopes but parented to the wayland
+        socket. Falls back to a cgroup-wide SIGKILL on timeout.
+        """
+        proc = self._process
+        unit = self._scope_unit
+        if proc and proc.poll() is None and unit:
+            logger.info(
+                "SwayManager: stopping scope=%s pid=%d", unit, proc.pid,
+            )
+            subprocess.run(
+                ["systemctl", "stop", unit],
+                timeout=8, check=False,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                subprocess.run(
+                    ["systemctl", "kill", "-s", "SIGKILL", unit],
+                    timeout=5, check=False,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    pass
+        self._process = None
+        self._scope_unit = None
+
+    def is_alive(self) -> bool:
+        """True iff the sway subprocess is still running."""
+        return bool(self._process and self._process.poll() is None)
+
+    # ── Client env ──
+
+    def env_for_client(self) -> dict[str, str]:
+        """Env vars a per-slot chromium subprocess needs to connect to this sway.
+
+        Returned dict can be merged into ``os.environ.copy()`` before
+        ``subprocess.Popen``.
+        """
+        return {
+            "XDG_RUNTIME_DIR": self._runtime_dir,
+            "WAYLAND_DISPLAY": self._wayland_display,
+        }
+
+    # ── Runtime control ──
+
+    def swaymsg(self, *args: str, timeout: float = 5.0) -> Optional[str]:
+        """Run ``swaymsg <args>`` against the live sway. Returns stdout or None.
+
+        Used by callers that need to move a window between outputs or
+        otherwise reconfigure layout at runtime. Returns ``None`` on
+        failure (sway not running, swaymsg missing, timeout, non-zero
+        exit) -- callers should treat that as best-effort: the baked
+        ``for_window`` pin should handle the common case so swaymsg
+        calls are a runtime-fixup safety net.
+        """
+        env = os.environ.copy()
+        env.update(self.env_for_client())
+        try:
+            result = subprocess.run(
+                ["swaymsg", *args],
+                env=env, timeout=timeout, check=False,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as e:
+            logger.debug("SwayManager.swaymsg(%s) failed: %s", args, e)
+            return None
+        if result.returncode != 0:
+            logger.debug(
+                "SwayManager.swaymsg(%s) exit=%d stderr=%s",
+                args, result.returncode, result.stderr.strip(),
+            )
+            return None
+        return result.stdout
+
+    # ── Internals ──
+
+    def _write_config(self) -> Path:
+        """Render the sway config and write it under the runtime dir.
+
+        Same security posture as ``ChromiumPlayer._write_shell_sway_config``:
+        runtime dir is 0o700, config opened ``O_NOFOLLOW`` so a
+        pre-existing symlink can't redirect the write.
+        """
+        body = self._render_config()
+        runtime_dir = Path(self._runtime_dir)
+        runtime_dir.mkdir(mode=0o700, exist_ok=True)
+        try:
+            os.chmod(runtime_dir, 0o700)
+        except OSError:
+            pass
+        conf_path = Path(self._config_path)
+        o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(
+            str(conf_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | o_nofollow,
+            0o600,
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(body)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        return conf_path
+
+    def _render_config(self) -> str:
+        """Return the sway config body as a single string.
+
+        Output blocks for **both** HDMI-A-1 and HDMI-A-2 are always
+        emitted so single-output boards work with the same baked config
+        as dual-output boards (sway treats the absent output as
+        disconnected). Per-slot ``for_window`` pin lines are only
+        emitted for slots in ``self._slots`` so a single-display device
+        doesn't pin a non-existent app_id.
+        """
+        lines: list[str] = [
+            "# Generated by agora SwayManager",
+            "",
+            "# Both HDMI outputs declared up-front: swaymsg reload",
+            "# does NOT pick up hot-added output blocks, so we have",
+            "# to bake them in at boot.",
+            "output HDMI-A-1 bg #000000 solid_color",
+            "output HDMI-A-2 bg #000000 solid_color",
+            "",
+            "seat * hide_cursor 1",
+            "default_border none",
+            "default_floating_border none",
+            "hide_edge_borders both",
+            "",
+            "# Per-slot kiosk window pinning. Each chromium subprocess",
+            "# is launched with --class=agora-shell-<slot> (which maps",
+            "# to xdg-shell app_id on Wayland) and is moved to its",
+            "# target HDMI output here.",
+        ]
+        for slot in self._slots:
+            output = SLOT_OUTPUT_MAP.get(slot)
+            if output is None:
+                logger.warning(
+                    "SwayManager: unknown slot %r, skipping for_window pin",
+                    slot,
+                )
+                continue
+            app_id = app_id_for_slot(slot)
+            lines.append(
+                'for_window [app_id="%s"] move container to output %s, '
+                'fullscreen enable, border none'
+                % (app_id, output),
+            )
+        lines.append("")
+        return "\n".join(lines)

--- a/shared/bootstrap_identity.py
+++ b/shared/bootstrap_identity.py
@@ -183,7 +183,11 @@ def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
     Raises ``exc_cls`` if the file is a symlink, not a regular file, owned
     by a different uid, or (repairably) has loose permissions.
 
-    Same-owner over-permissive mode is repaired to ``0o400`` via ``fchmod``.
+    Same-owner over-permissive mode is repaired to ``0o400`` via ``fchmod``
+    on POSIX. On Windows the POSIX file mode bits are synthesized from a
+    default template that doesn't reflect actual ACLs, and ``fchmod`` to
+    ``0o400`` raises ``WinError 5 (Access is denied)``, so we skip the
+    perm check entirely on non-POSIX platforms.
 
     Note: ``os.O_NOFOLLOW`` is Unix-only; on platforms without it (e.g.
     Windows) we degrade to a no-op (``0``) bit in the open flags. This
@@ -211,8 +215,7 @@ def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
                 f"refusing to load a secret from a file owned by another user"
             )
         perm = st.st_mode & 0o777
-        if perm != _FILE_MODE:
-            # Same owner and loose perms → repair via fd.
+        if os.name == "posix" and perm != _FILE_MODE:
             try:
                 os.fchmod(fd, _FILE_MODE)
             except OSError as e:

--- a/shared/bootstrap_identity.py
+++ b/shared/bootstrap_identity.py
@@ -184,9 +184,17 @@ def _open_existing_regular_file(path: Path, exc_cls: type[Exception]) -> int:
     by a different uid, or (repairably) has loose permissions.
 
     Same-owner over-permissive mode is repaired to ``0o400`` via ``fchmod``.
+
+    Note: ``os.O_NOFOLLOW`` is Unix-only; on platforms without it (e.g.
+    Windows) we degrade to a no-op (``0``) bit in the open flags. This
+    matches the defensive ``getattr(os, "O_NOFOLLOW", 0)`` pattern used by
+    the rest of agora (``chromium_backend``, ``player.service``,
+    ``sway_manager``) and lets the softplayer's Windows shim path actually
+    boot.
     """
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
-        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        fd = os.open(path, os.O_RDONLY | o_nofollow)
     except OSError as e:
         # ELOOP means a symlink was followed; distinguish for the caller.
         if getattr(e, "errno", None) in (40,):  # ELOOP on Linux
@@ -233,10 +241,11 @@ def _create_new_secret_file(
     newly-created file is durable across power-loss.
     """
     parent = path.parent
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
     try:
         fd = os.open(
             path,
-            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | o_nofollow,
             _FILE_MODE,
         )
     except FileExistsError:

--- a/tests/test_chromium_backend_external_sway.py
+++ b/tests/test_chromium_backend_external_sway.py
@@ -1,0 +1,204 @@
+"""Tests for ChromiumPlayer in external-sway mode (multi-display path).
+
+The standalone (single-display, legacy) code path is covered by
+``tests/test_chromium_backend.py``. This file exclusively covers the
+new behavior when a ``SwayManager`` is supplied at construction:
+
+- ``--class=<app_id>`` is appended to chromium argv
+- chromium is launched as a transient systemd scope (NOT inside sway)
+- the sway manager is NOT touched at start or stop
+- the wayland env vars come from the sway manager
+- ``stop()`` only tears down the chromium scope, never the sway
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from player.chromium_backend import ChromiumPlayer
+from player.sway_manager import SwayManager, app_id_for_slot
+
+
+@pytest.fixture
+def sway_mgr(tmp_path: Path) -> SwayManager:
+    """A SwayManager configured with tmp paths but not actually started."""
+    return SwayManager(
+        slots=("A", "B"),
+        runtime_dir=str(tmp_path / "rt"),
+        config_path=str(tmp_path / "rt" / "sway.conf"),
+    )
+
+
+# ── chromium argv ────────────────────────────────────────────────────
+
+
+def test_chromium_argv_includes_class_flag_when_app_id_provided(tmp_path: Path, sway_mgr) -> None:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets,
+        port=8781,
+        sway_manager=sway_mgr,
+        app_id="agora-shell-B",
+    )
+    argv = cp._chromium_argv(app_id=cp._app_id)
+    assert "--class=agora-shell-B" in argv
+    # URL last (chromium convention)
+    assert argv[-1] == "http://127.0.0.1:8781/"
+
+
+def test_chromium_argv_omits_class_when_no_app_id(tmp_path: Path) -> None:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(assets_dir=assets)
+    argv = cp._chromium_argv(app_id=None)
+    assert not any(a.startswith("--class=") for a in argv)
+
+
+# ── start in external-sway mode ──────────────────────────────────────
+
+
+def _fake_popen() -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 999
+    proc.poll.return_value = None
+    proc.wait.return_value = 0
+    return proc
+
+
+def test_external_sway_start_launches_chromium_not_sway(tmp_path: Path, sway_mgr) -> None:
+    """In external-sway mode the spawn must skip sway entirely."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets,
+        port=8781,
+        sway_manager=sway_mgr,
+        app_id=app_id_for_slot("B"),
+    )
+    # Drive _start_chromium_client_scope directly -- ChromiumPlayer.start
+    # also spins up the uvicorn shell server which we don't need here.
+    with patch("player.chromium_backend.subprocess.Popen", return_value=_fake_popen()) as popen:
+        cp._start_chromium_client_scope()
+    popen.assert_called_once()
+    cmd = popen.call_args[0][0]
+    assert cmd[0] == "systemd-run"
+    assert "--scope" in cmd
+    # systemd-run scope wraps chromium DIRECTLY (no `sway -c`).
+    assert "sway" not in cmd
+    assert "chromium" in cmd
+    # --class set to the slot's app_id
+    assert any(part == "--class=agora-shell-B" for part in cmd)
+    # Env includes wayland vars from the sway manager
+    env = popen.call_args[1]["env"]
+    assert "WAYLAND_DISPLAY" in env
+    assert "XDG_RUNTIME_DIR" in env
+    assert env["XDG_RUNTIME_DIR"] == str(tmp_path / "rt")
+
+
+def test_external_sway_start_does_not_invoke_internal_write_config(tmp_path: Path, sway_mgr) -> None:
+    """We must NOT write our own sway config in external-sway mode."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets, port=8781,
+        sway_manager=sway_mgr, app_id="agora-shell-B",
+    )
+    with patch.object(cp, "_write_shell_sway_config") as wsc, \
+         patch("player.chromium_backend.subprocess.Popen", return_value=_fake_popen()):
+        cp._start_chromium_client_scope()
+    wsc.assert_not_called()
+
+
+def test_external_sway_start_idempotent(tmp_path: Path, sway_mgr) -> None:
+    """Calling _start_chromium_client_scope twice stops the previous scope first."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets, port=8781,
+        sway_manager=sway_mgr, app_id="agora-shell-B",
+    )
+    p1 = _fake_popen()
+    p2 = _fake_popen()
+    with patch(
+        "player.chromium_backend.subprocess.Popen",
+        side_effect=[p1, p2],
+    ), patch(
+        "player.chromium_backend.subprocess.run",
+    ) as srun:
+        srun.return_value = MagicMock(returncode=0)
+        cp._start_chromium_client_scope()
+        first_unit = cp._sway_scope_unit
+        cp._start_chromium_client_scope()
+        second_unit = cp._sway_scope_unit
+    # Second call should have invoked systemctl stop on first scope.
+    stop_calls = [c for c in srun.call_args_list if c[0][0][:2] == ["systemctl", "stop"]]
+    assert any(c[0][0][2] == first_unit for c in stop_calls), (
+        "second start did not stop the first chromium scope"
+    )
+    assert first_unit != second_unit
+
+
+def test_external_sway_stop_does_not_touch_sway_manager(tmp_path: Path, sway_mgr) -> None:
+    """stop() in external-sway mode must NOT call SwayManager.stop()."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets, port=8781,
+        sway_manager=sway_mgr, app_id="agora-shell-B",
+    )
+    sway_mgr.stop = MagicMock()  # type: ignore[method-assign]
+    with patch(
+        "player.chromium_backend.subprocess.Popen", return_value=_fake_popen(),
+    ), patch(
+        "player.chromium_backend.subprocess.run",
+    ) as srun:
+        srun.return_value = MagicMock(returncode=0)
+        cp._start_chromium_client_scope()
+        cp.stop()
+    sway_mgr.stop.assert_not_called()
+    # And systemctl stop WAS called on our chromium scope.
+    cmds = [c[0][0] for c in srun.call_args_list]
+    assert any(c[:2] == ["systemctl", "stop"] for c in cmds)
+
+
+def test_external_sway_start_handles_popen_failure(tmp_path: Path, sway_mgr) -> None:
+    """A failed launch leaves the process handle cleared."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(
+        assets_dir=assets, port=8781,
+        sway_manager=sway_mgr, app_id="agora-shell-B",
+    )
+    with patch(
+        "player.chromium_backend.subprocess.Popen",
+        side_effect=FileNotFoundError("no systemd-run"),
+    ):
+        cp._start_chromium_client_scope()
+    assert cp._sway_process is None
+    assert cp._sway_scope_unit is None
+
+
+# ── shell_url honours custom port ───────────────────────────────────
+
+
+def test_shell_url_reflects_custom_port(tmp_path: Path, sway_mgr) -> None:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(assets_dir=assets, port=8781, sway_manager=sway_mgr)
+    assert cp.shell_url() == "http://127.0.0.1:8781/"
+
+
+# ── legacy mode regression ──────────────────────────────────────────
+
+
+def test_legacy_mode_still_writes_internal_sway_config(tmp_path: Path) -> None:
+    """Without sway_manager, ChromiumPlayer keeps owning sway (regression)."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    cp = ChromiumPlayer(assets_dir=assets)
+    assert cp._sway_manager is None
+    assert cp._app_id is None

--- a/tests/test_cms_client_bind_display.py
+++ b/tests/test_cms_client_bind_display.py
@@ -1,0 +1,270 @@
+"""Tests for ``bind_display`` / ``unbind_display`` WS handlers + heartbeat slots.
+
+PR 2a wires two new CMS-driven messages into ``cms_client.service``:
+
+- ``bind_display``: persist slot-B credentials so the player can
+  activate slot B; reply with ``bind_ack``.
+- ``unbind_display``: remove slot-B credentials so the player tears
+  slot B down; reply with ``unbind_ack``.
+
+The heartbeat also advertises ``available_slots`` (Pi5 → ``["A","B"]``,
+others → ``["A"]``).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault("websockets", MagicMock())
+sys.modules.setdefault("websockets.asyncio", MagicMock())
+sys.modules.setdefault("websockets.asyncio.client", MagicMock())
+sys.modules.setdefault("aiohttp", MagicMock())
+
+from cms_client.service import CMSClient  # noqa: E402
+from shared.devices_store import (  # noqa: E402
+    SLOT_A,
+    SLOT_B,
+    devices_path,
+    read_slot,
+    write_slot,
+)
+
+
+# ── Fixture ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    """Bypass-init CMSClient stub with just enough surface for the handlers."""
+    settings = MagicMock()
+    settings.persist_dir = tmp_path / "persist"
+    settings.persist_dir.mkdir()
+    settings.state_dir = tmp_path / "state"
+    settings.state_dir.mkdir()
+    settings.assets_dir = tmp_path / "assets"
+    settings.assets_dir.mkdir()
+    settings.current_state_path = settings.state_dir / "current.json"
+    settings.device_name = "agora-node-test"
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        c = CMSClient(settings)
+    c.settings = settings
+    c.device_id = "slot-a-device-id"
+    return c
+
+
+@pytest.fixture
+def ws_mock():
+    ws = MagicMock()
+    ws.send = AsyncMock()
+    return ws
+
+
+def _sent_payloads(ws_mock) -> list[dict]:
+    return [json.loads(call.args[0]) for call in ws_mock.send.await_args_list]
+
+
+# ── bind_display ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bind_display_persists_creds_and_acks(client, ws_mock, tmp_path: Path):
+    msg = {
+        "type": "bind_display",
+        "slot": "B",
+        "device_id": "slot-b-id",
+        "api_key": "slot-b-key",
+    }
+    await client._handle_bind_display(msg, ws_mock)
+
+    creds = read_slot(client.settings.persist_dir, SLOT_B)
+    assert creds == {"device_id": "slot-b-id", "api_key": "slot-b-key"}
+
+    sent = _sent_payloads(ws_mock)
+    assert sent == [{"type": "bind_ack", "slot": "B", "status": "ok"}]
+
+
+@pytest.mark.asyncio
+async def test_bind_display_does_not_touch_slot_a(client, ws_mock):
+    write_slot(
+        client.settings.persist_dir, SLOT_A,
+        {"device_id": "slot-a-id", "api_key": "slot-a-key"},
+    )
+    msg = {
+        "type": "bind_display", "slot": "B",
+        "device_id": "slot-b-id", "api_key": "slot-b-key",
+    }
+    await client._handle_bind_display(msg, ws_mock)
+
+    a = read_slot(client.settings.persist_dir, SLOT_A)
+    assert a == {"device_id": "slot-a-id", "api_key": "slot-a-key"}
+
+
+@pytest.mark.asyncio
+async def test_bind_display_rejects_slot_a(client, ws_mock):
+    msg = {
+        "type": "bind_display", "slot": "A",
+        "device_id": "x", "api_key": "y",
+    }
+    await client._handle_bind_display(msg, ws_mock)
+
+    sent = _sent_payloads(ws_mock)
+    assert len(sent) == 1
+    assert sent[0]["type"] == "bind_ack"
+    assert sent[0]["status"] == "error"
+    assert read_slot(client.settings.persist_dir, SLOT_A) is None
+
+
+@pytest.mark.asyncio
+async def test_bind_display_rejects_unknown_slot(client, ws_mock):
+    msg = {
+        "type": "bind_display", "slot": "C",
+        "device_id": "x", "api_key": "y",
+    }
+    await client._handle_bind_display(msg, ws_mock)
+
+    sent = _sent_payloads(ws_mock)
+    assert sent[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_bind_display_rejects_missing_device_id(client, ws_mock):
+    msg = {"type": "bind_display", "slot": "B", "api_key": "k"}
+    await client._handle_bind_display(msg, ws_mock)
+    sent = _sent_payloads(ws_mock)
+    assert sent[0]["status"] == "error"
+    assert "device_id" in sent[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_bind_display_rejects_missing_api_key(client, ws_mock):
+    msg = {"type": "bind_display", "slot": "B", "device_id": "d"}
+    await client._handle_bind_display(msg, ws_mock)
+    sent = _sent_payloads(ws_mock)
+    assert sent[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_bind_display_idempotent_overwrites_existing(client, ws_mock):
+    write_slot(
+        client.settings.persist_dir, SLOT_B,
+        {"device_id": "old", "api_key": "old-key"},
+    )
+    msg = {
+        "type": "bind_display", "slot": "B",
+        "device_id": "new", "api_key": "new-key",
+    }
+    await client._handle_bind_display(msg, ws_mock)
+    creds = read_slot(client.settings.persist_dir, SLOT_B)
+    assert creds == {"device_id": "new", "api_key": "new-key"}
+
+
+# ── unbind_display ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unbind_display_clears_creds_and_acks(client, ws_mock):
+    write_slot(
+        client.settings.persist_dir, SLOT_B,
+        {"device_id": "b-id", "api_key": "b-key"},
+    )
+    msg = {"type": "unbind_display", "slot": "B"}
+    await client._handle_unbind_display(msg, ws_mock)
+    assert read_slot(client.settings.persist_dir, SLOT_B) is None
+    sent = _sent_payloads(ws_mock)
+    assert sent == [{"type": "unbind_ack", "slot": "B", "status": "ok"}]
+
+
+@pytest.mark.asyncio
+async def test_unbind_display_preserves_slot_a(client, ws_mock):
+    write_slot(
+        client.settings.persist_dir, SLOT_A,
+        {"device_id": "a-id", "api_key": "a-key"},
+    )
+    write_slot(
+        client.settings.persist_dir, SLOT_B,
+        {"device_id": "b-id", "api_key": "b-key"},
+    )
+    msg = {"type": "unbind_display", "slot": "B"}
+    await client._handle_unbind_display(msg, ws_mock)
+    a = read_slot(client.settings.persist_dir, SLOT_A)
+    assert a == {"device_id": "a-id", "api_key": "a-key"}
+
+
+@pytest.mark.asyncio
+async def test_unbind_display_when_already_absent_still_acks_ok(client, ws_mock):
+    msg = {"type": "unbind_display", "slot": "B"}
+    await client._handle_unbind_display(msg, ws_mock)
+    sent = _sent_payloads(ws_mock)
+    assert sent[0]["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_unbind_display_rejects_slot_a(client, ws_mock):
+    write_slot(
+        client.settings.persist_dir, SLOT_A,
+        {"device_id": "a", "api_key": "k"},
+    )
+    msg = {"type": "unbind_display", "slot": "A"}
+    await client._handle_unbind_display(msg, ws_mock)
+    sent = _sent_payloads(ws_mock)
+    assert sent[0]["status"] == "error"
+    assert read_slot(client.settings.persist_dir, SLOT_A) is not None
+
+
+# ── Heartbeat available_slots ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_status_advertises_two_slots_on_pi5(client):
+    client.settings.current_state_path.write_text(
+        '{"mode": "splash", "asset": null}'
+    )
+    client._ws = MagicMock()
+    client._ws.send = AsyncMock()
+    with patch("shared.board.hdmi_port_count", return_value=2), \
+         patch("cms_client.service._get_storage_mb", return_value=(100, 50)), \
+         patch("cms_client.service._get_cpu_temp", return_value=42.0), \
+         patch("cms_client.service._is_ssh_enabled", return_value=False), \
+         patch("cms_client.service._is_local_api_enabled", return_value=False):
+        await client._send_status()
+    sent = json.loads(client._ws.send.await_args.args[0])
+    assert sent["available_slots"] == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_send_status_single_slot_on_pi_zero(client):
+    client.settings.current_state_path.write_text(
+        '{"mode": "splash", "asset": null}'
+    )
+    client._ws = MagicMock()
+    client._ws.send = AsyncMock()
+    with patch("shared.board.hdmi_port_count", return_value=1), \
+         patch("cms_client.service._get_storage_mb", return_value=(100, 50)), \
+         patch("cms_client.service._get_cpu_temp", return_value=42.0), \
+         patch("cms_client.service._is_ssh_enabled", return_value=False), \
+         patch("cms_client.service._is_local_api_enabled", return_value=False):
+        await client._send_status()
+    sent = json.loads(client._ws.send.await_args.args[0])
+    assert sent["available_slots"] == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_send_status_falls_back_to_slot_a_on_board_error(client):
+    client.settings.current_state_path.write_text(
+        '{"mode": "splash", "asset": null}'
+    )
+    client._ws = MagicMock()
+    client._ws.send = AsyncMock()
+    with patch("shared.board.hdmi_port_count", side_effect=RuntimeError("boom")), \
+         patch("cms_client.service._get_storage_mb", return_value=(100, 50)), \
+         patch("cms_client.service._get_cpu_temp", return_value=42.0), \
+         patch("cms_client.service._is_ssh_enabled", return_value=False), \
+         patch("cms_client.service._is_local_api_enabled", return_value=False):
+        await client._send_status()
+    sent = json.loads(client._ws.send.await_args.args[0])
+    assert sent["available_slots"] == ["A"]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,308 @@
+"""Tests for ``player/coordinator.py``.
+
+The Coordinator wires SwayManager + per-slot ChromiumPlayer instances
+together. These tests use a mocked ChromiumPlayer (no subprocesses, no
+sockets) and a mocked SwayManager (no sway lifecycle).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from player.coordinator import PORT_FOR_SLOT, Coordinator, _port_for_slot
+from player.slot_state import SlotPaths
+
+
+# ── port_for_slot ────────────────────────────────────────────────────
+
+
+def test_port_map_has_both_slots() -> None:
+    assert PORT_FOR_SLOT["A"] == 8780
+    assert PORT_FOR_SLOT["B"] == 8781
+
+
+def test_port_for_slot_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        _port_for_slot("Z")
+
+
+# ── constructor ──────────────────────────────────────────────────────
+
+
+def test_coordinator_rejects_invalid_slot_a_paths_mode(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        Coordinator(
+            base_path=tmp_path, assets_dir=tmp_path / "assets",
+            slot_a_paths_mode="invalid_mode",
+        )
+
+
+def test_coordinator_constructor_wires_sway_with_available_slots(tmp_path: Path) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    assert coord.sway_manager._slots == ("A", "B")
+    assert coord.available_slots == ("A", "B")
+
+
+# ── activate_slot ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_chromium_class():
+    """Patch ChromiumPlayer where Coordinator imports it; track constructor calls."""
+    with patch("player.chromium_backend.ChromiumPlayer") as cls:
+        instances: list[MagicMock] = []
+
+        def make(*args, **kwargs):
+            inst = MagicMock()
+            inst.port = kwargs.get("port")
+            inst.is_alive.return_value = True
+            instances.append(inst)
+            return inst
+        cls.side_effect = make
+        cls.instances = instances  # type: ignore[attr-defined]
+        yield cls
+
+
+def test_activate_slot_a_uses_legacy_paths_by_default(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+    )
+    with patch.object(coord.sway_manager, "start"):
+        state = coord.activate_slot("A")
+    assert state is not None
+    assert state.paths == SlotPaths.legacy(tmp_path)
+
+
+def test_activate_slot_a_per_slot_paths_when_mode_per_slot(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+        slot_a_paths_mode="per_slot",
+    )
+    state = coord.activate_slot("A")
+    assert state is not None
+    assert state.paths == SlotPaths.for_slot(tmp_path, "A")
+
+
+def test_activate_slot_b_always_uses_per_slot_paths(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    state = coord.activate_slot("B")
+    assert state is not None
+    assert state.paths == SlotPaths.for_slot(tmp_path, "B")
+
+
+def test_activate_slot_uses_correct_port_per_slot(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    state_a = coord.activate_slot("A")
+    state_b = coord.activate_slot("B")
+    assert state_a is not None and state_a.chromium_player.port == 8780
+    assert state_b is not None and state_b.chromium_player.port == 8781
+
+
+def test_activate_slot_passes_sway_manager_and_app_id(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    coord.activate_slot("B")
+    last_call = fake_chromium_class.call_args
+    assert last_call.kwargs["sway_manager"] is coord.sway_manager
+    assert last_call.kwargs["app_id"] == "agora-shell-B"
+    assert last_call.kwargs["port"] == 8781
+
+
+def test_activate_slot_idempotent(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+    )
+    s1 = coord.activate_slot("A")
+    s2 = coord.activate_slot("A")
+    assert s1 is s2
+    # ChromiumPlayer should only be constructed once.
+    assert len(fake_chromium_class.instances) == 1  # type: ignore[attr-defined]
+
+
+def test_activate_slot_unsupported_returns_none(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+    )
+    result = coord.activate_slot("B")
+    assert result is None
+    assert "B" not in coord.slots
+
+
+# ── deactivate_slot ──────────────────────────────────────────────────
+
+
+def test_deactivate_slot_stops_and_removes(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    coord.activate_slot("B")
+    cp_b = coord.slots["B"].chromium_player
+    coord.deactivate_slot("B")
+    cp_b.stop.assert_called_once()
+    assert "B" not in coord.slots
+
+
+def test_deactivate_slot_noop_when_never_activated(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    coord.deactivate_slot("B")  # must not raise
+
+
+# ── start / stop ─────────────────────────────────────────────────────
+
+
+def test_start_brings_up_sway_and_slot_a(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+    )
+    with patch.object(coord.sway_manager, "start") as sm_start:
+        coord.start()
+    sm_start.assert_called_once()
+    assert "A" in coord.slots
+
+
+def test_start_activates_slot_b_when_devices_json_has_creds(tmp_path: Path, fake_chromium_class) -> None:
+    """If devices.json slot B has creds at startup, Coordinator brings B up."""
+    persist = tmp_path / "persist"
+    persist.mkdir()
+    (persist / "devices.json").write_text(
+        '{"B": {"device_id": "d2", "api_key": "k2"}}'
+    )
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    with patch.object(coord.sway_manager, "start"):
+        coord.start()
+    assert "A" in coord.slots
+    assert "B" in coord.slots
+
+
+def test_start_does_not_activate_slot_b_when_no_creds(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    with patch.object(coord.sway_manager, "start"):
+        coord.start()
+    assert "A" in coord.slots
+    assert "B" not in coord.slots
+
+
+def test_start_does_not_activate_slot_b_when_unavailable(tmp_path: Path, fake_chromium_class) -> None:
+    """Even with slot B creds present, do nothing on a single-output board."""
+    persist = tmp_path / "persist"
+    persist.mkdir()
+    (persist / "devices.json").write_text(
+        '{"B": {"device_id": "d2", "api_key": "k2"}}'
+    )
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),  # single-output board
+    )
+    with patch.object(coord.sway_manager, "start"):
+        coord.start()
+    assert "B" not in coord.slots
+
+
+def test_stop_tears_down_all_slots_then_sway(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    with patch.object(coord.sway_manager, "start"):
+        coord.activate_slot("A")
+        coord.activate_slot("B")
+    cps = [coord.slots[s].chromium_player for s in ("A", "B")]
+    with patch.object(coord.sway_manager, "stop") as sm_stop:
+        coord.stop()
+    for cp in cps:
+        cp.stop.assert_called_once()
+    sm_stop.assert_called_once()
+    assert coord.slots == {}
+
+
+# ── event callback ───────────────────────────────────────────────────
+
+
+def test_event_callback_passes_slot_id(tmp_path: Path, fake_chromium_class) -> None:
+    """The Coordinator wraps the slot-aware callback to look like the per-slot one."""
+    events: list[tuple[str, dict]] = []
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+        on_chromium_event=lambda slot, payload: events.append((slot, payload)),
+    )
+    coord.activate_slot("A")
+    coord.activate_slot("B")
+    # Capture the on_event callbacks passed to each ChromiumPlayer.
+    call_a, call_b = fake_chromium_class.call_args_list
+    cb_a = call_a.kwargs["on_event"]
+    cb_b = call_b.kwargs["on_event"]
+    cb_a({"event": "ended"})
+    cb_b({"event": "error", "msg": "oops"})
+    assert events == [
+        ("A", {"event": "ended"}),
+        ("B", {"event": "error", "msg": "oops"}),
+    ]
+
+
+def test_event_callback_swallows_exceptions(tmp_path: Path, fake_chromium_class) -> None:
+    """A raising callback must not propagate into the chromium event handler."""
+    def bad(slot: str, payload: dict) -> None:
+        raise RuntimeError("intentional")
+
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+        on_chromium_event=bad,
+    )
+    coord.activate_slot("A")
+    cb = fake_chromium_class.call_args.kwargs["on_event"]
+    # Should not raise:
+    cb({"event": "anything"})
+
+
+def test_event_callback_none_when_no_handler(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A",),
+    )
+    coord.activate_slot("A")
+    assert fake_chromium_class.call_args.kwargs["on_event"] is None
+
+
+# ── has_slot ─────────────────────────────────────────────────────────
+
+
+def test_has_slot_tracks_activation(tmp_path: Path, fake_chromium_class) -> None:
+    coord = Coordinator(
+        base_path=tmp_path, assets_dir=tmp_path / "assets",
+        available_slots=("A", "B"),
+    )
+    assert not coord.has_slot("A")
+    coord.activate_slot("A")
+    assert coord.has_slot("A")
+    coord.deactivate_slot("A")
+    assert not coord.has_slot("A")

--- a/tests/test_slot_reconciliation.py
+++ b/tests/test_slot_reconciliation.py
@@ -1,0 +1,107 @@
+"""Tests for AgoraPlayer's slot-B reconciliation tick.
+
+The cms_client persists bind/unbind decisions to ``devices.json``;
+AgoraPlayer reconciles the actual Coordinator state to match on a
+periodic GLib tick. These tests exercise that logic without spinning
+up a real player.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Match the import-time mocks used by other player_service tests.
+sys.modules.setdefault("gi", MagicMock())
+sys.modules.setdefault("gi.repository", MagicMock())
+
+from shared.devices_store import SLOT_B, write_slot  # noqa: E402
+
+
+def _make_player_with_coordinator(tmp_path: Path, *, has_b: bool, available=("A", "B")):
+    from player.service import AgoraPlayer
+
+    # Bypass __init__; the reconciler only touches a few attrs.
+    player = AgoraPlayer.__new__(AgoraPlayer)
+    player.persist_dir = tmp_path / "persist"
+    player.persist_dir.mkdir(parents=True, exist_ok=True)
+
+    coord = MagicMock()
+    coord.available_slots = available
+    coord.has_slot.return_value = has_b
+    player._coordinator = coord
+    return player, coord
+
+
+def test_reconcile_activates_slot_b_when_creds_appear(tmp_path: Path):
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False)
+    write_slot(player.persist_dir, SLOT_B, {"device_id": "d", "api_key": "k"})
+    player._reconcile_slot_b()
+    coord.activate_slot.assert_called_once_with("B")
+    coord.deactivate_slot.assert_not_called()
+
+
+def test_reconcile_deactivates_slot_b_when_creds_vanish(tmp_path: Path):
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=True)
+    # No write_slot -- devices.json absent.
+    player._reconcile_slot_b()
+    coord.deactivate_slot.assert_called_once_with("B")
+    coord.activate_slot.assert_not_called()
+
+
+def test_reconcile_noop_when_creds_and_slot_b_already_up(tmp_path: Path):
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=True)
+    write_slot(player.persist_dir, SLOT_B, {"device_id": "d", "api_key": "k"})
+    player._reconcile_slot_b()
+    coord.activate_slot.assert_not_called()
+    coord.deactivate_slot.assert_not_called()
+
+
+def test_reconcile_noop_when_no_creds_and_slot_b_down(tmp_path: Path):
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False)
+    player._reconcile_slot_b()
+    coord.activate_slot.assert_not_called()
+    coord.deactivate_slot.assert_not_called()
+
+
+def test_reconcile_ignores_when_slot_b_unavailable(tmp_path: Path):
+    """Single-output boards: never touch slot B regardless of devices.json."""
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False, available=("A",))
+    write_slot(player.persist_dir, SLOT_B, {"device_id": "d", "api_key": "k"})
+    player._reconcile_slot_b()
+    coord.activate_slot.assert_not_called()
+    coord.deactivate_slot.assert_not_called()
+
+
+def test_reconcile_treats_empty_api_key_as_no_creds(tmp_path: Path):
+    """Defensive: a slot entry with empty api_key isn't real creds."""
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False)
+    write_slot(player.persist_dir, SLOT_B, {"device_id": "d", "api_key": ""})
+    player._reconcile_slot_b()
+    coord.activate_slot.assert_not_called()
+
+
+def test_reconcile_tick_swallows_exceptions(tmp_path: Path):
+    """The GLib timeout callback must never raise -- it would break the loop."""
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False)
+    coord.activate_slot.side_effect = RuntimeError("boom")
+    write_slot(player.persist_dir, SLOT_B, {"device_id": "d", "api_key": "k"})
+    # Returns True so GLib re-arms it.
+    assert player._reconcile_slots_tick() is True
+
+
+def test_reconcile_tick_returns_true_for_glib_rearm(tmp_path: Path):
+    player, coord = _make_player_with_coordinator(tmp_path, has_b=False)
+    assert player._reconcile_slots_tick() is True
+
+
+def test_reconcile_skipped_when_no_coordinator(tmp_path: Path):
+    from player.service import AgoraPlayer
+    player = AgoraPlayer.__new__(AgoraPlayer)
+    player.persist_dir = tmp_path / "persist"
+    player.persist_dir.mkdir(parents=True, exist_ok=True)
+    player._coordinator = None
+    # Must not raise:
+    player._reconcile_slot_b()

--- a/tests/test_slot_state.py
+++ b/tests/test_slot_state.py
@@ -1,0 +1,143 @@
+"""Tests for ``player/slot_state.py``.
+
+These tests exercise the dataclass + lifecycle without spinning up a
+real chromium player. We mock ``ChromiumPlayer`` to a MagicMock with the
+``start`` / ``stop`` / ``is_alive`` / ``port`` surface we depend on.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from player.slot_state import SlotPaths, SlotState
+
+
+# ── SlotPaths.legacy ─────────────────────────────────────────────────
+
+
+def test_slot_paths_legacy_layout(tmp_path: Path) -> None:
+    p = SlotPaths.legacy(tmp_path)
+    assert p.desired == tmp_path / "state" / "desired.json"
+    assert p.current == tmp_path / "state" / "current.json"
+    assert p.cms_status == tmp_path / "state" / "cms_status.json"
+    assert p.schedule == tmp_path / "state" / "schedule.json"
+    assert p.splash == tmp_path / "persist" / "splash"
+
+
+def test_slot_paths_legacy_is_frozen(tmp_path: Path) -> None:
+    p = SlotPaths.legacy(tmp_path)
+    with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        p.desired = Path("/whatever")  # type: ignore[misc]
+
+
+# ── SlotPaths.for_slot ───────────────────────────────────────────────
+
+
+def test_slot_paths_for_slot_a(tmp_path: Path) -> None:
+    p = SlotPaths.for_slot(tmp_path, "A")
+    assert p.desired == tmp_path / "state" / "displays" / "A" / "desired.json"
+    assert p.current == tmp_path / "state" / "displays" / "A" / "current.json"
+    assert p.cms_status == tmp_path / "state" / "displays" / "A" / "cms_status.json"
+    assert p.schedule == tmp_path / "state" / "displays" / "A" / "schedule.json"
+    assert p.splash == tmp_path / "persist" / "displays" / "A" / "splash"
+
+
+def test_slot_paths_for_slot_b(tmp_path: Path) -> None:
+    p = SlotPaths.for_slot(tmp_path, "B")
+    assert "displays" in str(p.desired)
+    assert "B" in str(p.desired)
+    assert "B" in str(p.splash)
+
+
+def test_slot_paths_a_and_b_do_not_collide(tmp_path: Path) -> None:
+    a = SlotPaths.for_slot(tmp_path, "A")
+    b = SlotPaths.for_slot(tmp_path, "B")
+    for attr in ("desired", "current", "cms_status", "schedule", "splash"):
+        assert getattr(a, attr) != getattr(b, attr), f"{attr} collides"
+
+
+# ── SlotState lifecycle ──────────────────────────────────────────────
+
+
+def _make_chromium_mock() -> MagicMock:
+    cp = MagicMock()
+    cp.port = 8780
+    cp.is_alive.return_value = True
+    return cp
+
+
+def test_slot_state_ensure_dirs_creates_state_and_persist(tmp_path: Path) -> None:
+    paths = SlotPaths.for_slot(tmp_path, "B")
+    state = SlotState(slot="B", paths=paths, chromium_player=_make_chromium_mock())
+    state.ensure_dirs()
+    assert (tmp_path / "state" / "displays" / "B").is_dir()
+    assert (tmp_path / "persist" / "displays" / "B").is_dir()
+
+
+def test_slot_state_ensure_dirs_idempotent(tmp_path: Path) -> None:
+    paths = SlotPaths.for_slot(tmp_path, "A")
+    state = SlotState(slot="A", paths=paths, chromium_player=_make_chromium_mock())
+    state.ensure_dirs()
+    state.ensure_dirs()  # second call must not raise
+    assert (tmp_path / "state" / "displays" / "A").is_dir()
+
+
+def test_slot_state_start_calls_chromium_start(tmp_path: Path) -> None:
+    cp = _make_chromium_mock()
+    state = SlotState(
+        slot="A",
+        paths=SlotPaths.legacy(tmp_path),
+        chromium_player=cp,
+    )
+    state.start()
+    cp.start.assert_called_once()
+
+
+def test_slot_state_start_ensures_dirs(tmp_path: Path) -> None:
+    cp = _make_chromium_mock()
+    state = SlotState(
+        slot="B",
+        paths=SlotPaths.for_slot(tmp_path, "B"),
+        chromium_player=cp,
+    )
+    state.start()
+    assert (tmp_path / "state" / "displays" / "B").is_dir()
+
+
+def test_slot_state_stop_calls_chromium_stop(tmp_path: Path) -> None:
+    cp = _make_chromium_mock()
+    state = SlotState(
+        slot="A",
+        paths=SlotPaths.legacy(tmp_path),
+        chromium_player=cp,
+    )
+    state.stop()
+    cp.stop.assert_called_once()
+
+
+def test_slot_state_is_alive_delegates_to_chromium(tmp_path: Path) -> None:
+    cp = _make_chromium_mock()
+    state = SlotState(
+        slot="A",
+        paths=SlotPaths.legacy(tmp_path),
+        chromium_player=cp,
+    )
+    cp.is_alive.return_value = True
+    assert state.is_alive() is True
+    cp.is_alive.return_value = False
+    assert state.is_alive() is False
+
+
+def test_slot_state_repr_includes_slot_and_port(tmp_path: Path) -> None:
+    cp = _make_chromium_mock()
+    cp.port = 8781
+    state = SlotState(
+        slot="B",
+        paths=SlotPaths.for_slot(tmp_path, "B"),
+        chromium_player=cp,
+    )
+    text = repr(state)
+    assert "B" in text
+    assert "8781" in text

--- a/tests/test_sway_manager.py
+++ b/tests/test_sway_manager.py
@@ -1,0 +1,298 @@
+"""Tests for ``player/sway_manager.py``.
+
+The real ``SwayManager`` spawns ``sway`` and ``systemctl`` -- neither
+runs in a test environment. These tests exercise:
+
+- Config rendering (output blocks + per-slot pin lines)
+- ``write_config`` writing to a tmp runtime dir with the right perms
+- ``start`` invoking ``systemd-run`` with the expected args, and being
+  idempotent
+- ``stop`` shelling out to ``systemctl stop`` on the scope unit
+- ``env_for_client`` returning the wayland env vars
+- ``swaymsg`` handling the common error paths
+- ``app_id_for_slot`` mapping
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from player.sway_manager import (
+    DEFAULT_RUNTIME_DIR,
+    DEFAULT_CONFIG_PATH,
+    SLOT_OUTPUT_MAP,
+    SwayManager,
+    app_id_for_slot,
+)
+
+
+# ── app_id_for_slot ──────────────────────────────────────────────────
+
+
+def test_app_id_for_slot_returns_expected_strings() -> None:
+    assert app_id_for_slot("A") == "agora-shell-A"
+    assert app_id_for_slot("B") == "agora-shell-B"
+
+
+def test_slot_output_map_covers_a_and_b() -> None:
+    assert SLOT_OUTPUT_MAP["A"] == "HDMI-A-1"
+    assert SLOT_OUTPUT_MAP["B"] == "HDMI-A-2"
+
+
+# ── config rendering ─────────────────────────────────────────────────
+
+
+def test_render_config_declares_both_outputs() -> None:
+    mgr = SwayManager(slots=("A",))
+    body = mgr._render_config()
+    assert "output HDMI-A-1" in body
+    assert "output HDMI-A-2" in body, (
+        "HDMI-A-2 must always be declared even on single-slot boards"
+    )
+
+
+def test_render_config_includes_for_window_only_for_active_slots() -> None:
+    mgr = SwayManager(slots=("A",))
+    body = mgr._render_config()
+    assert 'for_window [app_id="agora-shell-A"] move container to output HDMI-A-1' in body
+    assert "agora-shell-B" not in body, (
+        "Single-slot devices must not pin the B kiosk"
+    )
+
+
+def test_render_config_dual_slot_pins_both() -> None:
+    mgr = SwayManager(slots=("A", "B"))
+    body = mgr._render_config()
+    assert 'for_window [app_id="agora-shell-A"] move container to output HDMI-A-1' in body
+    assert 'for_window [app_id="agora-shell-B"] move container to output HDMI-A-2' in body
+
+
+def test_render_config_unknown_slot_logged_and_skipped() -> None:
+    mgr = SwayManager(slots=("A", "Z"))
+    body = mgr._render_config()
+    assert 'for_window [app_id="agora-shell-A"]' in body
+    assert "agora-shell-Z" not in body
+
+
+def test_render_config_has_hide_cursor_and_no_borders() -> None:
+    body = SwayManager(slots=("A",))._render_config()
+    assert "hide_cursor 1" in body
+    assert "default_border none" in body
+    assert "hide_edge_borders both" in body
+
+
+# ── _write_config ────────────────────────────────────────────────────
+
+
+def test_write_config_creates_runtime_dir_and_writes_body(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "agora-sway-shell-run"
+    config_path = runtime_dir / "sway.conf"
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(runtime_dir),
+        config_path=str(config_path),
+    )
+
+    written = mgr._write_config()
+    assert written == config_path
+    assert config_path.exists()
+    body = config_path.read_text()
+    assert "output HDMI-A-1" in body
+    # Runtime dir is 0o700 (best-effort; not all filesystems honour it
+    # but the call should at least not crash).
+    assert runtime_dir.exists()
+
+
+def test_write_config_overwrites_existing_file(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "rt"
+    config_path = runtime_dir / "sway.conf"
+    runtime_dir.mkdir()
+    config_path.write_text("STALE")
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(runtime_dir),
+        config_path=str(config_path),
+    )
+    mgr._write_config()
+    body = config_path.read_text()
+    assert "STALE" not in body
+    assert "output HDMI-A-1" in body
+
+
+# ── start / stop / is_alive ──────────────────────────────────────────
+
+
+def _fake_popen(alive: bool = True) -> MagicMock:
+    """Return a MagicMock that quacks like subprocess.Popen."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    proc.poll.return_value = None if alive else 0
+    proc.wait.return_value = 0
+    return proc
+
+
+def test_start_invokes_systemd_run_with_scope(tmp_path: Path) -> None:
+    runtime_dir = tmp_path / "rt"
+    mgr = SwayManager(
+        slots=("A", "B"),
+        runtime_dir=str(runtime_dir),
+        config_path=str(runtime_dir / "sway.conf"),
+    )
+    fake_proc = _fake_popen(alive=True)
+    with patch("player.sway_manager.subprocess.Popen", return_value=fake_proc) as popen:
+        mgr.start()
+    popen.assert_called_once()
+    args, kwargs = popen.call_args
+    cmd = args[0]
+    assert cmd[0] == "systemd-run"
+    assert "--scope" in cmd
+    assert "--unit" in cmd
+    assert any(part.startswith("agora-sway-shell-") and part.endswith(".scope") for part in cmd)
+    assert cmd[-3:] == ["sway", "-c", str(runtime_dir / "sway.conf")]
+    env = kwargs["env"]
+    assert env["XDG_RUNTIME_DIR"] == str(runtime_dir)
+    assert env["WAYLAND_DISPLAY"] == "wayland-1"
+    assert mgr.is_alive()
+
+
+def test_start_idempotent_when_already_alive(tmp_path: Path) -> None:
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(tmp_path / "rt"),
+        config_path=str(tmp_path / "rt" / "sway.conf"),
+    )
+    fake_proc = _fake_popen(alive=True)
+    with patch("player.sway_manager.subprocess.Popen", return_value=fake_proc) as popen:
+        mgr.start()
+        mgr.start()
+    assert popen.call_count == 1
+
+
+def test_start_handles_popen_failure(tmp_path: Path) -> None:
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(tmp_path / "rt"),
+        config_path=str(tmp_path / "rt" / "sway.conf"),
+    )
+    with patch(
+        "player.sway_manager.subprocess.Popen",
+        side_effect=FileNotFoundError("no systemd-run"),
+    ):
+        mgr.start()
+    assert not mgr.is_alive()
+
+
+def test_stop_invokes_systemctl_stop(tmp_path: Path) -> None:
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(tmp_path / "rt"),
+        config_path=str(tmp_path / "rt" / "sway.conf"),
+    )
+    fake_proc = _fake_popen(alive=True)
+    with patch("player.sway_manager.subprocess.Popen", return_value=fake_proc):
+        mgr.start()
+    captured_unit = mgr._scope_unit
+    assert captured_unit is not None
+
+    with patch("player.sway_manager.subprocess.run") as srun:
+        srun.return_value = MagicMock(returncode=0)
+        mgr.stop()
+    # First (and only) call: systemctl stop <unit>
+    first_call = srun.call_args_list[0]
+    assert first_call[0][0][:2] == ["systemctl", "stop"]
+    assert first_call[0][0][2] == captured_unit
+    assert not mgr.is_alive()
+
+
+def test_stop_falls_back_to_sigkill_on_timeout(tmp_path: Path) -> None:
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(tmp_path / "rt"),
+        config_path=str(tmp_path / "rt" / "sway.conf"),
+    )
+    fake_proc = _fake_popen(alive=True)
+    fake_proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="sway", timeout=5), 0]
+    with patch("player.sway_manager.subprocess.Popen", return_value=fake_proc):
+        mgr.start()
+
+    with patch("player.sway_manager.subprocess.run") as srun:
+        srun.return_value = MagicMock(returncode=0)
+        mgr.stop()
+    # Expect two srun calls: stop then kill.
+    cmds = [call[0][0] for call in srun.call_args_list]
+    assert cmds[0][:2] == ["systemctl", "stop"]
+    assert cmds[1][:2] == ["systemctl", "kill"]
+
+
+def test_stop_when_never_started_is_noop() -> None:
+    mgr = SwayManager(slots=("A",))
+    # Should not raise.
+    mgr.stop()
+    assert not mgr.is_alive()
+
+
+# ── env_for_client ───────────────────────────────────────────────────
+
+
+def test_env_for_client_returns_wayland_vars(tmp_path: Path) -> None:
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(tmp_path / "rt"),
+    )
+    env = mgr.env_for_client()
+    assert env["XDG_RUNTIME_DIR"] == str(tmp_path / "rt")
+    assert env["WAYLAND_DISPLAY"] == "wayland-1"
+
+
+# ── swaymsg ──────────────────────────────────────────────────────────
+
+
+def test_swaymsg_returns_stdout_on_success(tmp_path: Path) -> None:
+    mgr = SwayManager(slots=("A",), runtime_dir=str(tmp_path / "rt"))
+    with patch("player.sway_manager.subprocess.run") as srun:
+        srun.return_value = MagicMock(
+            returncode=0, stdout="OK\n", stderr="",
+        )
+        out = mgr.swaymsg("workspace", "1")
+    assert out == "OK\n"
+
+
+def test_swaymsg_returns_none_on_nonzero_exit(tmp_path: Path) -> None:
+    mgr = SwayManager(slots=("A",), runtime_dir=str(tmp_path / "rt"))
+    with patch("player.sway_manager.subprocess.run") as srun:
+        srun.return_value = MagicMock(returncode=1, stdout="", stderr="oops")
+        out = mgr.swaymsg("bogus")
+    assert out is None
+
+
+def test_swaymsg_returns_none_when_swaymsg_missing(tmp_path: Path) -> None:
+    mgr = SwayManager(slots=("A",), runtime_dir=str(tmp_path / "rt"))
+    with patch(
+        "player.sway_manager.subprocess.run",
+        side_effect=FileNotFoundError("no swaymsg"),
+    ):
+        out = mgr.swaymsg("workspace", "1")
+    assert out is None
+
+
+def test_swaymsg_returns_none_on_timeout(tmp_path: Path) -> None:
+    mgr = SwayManager(slots=("A",), runtime_dir=str(tmp_path / "rt"))
+    with patch(
+        "player.sway_manager.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="swaymsg", timeout=5),
+    ):
+        out = mgr.swaymsg("workspace", "1")
+    assert out is None
+
+
+# ── defaults sanity ─────────────────────────────────────────────────
+
+
+def test_default_paths_are_under_tmp_runtime_dir() -> None:
+    """Lock the default paths so any reshuffle is intentional."""
+    assert DEFAULT_RUNTIME_DIR == "/tmp/agora-sway-shell-run"
+    assert DEFAULT_CONFIG_PATH == "/tmp/agora-sway-shell-run/sway.conf"


### PR DESCRIPTION
Unifies the two long-lived feature branches so softplayer (which currently pins `feat/multi-display-coordinator`) can pick up the Phase 4 slideshow-engine extraction in agora#235 + agora#236.

## Why

After the Phase 4 PRs merged into `feat/chromium-player` (#235 pure helpers, #236 manifest read + anchor resolve), softplayer couldn't consume them: its submodule branch is `feat/multi-display-coordinator`, which had diverged with 7 commits of multi-display scaffolding + Windows-compat fixes.

Merging multi-display **into** chromium-player makes chromium-player the unified base. Softplayer's PR-3 (next) repoints the submodule branch from `feat/multi-display-coordinator` → `feat/chromium-player` and bumps the pin to this merge commit.

## Conflict resolved

Single conflict in `player/service.py` class-attribute block: both sides added a new `AgoraPlayer` class attribute (`_forward_schema_logged` from chromium-player, `_coordinator` from multi-display). Resolved additively — both attributes kept.

## Validation

Full focused test run on Windows: `1751 passed, 33 skipped` (slideshow + chromium_backend + coordinator + everything else, minus the two known-broken-on-Windows tests `test_cms_url_reconnect.py` and `test_wss_support.py`).

Slideshow + chromium + coordinator subset specifically: `168 passed`.

No behaviour change beyond the union of the two branches.