### PR TITLE
fix(os_updater): allow hyphens in version prerelease segment

### DIFF
--- a/docs/bundle-format.md
+++ b/docs/bundle-format.md
@@ -22,7 +22,7 @@ agora-os-<version>.tar.zst
 agora-os-<version>.tar.zst.minisig
 ```
 
-- `<version>` is the same SemVer string declared inside `meta.json` (`major.minor.patch`, optionally `-prerelease`). It matches `^\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?$` — the same regex the dispatch validator enforces.
+- `<version>` is the same SemVer string declared inside `meta.json` (`major.minor.patch`, optionally `-prerelease`). It matches `^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$` — the same regex the dispatch validator enforces.
 - The minisign sig file ALWAYS has the `.minisig` extension (minisign's default), not `.sig`. The dispatch payload's `signature_url` SHOULD point at the `.minisig`, but the device is willing to accept a `.sig` extension as well so an operator can rename it without breaking anything.
 
 ## Tarball layout

--- a/os_updater/service.py
+++ b/os_updater/service.py
@@ -118,7 +118,7 @@ _PROMOTE_HANDSHAKE_TICK_SEC = 30.0
 
 #: Same regex as dispatch._VERSION_RE — kept local to avoid importing a
 #: private symbol. Used by the version-floor check.
-_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z0-9.]+))?$")
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z0-9.-]+))?$")
 
 
 log = logging.getLogger(__name__)

--- a/tests/test_os_updater_service.py
+++ b/tests/test_os_updater_service.py
@@ -171,6 +171,11 @@ class TestVersionAtLeast:
             ("1.0.0", "1.0.0-rc1", True),
             ("1.0.0-rc1", "1.0.0", False),
             ("1.0.0-rc2", "1.0.0-rc1", True),
+            # Multi-hyphen prerelease tags (e.g. agora-os "-test-unpin",
+            # "-test-hevc-real", "-rc1-hotfix") must parse, not crash.
+            ("0.1.1-test-unpin", "0.1.0", True),
+            ("0.1.3-test-hevc-real", "0.1.1-test-unpin", True),
+            ("1.0.0-rc1", "0.1.3-test-hevc-real", True),
         ],
     )
     def test_compare(self, current, floor, expected):


### PR DESCRIPTION
## Problem

OTA upgrades silently failed on devices running agora-os images with multi-hyphen
prerelease tags (e.g. `0.1.1-test-unpin`, `0.1.3-test-hevc-real`). When the CMS
dispatched `device.upgrade`, the OS updater service crashed in `_parse_version`
with `ValueError: unparseable version` and the WPS loop reconnected — dropping
the dispatch. From the user's perspective, clicking **Upgrade** in the CMS did
nothing.

Found today on pi100 (running `0.1.1-test-unpin`).

## Root cause

`os_updater/service.py:121` had:
`re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z0-9.]+))?\$")`

The prerelease character class `[A-Za-z0-9.]` rejects hyphens, so anything
after the second `-` failed to match. `os_updater/dispatch.py` (the
validator) was already correct: `[A-Za-z0-9.-]`. service.py had drifted.

## Fix

One-character change: `[A-Za-z0-9.]` → `[A-Za-z0-9.-]` in service.py to match
dispatch.py. Plus a stale regex reference in `docs/bundle-format.md`. Plus 3
regression test cases covering the actual agora-os tag patterns:
`0.1.1-test-unpin`, `0.1.3-test-hevc-real`, `1.0.0-rc1` vs prior `-test-*`.

## Verification

- `pytest tests/test_os_updater_service.py -k VersionAtLeast` → 12 passed (3 new).
- Hot-patched live on pi100; `agora-os-updater` now starts cleanly with
  `current_version=0.1.1-test-unpin`, no crash on WPS reconnect.

## Why this matters now

We just cut `agora-os v1.0.0-rc1` for CMS pickup. Devices on any older
`-test-*` image would hit the same crash on the next upgrade dispatch. This
PR + APT publish unblocks the v1.0.0-rc1 rollout.