### PR TITLE
fix(player): launch sway+chromium with correct wayland env

### DIFF
--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -470,6 +470,11 @@ class ChromiumPlayer:
         """
         argv = [
             "chromium", "--no-sandbox", "--kiosk", "--noerrdialogs",
+            # Force the wayland ozone backend; without these chromium
+            # defaults to X11 and exits immediately on systems with no
+            # X server (i.e. every agora device).
+            "--ozone-platform=wayland",
+            "--enable-features=UseOzonePlatform",
             "--disable-translate", "--disable-infobars", "--incognito",
             "--hide-scrollbars",
             "--autoplay-policy=no-user-gesture-required",
@@ -570,7 +575,9 @@ class ChromiumPlayer:
             self._sway_process = subprocess.Popen(
                 cmd, env=env,
                 start_new_session=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                # stderr inherited (→ journal) so silent launch failures
+                # surface in `journalctl -u agora-player`.
+                stdout=subprocess.DEVNULL,
             )
         except (FileNotFoundError, OSError) as e:
             logger.error(
@@ -662,7 +669,9 @@ class ChromiumPlayer:
             self._sway_process = subprocess.Popen(
                 cmd, env=env,
                 start_new_session=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                # stderr inherited (→ journal) so silent launch failures
+                # surface in `journalctl -u agora-player`.
+                stdout=subprocess.DEVNULL,
             )
         except (FileNotFoundError, OSError) as e:
             logger.error(

--- a/player/sway_manager.py
+++ b/player/sway_manager.py
@@ -130,7 +130,12 @@ class SwayManager:
 
         env = os.environ.copy()
         env["XDG_RUNTIME_DIR"] = self._runtime_dir
-        env["WAYLAND_DISPLAY"] = self._wayland_display
+        # sway IS the wayland compositor — must not have WAYLAND_DISPLAY set
+        # in its own env, or wlroots picks the wayland-client backend and
+        # tries to connect to a nonexistent parent compositor, then exits
+        # silently. Only client subprocesses (chromium kiosks) get this
+        # via env_for_client().
+        env.pop("WAYLAND_DISPLAY", None)
 
         self._scope_unit = f"agora-sway-shell-{uuid.uuid4().hex[:8]}.scope"
         cmd = [
@@ -148,7 +153,10 @@ class SwayManager:
             self._process = subprocess.Popen(
                 cmd, env=env,
                 start_new_session=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                # stderr → journal (inherit) so launch failures are visible.
+                # Sway's stdout is noisy on success but its stderr stays
+                # quiet unless it actually breaks, so the trade-off is fine.
+                stdout=subprocess.DEVNULL,
             )
         except (FileNotFoundError, OSError) as e:
             logger.error("SwayManager: failed to launch sway: %s", e)

--- a/tests/test_chromium_backend.py
+++ b/tests/test_chromium_backend.py
@@ -433,3 +433,20 @@ def test_quit_plymouth_swallows_missing_binary(monkeypatch):
     monkeypatch.setattr(chromium_backend.subprocess, "run", raises)
     # Must not raise.
     chromium_backend._quit_plymouth()
+
+
+# ── Chromium argv: wayland ozone backend ─────────────────────────────
+
+
+def test_chromium_argv_forces_wayland_ozone(cp):
+    """Regression: without ``--ozone-platform=wayland`` chromium tries the
+    X11 backend, fails to connect to an X server (none on agora devices),
+    and exits within ~1s — leaving the player with no rendered output and
+    no visible error. The kiosk MUST be launched with the wayland ozone
+    backend explicitly forced.
+    """
+    argv = cp._chromium_argv(app_id="agora-shell-A")
+    assert "--ozone-platform=wayland" in argv
+    assert "--enable-features=UseOzonePlatform" in argv
+    # And the binary is still first so systemd-run can find it.
+    assert argv[0] == "chromium"

--- a/tests/test_sway_manager.py
+++ b/tests/test_sway_manager.py
@@ -155,8 +155,34 @@ def test_start_invokes_systemd_run_with_scope(tmp_path: Path) -> None:
     assert cmd[-3:] == ["sway", "-c", str(runtime_dir / "sway.conf")]
     env = kwargs["env"]
     assert env["XDG_RUNTIME_DIR"] == str(runtime_dir)
-    assert env["WAYLAND_DISPLAY"] == "wayland-1"
+    # sway IS the compositor — must NOT have WAYLAND_DISPLAY in its env,
+    # or wlroots picks the wayland-client backend and exits silently.
+    # (env_for_client() still returns WAYLAND_DISPLAY — that's for the
+    # chromium kiosk clients, covered by a separate test below.)
+    assert "WAYLAND_DISPLAY" not in env
     assert mgr.is_alive()
+
+
+def test_start_strips_inherited_wayland_display(tmp_path: Path) -> None:
+    """Regression: even if the parent agora-player process has
+    WAYLAND_DISPLAY in its env (e.g. via a systemd drop-in or a stray
+    export), it must be removed before sway is launched."""
+    runtime_dir = tmp_path / "rt"
+    runtime_dir.mkdir()
+    mgr = SwayManager(
+        slots=("A",),
+        runtime_dir=str(runtime_dir),
+        config_path=str(runtime_dir / "sway.conf"),
+    )
+    fake_proc = _fake_popen(alive=True)
+    with patch.dict(
+        "player.sway_manager.os.environ",
+        {"WAYLAND_DISPLAY": "wayland-99"},
+        clear=False,
+    ), patch("player.sway_manager.subprocess.Popen", return_value=fake_proc) as popen:
+        mgr.start()
+    env = popen.call_args.kwargs["env"]
+    assert "WAYLAND_DISPLAY" not in env
 
 
 def test_start_idempotent_when_already_alive(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Two silent-failure bugs in the chromium-player backend prevented `AGORA_PLAYER_BACKEND=chromium` from actually working on devices. Both reproduced live on pi100 running v1.0.0-rc1: sway and chromium both went `<defunct>` within ~1 second of launch, with no error in the journal because stderr was redirected to `/dev/null`.

## Root causes

### 1. `sway_manager.py:133` set `WAYLAND_DISPLAY` on sway's own env

```python
env = os.environ.copy()
env["XDG_RUNTIME_DIR"] = self._runtime_dir
env["WAYLAND_DISPLAY"] = self._wayland_display   # ← bug
```

sway IS the wayland compositor — when wlroots sees `WAYLAND_DISPLAY` it picks the wayland-client backend and tries to connect to a parent compositor, then exits:

```
[ERROR] [wlr] backend/wayland/backend.c:601] Could not connect to remote display: No such file or directory
[ERROR] [sway/server.c:228] Unable to create backend
```

That env var is only meant for chromium kiosk clients (returned by `env_for_client()`).

The existing `test_starts_sway_via_systemd_run_scope` test actually *asserted the broken behavior* (`env["WAYLAND_DISPLAY"] == "wayland-1"`) — so it was pinning the bug in place.

### 2. `chromium_backend._chromium_argv` was missing `--ozone-platform=wayland`

Without it chromium defaults to X11, fails to connect to an X server (none on agora devices), and exits within ~1s.

### 3. stderr → `/dev/null` masked both failures

Both `sway_manager.py` and `chromium_backend.py` launched their child processes with `stderr=subprocess.DEVNULL`, which is exactly why these failures were silent in `journalctl`.

## Fix

- `sway_manager.py`: drop `WAYLAND_DISPLAY` from sway's env; defensively `pop` it from inherited env too.
- `chromium_backend.py`: add `--ozone-platform=wayland` and `--enable-features=UseOzonePlatform` to chromium argv.
- Both launch sites: `stderr` now inherited (→ journal) so the next failure surfaces.

## Tests

- Flipped `test_starts_sway_via_systemd_run_scope` to assert `WAYLAND_DISPLAY not in env`.
- Added `test_start_strips_inherited_wayland_display` (regression for the inherited-env path).
- Added `test_chromium_argv_forces_wayland_ozone`.
- `pytest tests/test_sway_manager.py tests/test_chromium_backend.py tests/test_chromium_backend_external_sway.py tests/test_coordinator.py -q` → **83 passed**.

## Live verification on pi100

Hot-patched both files, restarted `agora-player`, confirmed:

- sway running, `swaybg` painting both HDMI outputs.
- chromium kiosk launched with `--ozone-platform=wayland`, GPU process + renderers all spawned.
- `goodwill_splash.png` rendering on screen via the shell server at `http://127.0.0.1:8780/`.
- **User visually confirmed: "video is working!"**

Unblocks `agora-os v1.0.0-rc2`.
