### PR TITLE
fix(cms_client): rewrite slideshow manifest on fast path when envelope changes

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1806,7 +1806,40 @@ class CMSClient:
 
         # Fast path: slideshow + every slide already cached with matching checksums.
         if self._has_complete_slideshow(asset_name, expected_checksum, slides):
-            logger.info("Slideshow already cached and complete: %s", asset_name)
+            # Even on the fast path we may need to rewrite the manifest:
+            # the slide list is identical (so ``checksum`` matches and the
+            # files are all present) but the schema-1.1 envelope fields
+            # (``manifest_schema_version``, ``started_at``,
+            # ``cycle_duration_ms``) can change without changing the slide
+            # checksum. A device that cached the slideshow before the CMS
+            # started emitting 1.1 would otherwise stay stuck on a 1.0
+            # manifest forever, defeating wall-clock anchored playback.
+            existing = self._read_slideshow_manifest(asset_name) or {}
+            envelope_changed = (
+                existing.get("manifest_schema_version") != manifest_schema_version
+                or existing.get("started_at") != started_at
+                or existing.get("cycle_duration_ms") != cycle_duration_ms
+            )
+            if envelope_changed:
+                logger.info(
+                    "Slideshow %s: envelope changed "
+                    "(schema %s->%s, started_at %s->%s) -- rewriting manifest",
+                    asset_name,
+                    existing.get("manifest_schema_version"),
+                    manifest_schema_version,
+                    existing.get("started_at"),
+                    started_at,
+                )
+                self._write_slideshow_manifest(
+                    asset_name=asset_name,
+                    expected_checksum=expected_checksum,
+                    manifest_schema_version=manifest_schema_version,
+                    cycle_duration_ms=cycle_duration_ms,
+                    started_at=started_at,
+                    slides=slides,
+                )
+            else:
+                logger.info("Slideshow already cached and complete: %s", asset_name)
             await self._touch_slideshow_slides(asset_name, slides)
             await ws.send(json.dumps({
                 "type": "asset_ack",
@@ -1882,37 +1915,14 @@ class CMSClient:
 
         # All slides verified. Write the slideshow manifest with per-slide
         # checksums so the completeness check has all the data it needs.
-        manifest_payload = {
-            "name": asset_name,
-            "checksum": expected_checksum,
-            "manifest_schema_version": manifest_schema_version,
-            "cycle_duration_ms": cycle_duration_ms,
-            "started_at": started_at,
-            "slides": [
-                {
-                    "name": s["asset_name"],
-                    "asset_type": s.get("asset_type", ""),
-                    "checksum": s.get("checksum", ""),
-                    "size_bytes": s.get("size_bytes", 0),
-                    "duration_ms": s.get("duration_ms", 0),
-                    "play_to_end": bool(s.get("play_to_end", False)),
-                    # Per-slide transition (Phase 1a of agora#226).  Persisted
-                    # verbatim so the chromium-player branch can read it back;
-                    # the mpv player ignores anything other than ``cut``.
-                    # Defaults match the wire schema defaults.
-                    "transition": s.get("transition", "cut"),
-                    "transition_ms": int(s.get("transition_ms", 600)),
-                }
-                for s in slides
-            ],
-        }
-        self.settings.slideshows_dir.mkdir(parents=True, exist_ok=True)
-        manifest_path = self.settings.slideshows_dir / f"{asset_name}.json"
-        atomic_write(manifest_path, json.dumps(manifest_payload, indent=2))
-        manifest_size = manifest_path.stat().st_size
-
-        rel_path = str(manifest_path.relative_to(self.settings.assets_dir))
-        self.asset_manager.register(asset_name, rel_path, manifest_size, expected_checksum)
+        self._write_slideshow_manifest(
+            asset_name=asset_name,
+            expected_checksum=expected_checksum,
+            manifest_schema_version=manifest_schema_version,
+            cycle_duration_ms=cycle_duration_ms,
+            started_at=started_at,
+            slides=slides,
+        )
         await self._touch_slideshow_slides(asset_name, slides)
 
         # Re-trigger desired state if player is waiting for this slideshow
@@ -1933,6 +1943,53 @@ class CMSClient:
             "asset_name": asset_name,
             "checksum": expected_checksum,
         }))
+
+    def _write_slideshow_manifest(
+        self,
+        *,
+        asset_name: str,
+        expected_checksum: str,
+        manifest_schema_version: str,
+        cycle_duration_ms: int | None,
+        started_at: str | None,
+        slides: list[dict],
+    ) -> None:
+        """Atomically (re)write a slideshow manifest under
+        ``<slideshows_dir>/<name>.json``.
+
+        Called both from the slow path (after slide downloads) and from
+        the fast path when the schema-1.1 envelope fields have changed
+        on a cached slideshow. ``slides`` is the on-the-wire descriptor
+        list (with ``asset_name`` keys), not the persisted shape.
+        """
+        manifest_payload = {
+            "name": asset_name,
+            "checksum": expected_checksum,
+            "manifest_schema_version": manifest_schema_version,
+            "cycle_duration_ms": cycle_duration_ms,
+            "started_at": started_at,
+            "slides": [
+                {
+                    "name": s["asset_name"],
+                    "asset_type": s.get("asset_type", ""),
+                    "checksum": s.get("checksum", ""),
+                    "size_bytes": s.get("size_bytes", 0),
+                    "duration_ms": s.get("duration_ms", 0),
+                    "play_to_end": bool(s.get("play_to_end", False)),
+                    "transition": s.get("transition", "cut"),
+                    "transition_ms": int(s.get("transition_ms", 600)),
+                }
+                for s in slides
+            ],
+        }
+        self.settings.slideshows_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = self.settings.slideshows_dir / f"{asset_name}.json"
+        atomic_write(manifest_path, json.dumps(manifest_payload, indent=2))
+        manifest_size = manifest_path.stat().st_size
+        rel_path = str(manifest_path.relative_to(self.settings.assets_dir))
+        self.asset_manager.register(
+            asset_name, rel_path, manifest_size, expected_checksum,
+        )
 
     async def _touch_slideshow_slides(self, _asset_name: str, slides: list[dict]) -> None:
         """Bump LRU timestamps for every slide source in a slideshow."""

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -405,6 +405,144 @@ class TestSlideshowFetch:
         assert any(m["type"] == "asset_ack" and m["checksum"] == "stable-hash" for m in sent)
 
     @pytest.mark.asyncio
+    async def test_fast_path_rewrites_manifest_when_envelope_changes(self, cms_client):
+        """Regression for the wall-clock-anchor staleness bug: a device
+        that cached a slideshow under schema 1.0 (no ``started_at``)
+        and then receives a re-publish under schema 1.1 must rewrite
+        the manifest with the new envelope fields, even though the
+        slide list (and therefore the slideshow ``checksum``) hasn't
+        changed and no slide downloads are needed.
+
+        Before the fix, the fast path returned an ACK without touching
+        the manifest, leaving the device stuck on a 1.0 manifest
+        forever -- which made the player's anchored-playback branch
+        silently fall back to a free-running timer chain.
+        """
+        b1, b2 = b"img-bytes-aaaa", b"img-bytes-bbbb"
+        slide1 = _make_slide("img1.jpg", b1, asset_type="image", duration_ms=60000)
+        slide2 = _make_slide("img2.jpg", b2, asset_type="image", duration_ms=60000)
+        # Pre-seed cache for both slide sources
+        (cms_client.settings.images_dir / "img1.jpg").write_bytes(b1)
+        (cms_client.settings.images_dir / "img2.jpg").write_bytes(b2)
+        cms_client.asset_manager.register(
+            "img1.jpg", "images/img1.jpg", len(b1), _sha256(b1),
+        )
+        cms_client.asset_manager.register(
+            "img2.jpg", "images/img2.jpg", len(b2), _sha256(b2),
+        )
+        # Pre-seed a STALE schema-1.0 manifest (no envelope fields).
+        manifest_path = (
+            cms_client.settings.slideshows_dir / "MyShow.slideshow.json"
+        )
+        manifest_path.write_text(json.dumps({
+            "name": "MyShow.slideshow",
+            "checksum": "stable-hash",
+            "slides": [
+                {"name": "img1.jpg", "asset_type": "image",
+                 "checksum": _sha256(b1), "size_bytes": len(b1),
+                 "duration_ms": 60000, "play_to_end": False},
+                {"name": "img2.jpg", "asset_type": "image",
+                 "checksum": _sha256(b2), "size_bytes": len(b2),
+                 "duration_ms": 60000, "play_to_end": False},
+            ],
+        }))
+        cms_client.asset_manager.register(
+            "MyShow.slideshow", "slideshows/MyShow.slideshow.json",
+            manifest_path.stat().st_size, "stable-hash",
+        )
+        slide1["checksum"] = _sha256(b1)
+        slide2["checksum"] = _sha256(b2)
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "MyShow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "stable-hash",
+            "size_bytes": 0,
+            # CMS now emits schema 1.1 envelope fields
+            "manifest_schema_version": "1.1",
+            "cycle_duration_ms": 120000,
+            "started_at": "2026-05-23T23:29:41.155Z",
+            "slides": [slide1, slide2],
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # No slide downloads happened (fast path).
+        assert fake_session.calls == []
+        # ACK still sent.
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert any(
+            m["type"] == "asset_ack" and m["checksum"] == "stable-hash"
+            for m in sent
+        )
+        # Manifest on disk has been rewritten with the new envelope.
+        rewritten = json.loads(manifest_path.read_text())
+        assert rewritten["manifest_schema_version"] == "1.1"
+        assert rewritten["started_at"] == "2026-05-23T23:29:41.155Z"
+        assert rewritten["cycle_duration_ms"] == 120000
+
+    @pytest.mark.asyncio
+    async def test_fast_path_no_rewrite_when_envelope_unchanged(self, cms_client):
+        """When the on-disk manifest already has the correct schema-1.1
+        envelope, the fast path should NOT rewrite (avoids touching
+        atime/mtime and the asset manager for every CMS sync).
+        """
+        b1 = b"img-bytes"
+        slide1 = _make_slide("img.jpg", b1, asset_type="image", duration_ms=5000)
+        (cms_client.settings.images_dir / "img.jpg").write_bytes(b1)
+        cms_client.asset_manager.register(
+            "img.jpg", "images/img.jpg", len(b1), _sha256(b1),
+        )
+        manifest_path = (
+            cms_client.settings.slideshows_dir / "Stable.slideshow.json"
+        )
+        # Manifest already at schema 1.1 with the same envelope the CMS
+        # will send -- the fast path should treat this as a no-op
+        # (no rewrite).
+        existing_payload = {
+            "name": "Stable.slideshow",
+            "checksum": "h",
+            "manifest_schema_version": "1.1",
+            "cycle_duration_ms": 5000,
+            "started_at": "2026-05-23T23:29:41.155Z",
+            "slides": [
+                {"name": "img.jpg", "asset_type": "image",
+                 "checksum": _sha256(b1), "size_bytes": len(b1),
+                 "duration_ms": 5000, "play_to_end": False,
+                 "transition": "cut", "transition_ms": 600},
+            ],
+        }
+        manifest_path.write_text(json.dumps(existing_payload, indent=2))
+        original_bytes = manifest_path.read_bytes()
+        cms_client.asset_manager.register(
+            "Stable.slideshow", "slideshows/Stable.slideshow.json",
+            manifest_path.stat().st_size, "h",
+        )
+        slide1["checksum"] = _sha256(b1)
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Stable.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.1",
+            "cycle_duration_ms": 5000,
+            "started_at": "2026-05-23T23:29:41.155Z",
+            "slides": [slide1],
+        }
+        fake_aiohttp, _ = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # File contents identical -- no rewrite.
+        assert manifest_path.read_bytes() == original_bytes
+
+    @pytest.mark.asyncio
     async def test_partial_cache_only_fetches_missing(self, cms_client):
         b1, b2 = b"on-disk-bytes", b"need-this-bytes"
         slide1 = _make_slide("cached.mp4", b1, asset_type="video")


### PR DESCRIPTION
## Problem

The cms_client's slideshow fetch fast-path returned ACK without
rewriting the on-disk manifest whenever the slide list checksum was
unchanged. This silently drops **envelope** changes (schema version,
`cycle_duration_ms`, `started_at`) so devices that cached a
pre-schema-1.1 manifest stay stuck on it forever, even after the CMS
starts emitting wall-clock anchor fields.

This was the root cause of two test Pis showing different slide
indexes for the same slideshow today: one had a stale schema-1.0
manifest cached and never refetched envelope changes.

## Fix

Detect envelope changes in the fast path and rewrite the manifest
when any of `manifest_schema_version`, `started_at`, or
`cycle_duration_ms` differs from on-disk. Manifest writing is
extracted into `_write_slideshow_manifest()` so both the slow
(full-fetch) and fast (envelope-only) paths share the persistence
code.

## Tests

- `test_fast_path_rewrites_manifest_when_envelope_changes` --
  cached slides, new `started_at` on the wire => manifest gets
  rewritten.
- `test_fast_path_no_rewrite_when_envelope_unchanged` --
  cached slides, identical envelope => no write (preserves the
  original short-circuit benefit).
- Full `test_slideshow_fetch.py` suite: 20/20 pass.

## Out of scope (follow-ups)

- agora-cms does not yet emit the new envelope fields in
  `FetchAssetMessage` -- this PR is the **device-side** half so we're
  ready when the CMS-side emit lands. With this PR in place and CMS
  still on the current shape, behavior is unchanged.