### PR TITLE
feat(chromium-player): seek into video on start_offset_ms

### DIFF
--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -280,6 +280,7 @@ class ChromiumPlayer:
         transition: str = "cut",
         duration_ms: int = DEFAULT_TRANSITION_MS,
         loop_count: Optional[int] = None,
+        start_offset_ms: int = 0,
     ) -> None:
         url = self._asset_url(path)
         if url is None:
@@ -301,6 +302,14 @@ class ChromiumPlayer:
         # looping — otherwise the protocol stays backward-compatible.
         if loop_count is not None and loop_count > 0:
             payload["loop_count"] = int(loop_count)
+        # start_offset_ms drives wall-clock anchored seek-on-resume in
+        # the shell: the slideshow engine computes how far into the
+        # current video slide we should be (based on manifest
+        # ``started_at`` + per-slide durations) and the shell sets
+        # ``v.currentTime`` after loadedmetadata. Omit when zero so the
+        # protocol stays backward-compatible with older shell builds.
+        if start_offset_ms and start_offset_ms > 0:
+            payload["start_offset_ms"] = int(start_offset_ms)
         self._enqueue(payload)
 
     def show_splash(self, path: Path) -> None:

--- a/player/shell/player.js
+++ b/player/shell/player.js
@@ -93,6 +93,30 @@
       v.addEventListener("error", () => {
         send({ event: "error", asset: cmd.url, msg: "video load failed" });
       });
+      // Wall-clock anchored seek. When the slideshow engine restarts
+      // mid-cycle it tells the shell how far into the video to start
+      // (so a slideshow stays in sync across player restarts instead
+      // of replaying every video from t=0). Must wait for
+      // ``loadedmetadata`` -- HTMLMediaElement.currentTime can't be
+      // assigned before duration is known.
+      const startOffsetMs = Number.isFinite(cmd.start_offset_ms)
+        ? Math.max(0, cmd.start_offset_ms) : 0;
+      if (startOffsetMs > 0) {
+        v.addEventListener("loadedmetadata", () => {
+          try {
+            const dur = v.duration;
+            const target = startOffsetMs / 1000;
+            // Clamp into [0, dur). If dur is unknown (Infinity for live
+            // streams) just trust the request. Leaving a small epsilon
+            // below dur so the browser doesn't immediately fire ended.
+            if (Number.isFinite(dur) && dur > 0) {
+              v.currentTime = Math.min(target, Math.max(0, dur - 0.05));
+            } else {
+              v.currentTime = target;
+            }
+          } catch (_) { /* ignore -- play from start */ }
+        }, { once: true });
+      }
       return v;
     }
     // Default: image (show_image, show_splash)


### PR DESCRIPTION
## Problem

When the chromium player resumes a slideshow mid-cycle (wall-clock
anchored playback, after a process restart, or after a snap-resync),
a video slide currently restarts from t=0. The slideshow engine
already knows how far into the video we should be -- it just had no
way to tell the shell.

## Change

- `ChromiumPlayer.show_video()` accepts a new `start_offset_ms`
  kwarg (default 0). When non-zero, it's serialized into the IPC
  payload as `start_offset_ms`.
- `player/shell/player.js` attaches a `loadedmetadata` listener
  when `start_offset_ms > 0` and sets `v.currentTime` to the
  requested offset (clamped to `[0, duration - 0.05]` so the
  browser doesn't immediately fire `ended`).

Both halves are gated behind `start_offset_ms > 0`, so the protocol
stays backward-compatible: older shells ignore the extra field, and
callers that don't pass the kwarg get the existing
"play-from-start" behavior unchanged.

## Tests

- `tests/test_chromium_backend.py` -- 30/30 pass (existing
  `show_video` tests verify the no-offset path is untouched).
- Will be exercised end-to-end once the softplayer / agora player
  starts passing `start_offset_ms` from the anchored slideshow
  engine.

## Out of scope

- The agora-side slideshow engine doesn't yet *call* show_video with
  a non-zero `start_offset_ms`. That plumbing lands in a follow-up
  alongside the wall-clock anchor work.