### PR TITLE
fix(slot_confirm): never silently fail an upgrade (StartLimitBurst=0 + max_deferral cutover)

### DIFF
--- a/slot_confirm/__init__.py
+++ b/slot_confirm/__init__.py
@@ -45,9 +45,11 @@ CLI:
 
 from slot_confirm.core import (
     DEFAULT_AGORA_SERVICES,
+    DEFAULT_BOOT_AGE_PATH,
     DEFAULT_CMS_STATUS_PATH,
     DEFAULT_DATA_PROBE_DIR,
     DEFAULT_FRAMEBUFFER_DEVICE,
+    DEFAULT_MAX_DEFERRAL_SECONDS,
     DEFAULT_MIN_ACTIVE_SECONDS,
     CheckResult,
     ConfirmStatus,
@@ -62,9 +64,11 @@ from slot_confirm.core import (
 __version__ = "0.1.0"
 __all__ = [
     "DEFAULT_AGORA_SERVICES",
+    "DEFAULT_BOOT_AGE_PATH",
     "DEFAULT_CMS_STATUS_PATH",
     "DEFAULT_DATA_PROBE_DIR",
     "DEFAULT_FRAMEBUFFER_DEVICE",
+    "DEFAULT_MAX_DEFERRAL_SECONDS",
     "DEFAULT_MIN_ACTIVE_SECONDS",
     "CheckResult",
     "ConfirmStatus",

--- a/slot_confirm/core.py
+++ b/slot_confirm/core.py
@@ -55,6 +55,31 @@ DEFAULT_DATA_PROBE_DIR: str = "/data/agora"
 #: "disconnected" | "error", ...}``.
 DEFAULT_CMS_STATUS_PATH: str = "/opt/agora/state/cms_status.json"
 
+#: Maximum total time the gate is allowed to keep returning
+#: ``"deferred"`` before flipping over to ``"strike"`` instead.
+#:
+#: Background: post-tryboot, systemd fires this unit every
+#: ``RestartSec`` seconds (see ``agora-slot-mgr.service``) and the gate
+#: returns ``"deferred"`` while the agora-* services haven't reached the
+#: ``min_active_seconds`` bar. Without an upper bound, a slot that
+#: NEVER stabilises (e.g. the player crash-loops permanently) would
+#: defer forever, the os-updater would stay stuck in
+#: ``tryboot_running``, and CMS upgrade dispatches would be silently
+#: rejected -- the failure mode that motivated this constant.
+#:
+#: 30 minutes gives a healthy device plenty of headroom past the 5-min
+#: service-age window even when the player restarts a few times during
+#: early boot. Past that, the gate concludes "this slot is broken" and
+#: returns ``"strike"`` so the strike counter advances and the device
+#: rolls back to the previous good slot.
+DEFAULT_MAX_DEFERRAL_SECONDS: int = 30 * 60
+
+
+#: Path to the kernel-maintained system-uptime file. Used by
+#: :func:`_default_boot_age` to bound how long the gate will defer
+#: before striking.
+DEFAULT_BOOT_AGE_PATH: str = "/proc/uptime"
+
 
 # ── Types ───────────────────────────────────────────────────────────────────
 
@@ -127,6 +152,7 @@ class ConfirmStatus:
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
 NowFn = Callable[[], datetime]
 MonotonicNowFn = Callable[[], float]
+BootAgeFn = Callable[[], float]
 FrameOpener = Callable[[str], Any]
 ProbeWriter = Callable[[str, bytes], None]
 StatusReader = Callable[[str], str]
@@ -165,6 +191,31 @@ def _default_monotonic_now() -> float:
     negative age and a spurious slot-confirm strike. See bug #197.
     """
     return time.monotonic()
+
+
+def _default_boot_age(path: str = DEFAULT_BOOT_AGE_PATH) -> float:
+    """Default source for "how long has this kernel been up?" in seconds.
+
+    Reads ``/proc/uptime``, whose first whitespace-separated field is
+    seconds-since-boot as a float. Used by :func:`slot_confirm` to bound
+    how long the gate may keep returning ``"deferred"`` before flipping
+    over to ``"strike"`` (see :data:`DEFAULT_MAX_DEFERRAL_SECONDS`).
+
+    On any I/O or parse failure we return ``0.0`` rather than raising:
+    "we just booted" is the lenient interpretation and keeps the gate
+    deferring (the systemd Restart loop will fire us again). The
+    catastrophic failure mode this whole code path defends against is
+    deferring *forever*; a transient read failure that leaves us
+    deferring for one more cycle is not interesting.
+    """
+    try:
+        with open(path, "r", encoding="ascii") as fh:
+            first = fh.readline().split()
+        if not first:
+            return 0.0
+        return float(first[0])
+    except (OSError, ValueError):
+        return 0.0
 
 
 def _parse_systemd_monotonic_us(raw: str) -> Optional[int]:
@@ -705,6 +756,8 @@ def slot_confirm(
     framebuffer_fn: Optional[Callable[[], CheckResult]] = None,
     data_writable_fn: Optional[Callable[[], CheckResult]] = None,
     wps_connected_fn: Optional[Callable[[], CheckResult]] = None,
+    boot_age_fn: Optional[BootAgeFn] = None,
+    max_deferral_seconds: int = DEFAULT_MAX_DEFERRAL_SECONDS,
 ) -> ConfirmStatus:
     """Run the slot-confirm 4-check gate against the current boot.
 
@@ -716,13 +769,34 @@ def slot_confirm(
          confirm; the device is already on the default slot).
     2. Tentative → run all 4 checks and aggregate.
        * Every check passed → ``next_action="promote"``.
-       * Any check failed → ``next_action="strike"``.
+       * Only failure is "services not yet aged" (bug #209) AND boot
+         age ≤ ``max_deferral_seconds`` → ``next_action="deferred"``
+         (systemd will fire us again).
+       * Only failure is "services not yet aged" AND boot age >
+         ``max_deferral_seconds`` → ``next_action="strike"``. A slot
+         that has gone this long without its services stabilising is
+         broken; advance the strike counter so the device rolls back
+         to the previous good slot instead of sitting stuck in
+         ``tryboot_running`` forever (see
+         :data:`DEFAULT_MAX_DEFERRAL_SECONDS`).
+       * Any other check failed → ``next_action="strike"``.
 
     Each ``*_fn`` parameter overrides the corresponding check; useful
     for tests and for callers that want to short-circuit one of the
     pillars (e.g. a headless test rig with no framebuffer).
+
+    Parameters
+    ----------
+    boot_age_fn
+        Returns seconds-since-boot as a float. Injection seam for tests
+        and for callers that want a different "elapsed since tryboot"
+        source. Defaults to reading ``/proc/uptime``.
+    max_deferral_seconds
+        See :data:`DEFAULT_MAX_DEFERRAL_SECONDS`. Pass a smaller value in
+        tests to exercise the cutover branch without sleeping.
     """
     slot_state_fn = slot_state_fn or _default_slot_state
+    boot_age_fn = boot_age_fn or _default_boot_age
     running, tentative, err = _safe_slot_info(slot_state_fn)
 
     if err:
@@ -773,8 +847,26 @@ def slot_confirm(
         # for a transient, expected condition. Recommend the caller
         # try again in a few seconds; the systemd unit's Restart=
         # policy does exactly that.
-        next_action = "deferred"
-        ok = False
+        #
+        # ...unless we've been deferring for too long. If the system
+        # has been up longer than `max_deferral_seconds` and we are
+        # STILL only deferring, the slot is not transiently slow --
+        # it's broken (e.g. the player is crash-looping and never
+        # accumulates the contiguous Active time the aging check
+        # requires). Flip to strike so the strike counter advances
+        # and the device rolls back. Without this cutover the
+        # os-updater stays in tryboot_running forever and silently
+        # rejects every future upgrade dispatch.
+        try:
+            boot_age = float(boot_age_fn())
+        except Exception:  # noqa: BLE001
+            boot_age = 0.0
+        if boot_age > max_deferral_seconds:
+            next_action = "strike"
+            ok = False
+        else:
+            next_action = "deferred"
+            ok = False
     else:
         next_action = "strike"
         ok = False

--- a/systemd/agora-slot-mgr.service
+++ b/systemd/agora-slot-mgr.service
@@ -22,17 +22,33 @@ DefaultDependencies=yes
 # Restart=/RestartSec= per-unit instance, but the StartLimit* knobs that
 # bound the total restart budget belong to the unit's lifecycle. When
 # they were misplaced in [Service] (pre-#193) systemd silently ignored
-# them and emitted a warning at unit-load time. Move here to actually
-# enforce the bounded retry budget the comment in [Service] promised.
-StartLimitBurst=10
-StartLimitIntervalSec=600
+# them and emitted a warning at unit-load time.
+#
+# `StartLimitBurst=0` disables the systemd-side burst budget entirely
+# (per systemd.unit(5): "If the rate limit is set to zero, no limit is
+# applied"). We do NOT want systemd to ever stop retrying this unit on
+# its own -- if it does, agora-os-updater stays stuck in
+# `tryboot_running` forever and silently rejects every future upgrade
+# dispatch, which is catastrophic.
+#
+# The terminal cutover for "this slot is permanently bad, give up and
+# strike" is enforced inside slot_confirm itself via
+# DEFAULT_MAX_DEFERRAL_SECONDS (see core.py): once the system has been
+# up long enough that we've been deferring instead of deciding, the
+# gate flips next_action="deferred" -> "strike" so the strike counter
+# advances and the device rolls back. The systemd unit's only job is
+# to keep firing the gate until it can decide.
+StartLimitBurst=0
 
 [Service]
-# `oneshot` so the unit runs once after boot and exits; the gate's job
-# is a single decision, not a long-running daemon. Combined with
-# `Restart=on-failure` below, this gives us a bounded retry budget for
-# the one case in `--auto` where the right answer really is "try again
-# in a moment": services not yet aged (bug #209).
+# `oneshot` so the unit runs once and exits; the gate's job is a
+# single decision, not a long-running daemon. Combined with
+# `Restart=on-failure` below, this gives us an unbounded retry loop
+# for the one case in `--auto` where the right answer really is "try
+# again in a moment": services not yet aged (bug #209). The terminal
+# decision (strike a permanently broken slot) is made inside the gate
+# itself once the system has been up longer than
+# DEFAULT_MAX_DEFERRAL_SECONDS.
 Type=oneshot
 ExecStart=/usr/bin/python3 -m slot_confirm --auto
 WorkingDirectory=/opt/agora/src
@@ -48,25 +64,26 @@ Environment=AGORA_BASE=/opt/agora
 #        to do.)
 #   75 → deferred (EX_TEMPFAIL). The agora-* services are up and
 #        healthy but haven't reached the ≥5 min Active threshold yet
-#        — the normal boot race, see bug #209. NOT a strike: this is
-#        an *expected* transient that the retry budget below covers.
-#        systemd sees failure, sleeps RestartSec, retries; eventually
-#        the services age past the threshold and we exit 0 with a
-#        promote or strike, OR StartLimitBurst runs out and the unit
-#        stops with a real failure.
+#        — the normal boot race, see bug #209. NOT a strike *yet*:
+#        this is an expected transient that the retry policy below
+#        covers. systemd sees failure, sleeps RestartSec, retries
+#        forever. The gate itself flips deferred→strike once the
+#        system has been up longer than DEFAULT_MAX_DEFERRAL_SECONDS
+#        (see slot_confirm/core.py); that path returns 0 and breaks
+#        the loop.
 #   2  → error (slot_state() raised, etc.). systemd retries the same
 #        way as 75 — also a transient condition (e.g. systemctl-show
-#        RPC timeout, status file briefly missing) — until the burst
-#        budget runs out.
+#        RPC timeout, status file briefly missing).
 #
 # `--check` exits 1 on a "gate-failed" result; the unit does not run
 # --check so that branch never reaches systemd.
 #
-# Budget math: RestartSec=45s × StartLimitBurst=10 = 450s ≈ 7.5 min,
-# which covers the 5-min service-age window with margin. StartLimit*
-# live in [Unit] above; see the comment there for why.
+# Retry policy: Restart=on-failure + RestartSec=60 + no burst cap (see
+# StartLimitBurst=0 in [Unit] above). The gate is responsible for
+# deciding when to stop deferring; systemd is only responsible for
+# keeping it ticking.
 Restart=on-failure
-RestartSec=45
+RestartSec=60
 
 StandardOutput=journal
 StandardError=journal

--- a/tests/test_slot_confirm.py
+++ b/tests/test_slot_confirm.py
@@ -743,6 +743,86 @@ class TestSlotConfirm:
         assert status.ok is False
         assert status.next_action == "strike"
 
+    def test_not_yet_aged_within_deferral_window_still_defers(self) -> None:
+        # Bookend to test_not_yet_aged_defers_aggregator: even with the
+        # cutover logic in place, a fresh boot (well under the deferral
+        # cap) must still defer, never strike. The cutover only kicks in
+        # AFTER the system has been up longer than max_deferral_seconds.
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=_services_not_yet_aged_check,
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+            boot_age_fn=lambda: 90.0,  # 90s since boot, well under 30 min
+            max_deferral_seconds=30 * 60,
+        )
+        assert status.ok is False
+        assert status.next_action == "deferred"
+
+    def test_not_yet_aged_past_deferral_window_strikes(self) -> None:
+        # Catastrophic-failure defense: if the gate has been deferring
+        # so long that the system has been up longer than
+        # max_deferral_seconds and the agora-* services are STILL not
+        # aged, the slot is genuinely broken (e.g. the player is
+        # crash-looping and never accumulates the contiguous Active
+        # time the aging check requires). We must flip to "strike" so
+        # the strike counter advances and the device rolls back --
+        # otherwise the os-updater sits in tryboot_running forever and
+        # silently rejects every future upgrade dispatch.
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=_services_not_yet_aged_check,
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+            boot_age_fn=lambda: 45 * 60.0,  # 45 min since boot
+            max_deferral_seconds=30 * 60,  # cap at 30 min
+        )
+        assert status.ok is False
+        assert status.next_action == "strike"
+        assert status.running_slot == 2
+        assert status.tentative is True
+
+    def test_boot_age_fn_failure_is_lenient(self) -> None:
+        # If the boot_age_fn raises, we treat boot age as 0 (fresh) so
+        # we stay in the deferral branch rather than spuriously
+        # striking. The whole point of the cutover is to defend against
+        # *forever* deferral; one transient deferral when /proc/uptime
+        # is briefly unreadable is fine.
+        def bad_boot_age() -> float:
+            raise OSError("nope")
+
+        status = slot_confirm(
+            slot_state_fn=lambda: FakeStatus(running_slot=2, default_slot=1, tentative=True),
+            agora_service_fn=_services_not_yet_aged_check,
+            framebuffer_fn=lambda: _ok_check("framebuffer"),
+            data_writable_fn=lambda: _ok_check("data_writable"),
+            wps_connected_fn=lambda: _ok_check("wps_connected"),
+            boot_age_fn=bad_boot_age,
+            max_deferral_seconds=30 * 60,
+        )
+        assert status.next_action == "deferred"
+
+    def test_default_boot_age_reads_proc_uptime(self, tmp_path: Any) -> None:
+        # _default_boot_age reads /proc/uptime's first whitespace field
+        # as seconds-since-boot. Verify against a synthetic file so we
+        # don't depend on the host's real /proc/uptime.
+        fake_uptime = tmp_path / "uptime"
+        fake_uptime.write_text("123.45 6789.01\n")
+        assert scc._default_boot_age(str(fake_uptime)) == pytest.approx(123.45)
+
+    def test_default_boot_age_missing_file_returns_zero(self, tmp_path: Any) -> None:
+        # On any I/O or parse failure, _default_boot_age returns 0.0 so
+        # the gate defers rather than strikes. See its docstring.
+        missing = tmp_path / "does-not-exist"
+        assert scc._default_boot_age(str(missing)) == 0.0
+
+    def test_default_boot_age_malformed_returns_zero(self, tmp_path: Any) -> None:
+        bad = tmp_path / "uptime"
+        bad.write_text("garbage not-a-number\n")
+        assert scc._default_boot_age(str(bad)) == 0.0
+
     def test_runs_all_4_checks_in_order(self) -> None:
         order: list[str] = []
 


### PR DESCRIPTION
## Summary

Two compounding bugs in the post-tryboot slot-confirm path caused `agora-os-updater` to get stuck in `tryboot_running` on Pi100 today, silently rejecting every CMS upgrade dispatch. This PR fixes both.

## Root cause (from Pi100 journal, 2026-05-23 16:34-16:42)

1. `agora-slot-mgr.service` had `StartLimitBurst=10` × `RestartSec=45` = ~7.5 min retry budget. That budget assumed the player would come up once and stay up. In practice the player restarted three times during the window (logs below), each restart resetting `active_for_seconds` to 0. systemd burned all 10 attempts before the gate ever saw a contiguous 5-minute Active window. After that the unit was permanently failed.
2. With slot-mgr dead, os-updater stayed in `tryboot_running` and silently rejected every subsequent dispatch (`rejecting dispatch <id> while in state tryboot_running`). No surfacing to CMS, no user-visible failure -- the user clicked Update, nothing happened.

\\\
16:34:53 player up      → slot-mgr attempt 1 (5s aged)
...                       ... attempts 2-5, aging up to 232s
16:39:28 PLAYER RESTART → aging resets
16:41:17 PLAYER RESTART → aging resets
16:41:57 PLAYER RESTART → aging resets
16:42:32 attempt 10: "Start request repeated too quickly" -- burst exhausted, unit dead
\\\

## Fixes

* `agora-slot-mgr.service`: `StartLimitBurst=0` (per `systemd.unit(5)`, zero disables the rate limit) and `RestartSec=60`. systemd is now only responsible for keeping the gate ticking -- it can never give up on its own.
* `slot_confirm.core.slot_confirm()`: new `max_deferral_seconds` parameter (default `DEFAULT_MAX_DEFERRAL_SECONDS = 30 min`) plus a `boot_age_fn` injection seam reading `/proc/uptime`. When the only failing check is the `not_yet_aged` services case AND boot age > `max_deferral_seconds`, the gate flips `next_action="deferred"` to `"strike"`. The strike counter advances; the device rolls back; we exit the tryboot loop in bounded time. This is the path that should fire when a slot is genuinely broken (e.g. the player is crash-looping permanently).

Net effect: systemd retries forever, **but** the gate itself enforces a 30-minute terminal cutover. The catastrophic `tryboot_running` silent-reject mode is gone.

## Tests

All 89 `slot_confirm` tests pass. New tests:

* `test_not_yet_aged_within_deferral_window_still_defers` -- fresh-boot defer behaviour unchanged.
* `test_not_yet_aged_past_deferral_window_strikes` -- new cutover fires past the cap.
* `test_boot_age_fn_failure_is_lenient` -- transient `/proc/uptime` read errors keep us deferring, not striking.
* `test_default_boot_age_*` -- happy path / missing file / malformed content.

## Follow-up

Filing a separate issue for the CMS-side gap: when a device is stuck in `tryboot_running`, the CMS should surface that as a status field (red) rather than silently accept upgrade dispatches that the device immediately drops. That's a CMS+device-API change; out of scope here.