### PR TITLE
cms_client: derive slideshow anchor from schedule.start_time device-side

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 
 import websockets
 
@@ -260,6 +261,64 @@ def _schedule_matches_now(entry: dict, now: datetime) -> bool:
             return False
 
     return True
+
+
+def _compute_schedule_anchor_for_today(
+    entry: dict,
+    local_now: datetime,
+    tz_name: str,
+) -> Optional[datetime]:
+    """Compute the wall-clock anchor for an active schedule entry.
+
+    The anchor is the wall-clock instant when the *current* occurrence
+    of the schedule began. Devices on the same schedule + timezone
+    compute the identical anchor, which is the mechanism that keeps
+    multi-display venues in sync without any per-device coordination.
+
+    Caller contract: ``entry`` must already match ``_schedule_matches_now``
+    at ``local_now`` -- this helper does NOT re-validate the date /
+    days_of_week / start_time-end_time window. It only computes the
+    anchor instant once the caller has chosen this entry as the winner.
+
+    Handles three shapes:
+
+    * Same-day schedule (start <= end on the clock face): anchor is
+      today_local at start_time.
+    * Midnight-spanning schedule (start > end) and we're in the
+      pre-midnight half: anchor is today at start_time.
+    * Midnight-spanning schedule and we're in the post-midnight tail
+      (``cur < end``): anchor is yesterday at start_time. Otherwise
+      every device's anchor would silently move forward at midnight
+      mid-cycle.
+
+    Returns ``None`` when ``start_time`` is missing, ``tz_name`` is
+    unparseable, or any other malformed-entry case -- callers should
+    treat ``None`` as "no schedule anchor available; fall back to
+    manifest started_at / legacy timer chain".
+    """
+    start_time_s = entry.get("start_time")
+    if not start_time_s:
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+        h, m, s = _parse_time(start_time_s)
+        tz = ZoneInfo(tz_name) if tz_name else timezone.utc
+        local_anchor = datetime(
+            local_now.year, local_now.month, local_now.day, h, m, s, tzinfo=tz,
+        )
+        # Detect post-midnight tail of a midnight-spanning window: anchor
+        # belongs to *yesterday* so elapsed-time math doesn't reset at 00:00.
+        end_time_s = entry.get("end_time") or ""
+        if end_time_s:
+            eh, em, es = _parse_time(end_time_s)
+            start_secs = h * 3600 + m * 60 + s
+            end_secs = eh * 3600 + em * 60 + es
+            cur_secs = local_now.hour * 3600 + local_now.minute * 60 + local_now.second
+            if start_secs > end_secs and cur_secs < end_secs:
+                local_anchor -= timedelta(days=1)
+        return local_anchor.astimezone(timezone.utc)
+    except Exception:
+        return None
 
 
 def _schedule_starts_within_hours(entry: dict, now: datetime, hours: int) -> bool:
@@ -1079,6 +1138,18 @@ class CMSClient:
             asset_type = winner.get("asset_type")
             new_schedule_id = winner.get("id")
             new_schedule_name = winner.get("name", "")
+            # Wall-clock anchor for slideshow playback (agora#226).
+            # Computed once from the winning schedule's start_time +
+            # today's date in the sync payload's timezone, normalized
+            # to UTC. Stamped on every scheduled DesiredState so the
+            # player (and softplayer) can land on the correct slide
+            # for the current cycle position without needing the CMS
+            # to emit a manifest envelope. None for entries that have
+            # no start_time (defensive); player falls back to legacy
+            # timer chain in that case.
+            schedule_anchor_at = _compute_schedule_anchor_for_today(
+                winner, local_now, tz_name,
+            )
 
             # Webpage schedule — render URL via Cage+Chromium, no file on disk
             if winner.get("asset_type") == "webpage" and winner.get("url"):
@@ -1120,7 +1191,7 @@ class CMSClient:
                 except OSError:
                     pass  # DNS resolution failed — let Chromium handle the error
 
-                state_key = ("webpage", url)
+                state_key = ("webpage", url, schedule_anchor_at.isoformat() if schedule_anchor_at else None)
                 if self._last_eval_state == state_key:
                     return
 
@@ -1132,6 +1203,7 @@ class CMSClient:
                     url=url,
                     loop=False,
                     loop_count=None,
+                    schedule_anchor_at=schedule_anchor_at,
                 )
                 write_state(self.settings.desired_state_path, desired)
                 self._last_eval_state = state_key
@@ -1190,7 +1262,7 @@ class CMSClient:
                 except OSError:
                     pass  # DNS resolution failed — let mpv handle the error
 
-                state_key = ("stream", url)
+                state_key = ("stream", url, schedule_anchor_at.isoformat() if schedule_anchor_at else None)
                 if self._last_eval_state == state_key:
                     return
 
@@ -1203,6 +1275,7 @@ class CMSClient:
                     asset_type="stream",
                     loop=False,
                     loop_count=None,
+                    schedule_anchor_at=schedule_anchor_at,
                 )
                 write_state(self.settings.desired_state_path, desired)
                 self._last_eval_state = state_key
@@ -1234,7 +1307,10 @@ class CMSClient:
                     self._last_eval_state = ("waiting", asset, checksum)
                 return
 
-            state_key = ("play", asset, checksum, loop_count, asset_type)
+            state_key = (
+                "play", asset, checksum, loop_count, asset_type,
+                schedule_anchor_at.isoformat() if schedule_anchor_at else None,
+            )
             if self._last_eval_state == state_key:
                 return
 
@@ -1248,6 +1324,7 @@ class CMSClient:
                 loop=True,
                 loop_count=loop_count,
                 expected_checksum=checksum,
+                schedule_anchor_at=schedule_anchor_at,
             )
             write_state(self.settings.desired_state_path, desired)
             self.asset_manager.touch(asset)

--- a/player/service.py
+++ b/player/service.py
@@ -527,17 +527,29 @@ class AgoraPlayer:
                 digest[:8],
             )
             self._forward_schema_logged.add(digest)
-        # Wall-clock anchor (agora#226 Phase 2).  Only meaningful when
-        # the manifest is schema 1.1+ AND carries a parseable
-        # ``started_at`` AND the local wall clock is plausibly past it
-        # (clock-skew guard for pre-NTP boot).  If any precondition
-        # fails we fall back to the legacy relative-timer path; the
-        # anchor is rechecked each tick so a Pi whose clock syncs
-        # mid-playback transitions into anchored mode at the next tick.
-        anchor_dt = _parse_iso8601_utc(manifest.get("started_at") or "")
-        if anchor_dt is not None and _parse_schema_version(schema_version) < (1, 1):
-            # Defensive: ``started_at`` is only meaningful for 1.1+.
-            anchor_dt = None
+        # Wall-clock anchor (agora#226 Phase 2 / schedule-derived
+        # extension). Preferred source is ``current_desired.schedule_anchor_at``
+        # — computed device-side by cms_client from the winning
+        # schedule's ``start_time`` + today's date in the venue's
+        # timezone. Falling back to the manifest's ``started_at`` keeps
+        # the old wire-format and ad-hoc / default-asset paths working,
+        # since neither has a schedule context. If neither source
+        # produces a usable anchor the legacy relative-timer path runs.
+        anchor_dt = None
+        anchor_source = None
+        desired_anchor = getattr(self.current_desired, "schedule_anchor_at", None) \
+            if self.current_desired is not None else None
+        if desired_anchor is not None:
+            anchor_dt = desired_anchor
+            anchor_source = "schedule"
+        else:
+            manifest_anchor = _parse_iso8601_utc(manifest.get("started_at") or "")
+            if manifest_anchor is not None and _parse_schema_version(schema_version) < (1, 1):
+                # Defensive: ``started_at`` is only meaningful for 1.1+.
+                manifest_anchor = None
+            if manifest_anchor is not None:
+                anchor_dt = manifest_anchor
+                anchor_source = "manifest"
         # ``epoch`` is bumped each time a slideshow starts so a stale
         # play_to_end watchdog or late mpv event from a prior slideshow
         # cannot drive the new one.
@@ -575,8 +587,10 @@ class AgoraPlayer:
         self._slideshow_manifest_digest = digest
         self._loops_completed = 0
         logger.info(
-            "Slideshow start: name=%s slides=%d loop_count=%s epoch=%d digest=%s",
+            "Slideshow start: name=%s slides=%d loop_count=%s epoch=%d digest=%s anchor_source=%s anchor=%s",
             name, len(slides), loop_count, self._slideshow["epoch"], digest[:8],
+            anchor_source or "none",
+            anchor_dt.isoformat() if anchor_dt else "none",
         )
         self._play_next_slide()
 
@@ -3090,7 +3104,11 @@ class AgoraPlayer:
         if kind == "webpage":
             return a.url == b.url
         if kind == "slideshow":
-            return a.asset == b.asset and a.loop_count == b.loop_count
+            return (
+                a.asset == b.asset
+                and a.loop_count == b.loop_count
+                and getattr(a, "schedule_anchor_at", None) == getattr(b, "schedule_anchor_at", None)
+            )
         if kind == "file":
             return (
                 a.asset == b.asset

--- a/shared/models.py
+++ b/shared/models.py
@@ -21,6 +21,16 @@ class DesiredState(BaseModel):
     expected_checksum: Optional[str] = None  # SHA-256 from CMS schedule
     url: Optional[str] = None  # Webpage URL for Cage+Chromium rendering
     asset_type: Optional[str] = None  # "video", "image", "webpage", "stream"
+    # Wall-clock anchor for slideshow playback (agora#226). When set, the
+    # player uses ``(now - schedule_anchor_at) mod cycle_duration`` to
+    # decide which slide should be on screen, instead of starting from
+    # slide 0 on every fresh dispatch. cms_client populates this from
+    # the active schedule's ``start_time`` (in the schedule's timezone,
+    # normalized to UTC) so the anchor is the same on every device
+    # watching the same schedule -- giving free multi-display sync. Old
+    # players ignore the field; new players fall back to the manifest's
+    # ``started_at`` (and then to legacy timer-chain) when unset.
+    schedule_anchor_at: Optional[datetime] = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/tests/test_schedule_eval.py
+++ b/tests/test_schedule_eval.py
@@ -14,7 +14,12 @@ sys.modules.setdefault("websockets", MagicMock())
 sys.modules.setdefault("websockets.asyncio", MagicMock())
 sys.modules.setdefault("websockets.asyncio.client", MagicMock())
 
-from cms_client.service import _parse_time, _schedule_matches_now, _schedule_starts_within_hours
+from cms_client.service import (
+    _compute_schedule_anchor_for_today,
+    _parse_time,
+    _schedule_matches_now,
+    _schedule_starts_within_hours,
+)
 
 
 # ── _parse_time tests ──
@@ -266,3 +271,76 @@ class TestScheduleStartsWithinHours:
         entry = self._entry(days_of_week=None)
         now = datetime(2026, 3, 28, 10, 0)
         assert _schedule_starts_within_hours(entry, now, 24) is True
+
+
+# ── _compute_schedule_anchor_for_today tests ──
+
+
+class TestComputeScheduleAnchorForToday:
+    def test_basic_same_day(self):
+        """Anchor is today_local at start_time, normalized to UTC."""
+        entry = {"start_time": "09:00:00", "end_time": "17:00:00"}
+        # 2026-03-28 10:00 local in America/Los_Angeles (PDT, UTC-7)
+        local_now = datetime(2026, 3, 28, 10, 0, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "America/Los_Angeles")
+        assert anchor is not None
+        # 09:00 PDT == 16:00 UTC on 2026-03-28
+        assert anchor == datetime(2026, 3, 28, 16, 0, 0, tzinfo=timezone.utc)
+
+    def test_with_seconds_in_start_time(self):
+        entry = {"start_time": "05:53:42", "end_time": "06:13:02"}
+        local_now = datetime(2026, 5, 24, 6, 0, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "America/Los_Angeles")
+        assert anchor is not None
+        assert anchor.astimezone(timezone.utc) == datetime(
+            2026, 5, 24, 12, 53, 42, tzinfo=timezone.utc,
+        )
+
+    def test_midnight_spanning_pre_midnight(self):
+        """start 23:00 end 02:00, currently 23:30 — anchor today 23:00."""
+        entry = {"start_time": "23:00:00", "end_time": "02:00:00"}
+        local_now = datetime(2026, 3, 28, 23, 30, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "UTC")
+        assert anchor == datetime(2026, 3, 28, 23, 0, 0, tzinfo=timezone.utc)
+
+    def test_midnight_spanning_post_midnight(self):
+        """start 23:00 end 02:00, currently 00:30 — anchor YESTERDAY 23:00."""
+        entry = {"start_time": "23:00:00", "end_time": "02:00:00"}
+        local_now = datetime(2026, 3, 29, 0, 30, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "UTC")
+        assert anchor == datetime(2026, 3, 28, 23, 0, 0, tzinfo=timezone.utc)
+
+    def test_recurring_schedule_anchors_today_not_start_date(self):
+        """Weekly recurring: anchor is today's date, not original start_date."""
+        entry = {
+            "start_time": "09:00",
+            "end_time": "10:00",
+            "start_date": "2026-01-01",
+            "days_of_week": [1, 3, 5],
+        }
+        local_now = datetime(2026, 3, 30, 9, 30, 0)  # Monday
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "UTC")
+        assert anchor == datetime(2026, 3, 30, 9, 0, 0, tzinfo=timezone.utc)
+
+    def test_missing_start_time_returns_none(self):
+        entry = {"end_time": "10:00"}
+        local_now = datetime(2026, 3, 28, 9, 30, 0)
+        assert _compute_schedule_anchor_for_today(entry, local_now, "UTC") is None
+
+    def test_unknown_timezone_returns_none(self):
+        entry = {"start_time": "09:00", "end_time": "10:00"}
+        local_now = datetime(2026, 3, 28, 9, 30, 0)
+        assert _compute_schedule_anchor_for_today(entry, local_now, "Not/A_Real_Zone") is None
+
+    def test_empty_timezone_falls_back_to_utc(self):
+        entry = {"start_time": "09:00", "end_time": "10:00"}
+        local_now = datetime(2026, 3, 28, 9, 30, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "")
+        assert anchor == datetime(2026, 3, 28, 9, 0, 0, tzinfo=timezone.utc)
+
+    def test_missing_end_time_uses_start_only(self):
+        """No end_time means we can't detect midnight-span; anchor=today_start."""
+        entry = {"start_time": "09:00"}
+        local_now = datetime(2026, 3, 28, 9, 30, 0)
+        anchor = _compute_schedule_anchor_for_today(entry, local_now, "UTC")
+        assert anchor == datetime(2026, 3, 28, 9, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

Derive the slideshow wall-clock anchor from the winning schedule's `start_time` + today's local date, device-side in `cms_client`. Stamped onto `DesiredState.schedule_anchor_at` and consumed by the player ahead of the manifest's `started_at` field.

This fixes the issue where re-enabling a schedule (or any schedule firing for the second time in a day) anchored playback to a stale timestamp baked into the manifest. With the new derivation, every device on the same schedule + timezone computes an identical anchor for today's occurrence -> multi-display sync preserved, but anchored to a meaningful wall-clock instant rather than whenever the CMS happened to build the directive.

## Anchor source order (player)

1. `current_desired.schedule_anchor_at` -- schedule-derived (NEW, preferred)
2. `manifest.started_at` -- legacy, schema 1.1+ only (fallback for ad-hoc / FETCH_REQUEST paths)
3. None -> legacy relative-timer chain

## Edge cases covered

- Midnight-spanning schedules in the post-midnight tail anchor to **yesterday's** start_time (no anchor jump at 00:00).
- Schedule edit (e.g. moving start_time by 2 minutes) now enters `state_key` and `_desireds_equivalent`, so the player rebuilds and re-anchors. (User-visible effect: cycle position shifts by N seconds, NOT a slide-0 restart.)
- Recurring schedules (M/W/F) anchor to today's start_time, not the original `start_date`.
- Missing `start_time` / unknown timezone -> `None` -> player falls back to manifest / legacy.
- Old player + new wire field -> Pydantic ignores unknown.
- New player + old wire (no field) -> `getattr(..., None)` -> manifest fallback.

## Test results

- `tests/test_schedule_eval.py` -- 50 pass (9 new covering same-day, midnight-spanning pre/post, weekly recurring, missing start_time, unknown tz, empty tz UTC fallback, missing end_time).
- `tests/test_slideshow_player.py` + `tests/test_slideshow_engine.py` -- 155 pass.
- Full local suite: 1727 passed. (Pre-existing test-isolation errors in `test_wss_support.py` triggered by other tests mocking `sys.modules["websockets"]` -- not from this PR; each passes when run alone.)

## Followups

- agora-softplayer PR-B to bump submodule pin + plumb `desired.schedule_anchor_at` through `SlideshowSequencer.start(anchor=...)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
