### PR TITLE
fix: wire start_offset_ms through chromium anchored video playback

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -715,17 +715,32 @@ class AgoraPlayer:
             # advance, so the shell does not need to know about anchoring.
             slide_transition = slide.get("transition") or "cut"
             slide_transition_ms = int(slide.get("transition_ms") or 600)
+            # Anchored video seek-on-resume: when the wall clock says
+            # we're partway through this slide's window, tell the shell
+            # to seek the video to the corresponding currentTime so a
+            # restarted / late-joining player lines up with the rest of
+            # the wall (instead of replaying every video from t=0). The
+            # shell does sub-millisecond ``video.currentTime`` math and
+            # the browser snaps to the nearest decodable frame. Only
+            # meaningful for videos; images ignore the field.
+            slide_duration_ms = int(slide.get("duration_ms") or 0)
+            start_offset_ms = (
+                max(0, slide_duration_ms - remaining_ms)
+                if is_video_slide and slide_duration_ms > 0 else 0
+            )
             if play_to_end:
                 self._play_slide_to_end_chromium(
                     slide, slide_name, path, ss,
                     transition=slide_transition,
                     transition_ms=slide_transition_ms,
+                    start_offset_ms=start_offset_ms,
                 )
             elif is_video_slide:
                 self._chromium_player.show_video(
                     path, loop=True, muted=False,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
+                    start_offset_ms=start_offset_ms,
                 )
             else:
                 self._chromium_player.show_image(
@@ -1079,6 +1094,7 @@ class AgoraPlayer:
         *,
         transition: str,
         transition_ms: int,
+        start_offset_ms: int = 0,
     ) -> None:
         """Chromium equivalent of ``_play_slide_to_end``.
 
@@ -1099,6 +1115,7 @@ class AgoraPlayer:
             self._chromium_player.show_video(
                 path, loop=True, muted=False,
                 transition=transition, duration_ms=transition_ms,
+                start_offset_ms=start_offset_ms,
             )
             duration_ms = int(slide.get("duration_ms") or 0)
             if duration_ms <= 0:
@@ -1116,6 +1133,7 @@ class AgoraPlayer:
         self._chromium_player.show_video(
             path, loop=False, muted=False,
             transition=transition, duration_ms=transition_ms,
+            start_offset_ms=start_offset_ms,
         )
 
         # Watchdog: 2× hinted duration with a 60s floor, capped at the

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1113,3 +1113,51 @@ class TestAnchoredPlayback:
         # Still on slide 0; no extra loadfile call.
         assert ss["anchored_current_idx"] == 0
         player._loadfile_mpv.assert_not_called()
+
+    def test_chromium_anchored_video_passes_start_offset_ms(self, mpv_player):
+        """When the chromium backend is active and we anchored-dispatch
+        a video slide partway through its window, ``show_video`` is
+        called with ``start_offset_ms = duration_ms - remaining_ms``
+        so the browser seeks to the in-progress position instead of
+        replaying from t=0."""
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        # 60s slide, anchored 25s ago -> offset == 25_000 ms.
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self._write_anchored(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 60_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/v.mp4"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_video.assert_called_once()
+        kwargs = player._chromium_player.show_video.call_args.kwargs
+        # Offset must be within one second of 25_000 ms (test scheduling
+        # jitter -- the wall clock advances between _write_anchored
+        # and _start_slideshow).
+        assert 24_000 <= kwargs["start_offset_ms"] <= 26_000
+
+    def test_chromium_anchored_image_does_not_pass_start_offset(self, mpv_player):
+        """Image slides ignore the seek concept -- offset should be 0."""
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self._write_anchored(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 60_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/a.png"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_image.assert_called_once()
+        # show_video must not have been used for an image slide.
+        player._chromium_player.show_video.assert_not_called()


### PR DESCRIPTION
PR #242 added `start_offset_ms` handling to `player/shell/player.js` and `chromium_backend.show_video()`, but `_play_anchored_slide` in `player/service.py` never computed or passed it. Anchored video slides on Pi therefore replayed from t=0 on resume instead of seeking to the in-progress position.

Compute `start_offset_ms = max(0, slide_duration_ms - remaining_ms)` in the chromium branch of `_play_anchored_slide` and plumb it through both `show_video()` and `_play_slide_to_end_chromium()`. Matches the softplayer formula already shipped in agora-softplayer#20.

## Tests

- `test_chromium_anchored_video_passes_start_offset_ms` — anchor 25s into a 60s video → `show_video` called with `start_offset_ms ≈ 25_000`.
- `test_chromium_anchored_image_does_not_pass_start_offset` — image slides go through `show_image`; `show_video` is not called.