### PR TITLE
feat: implement all 7 slideshow transition modes in chromium shell

### DIFF
--- a/player/shell/player.css
+++ b/player/shell/player.css
@@ -19,15 +19,26 @@ html, body {
 /*
  * Two stacked layers. The active one is opaque; the inactive one stays
  * fully transparent so transitioning into it is a clean fade-in.
+ *
+ * The ``transition`` property covers every animatable hand-off we use:
+ * opacity for fade / fade_black, transform for push / dissolve / zoom,
+ * clip-path for wipe. Per-mode classes below (``tx-*``) override the
+ * initial / target state on the incoming layer; the ``transition``
+ * declaration here is what actually drives the animation.
  */
 .layer {
   position: absolute;
   inset: 0;
   opacity: 0;
-  transition: opacity var(--transition-ms, 600ms) ease-in-out;
+  transition:
+    opacity var(--transition-ms, 600ms) ease-in-out,
+    transform var(--transition-ms, 600ms) ease-in-out,
+    clip-path var(--transition-ms, 600ms) ease-in-out;
   display: flex;
   align-items: center;
   justify-content: center;
+  /* So translateX / scale animations stay inside the viewport box. */
+  will-change: opacity, transform, clip-path;
 }
 
 .layer.active {
@@ -48,3 +59,60 @@ html, body {
 .layer.no-transition {
   transition: none !important;
 }
+
+/* ── Per-mode transition rules ──
+ *
+ * For each mode we set: the OUTGOING layer's exit state (when ``.active``
+ * is removed) and the INCOMING layer's entry state (the inactive
+ * snapshot before ``.active`` is added). The swap is driven by the JS
+ * toggling ``.active`` after a layout flush; CSS does the rest.
+ */
+
+/* fade (default) — uses the .layer / .layer.active rules above unchanged. */
+
+/* push: incoming slides in from the right, outgoing slides off to the left.
+ * Opacity stays at 1 throughout so we never see the black gutter. */
+.layer.tx-push { opacity: 1; }
+.layer.tx-push:not(.active) {
+  transform: translateX(100%);
+}
+.layer.tx-push.active {
+  transform: translateX(0);
+}
+.layer.tx-push.tx-outgoing:not(.active) {
+  /* Drive the outgoing layer off-screen to the left rather than the
+   * default off-stage-right (which is the incoming entry state). */
+  transform: translateX(-100%);
+}
+
+/* wipe: incoming reveals itself L→R via a clip-path inset.  Outgoing
+ * stays put — the wipe IS the transition; we don't need to also move
+ * the outgoing layer. */
+.layer.tx-wipe { opacity: 1; }
+.layer.tx-wipe:not(.active) {
+  clip-path: inset(0 100% 0 0);
+}
+.layer.tx-wipe.active {
+  clip-path: inset(0 0 0 0);
+}
+.layer.tx-wipe.tx-outgoing { clip-path: inset(0 0 0 0); }
+
+/* dissolve (Ken Burns): crossfade + outgoing slowly scales up to 1.05. */
+.layer.tx-dissolve.tx-outgoing:not(.active) {
+  transform: scale(1.05);
+}
+.layer.tx-dissolve.tx-incoming.active {
+  transform: scale(1);
+}
+
+/* zoom: incoming scales 0.9 → 1.0 while fading 0 → 1. */
+.layer.tx-zoom:not(.active) {
+  transform: scale(0.9);
+}
+.layer.tx-zoom.active {
+  transform: scale(1);
+}
+
+/* fade_black is sequenced JS-side (two half-duration fades through the
+ * black stage background) — no extra CSS needed here. */
+

--- a/player/shell/player.js
+++ b/player/shell/player.js
@@ -6,18 +6,20 @@
  *
  * Protocol (server -> client):
  *   {"cmd":"show_image","url":"/assets/images/foo.jpg",
- *    "transition":"fade"|"cut","duration_ms":600}
+ *    "transition":"<mode>","duration_ms":600}
  *   {"cmd":"show_video","url":"/assets/videos/bar.mp4",
- *    "loop":true,"muted":false,"transition":"fade","duration_ms":600}
+ *    "loop":true,"muted":false,"transition":"<mode>","duration_ms":600}
  *   {"cmd":"show_video","url":"/assets/videos/bar.mp4",
- *    "loop":false,"loop_count":3,"muted":false,"transition":"fade",
+ *    "loop":false,"loop_count":3,"muted":false,"transition":"<mode>",
  *    "duration_ms":600}
  *   {"cmd":"show_splash","url":"/assets/splash/default.png"}
  *   {"cmd":"stop"}
  *
- * Transitions: "fade" runs the crossfade for `duration_ms`; "cut" swaps
- * instantly. Missing or unrecognized values fall back to "cut" with a
- * console.warn — the CMS is the source of truth, the shell never guesses.
+ * Transition modes (<mode> above): "cut" | "fade" | "fade_black" |
+ * "dissolve" | "push" | "wipe" | "zoom" — see swapTo() docstring for
+ * the per-mode semantics. Missing or unrecognized values fall back to
+ * "cut" with a log line; the CMS is the source of truth, the shell
+ * never guesses.
  *
  * loop_count (videos only): when > 0, the shell plays the video N times
  * in-place (no layer swap between iterations, so the loop is seamless)
@@ -131,14 +133,30 @@
   /**
    * Swap to the inactive layer with a transition.
    * Returns the new active element so caller can attach handlers if needed.
+   *
+   * Supported transitions (CMS-driven, see cms.schemas.asset.SLIDE_TRANSITIONS):
+   *
+   *   cut          Instant swap (durMs forced to 0).
+   *   fade         Crossfade (opacity-only). Default if mode is missing.
+   *   fade_black   Two-stage: outgoing fades to 0 over durMs/2, then
+   *                incoming fades up over durMs/2. Gives a brief black
+   *                pause; "scene change" feel.
+   *   dissolve     Crossfade + outgoing scales 1.00 -> 1.05 (Ken Burns).
+   *   push         Incoming slides in from the right, outgoing slides
+   *                off to the left.
+   *   wipe         Incoming reveals L->R via clip-path inset.
+   *   zoom         Incoming scales 0.9 -> 1.0 + opacity 0 -> 1.
+   *
+   * Unknown values fall back to cut.
    */
   function swapTo(cmd) {
     const next = 1 - activeIdx;
     const cur = layers[activeIdx];
     const nxt = layers[next];
 
-    // Resolve the transition. CMS-driven; default and unknown both → "cut".
-    const KNOWN_TRANSITIONS = ["fade", "cut"];
+    const KNOWN_TRANSITIONS = [
+      "cut", "fade", "fade_black", "dissolve", "push", "wipe", "zoom",
+    ];
     let mode = cmd.transition;
     if (!mode) {
       mode = "cut";
@@ -146,7 +164,15 @@
       log("unknown transition '" + mode + "', falling back to cut");
       mode = "cut";
     }
-    const durMs = mode === "fade" ? (cmd.duration_ms || 600) : 0;
+    const durMs = mode === "cut" ? 0 : (cmd.duration_ms || 600);
+
+    // Clear any per-mode classes left over from the previous transition.
+    const TX_CLASSES = [
+      "tx-fade", "tx-fade_black", "tx-dissolve", "tx-push", "tx-wipe", "tx-zoom",
+      "tx-incoming", "tx-outgoing",
+    ];
+    [cur, nxt].forEach((l) => TX_CLASSES.forEach((c) => l.classList.remove(c)));
+
     nxt.style.setProperty("--transition-ms", durMs + "ms");
     cur.style.setProperty("--transition-ms", durMs + "ms");
     nxt.classList.toggle("no-transition", durMs === 0);
@@ -157,13 +183,41 @@
     const el = buildElement(cmd);
     nxt.appendChild(el);
 
-    // Force a layout flush so the transition runs.
-    // eslint-disable-next-line no-unused-expressions
-    nxt.offsetHeight;
+    if (mode === "fade_black" && durMs > 0) {
+      // Two-stage sequenced fade through the black stage background.
+      // Stage 1: outgoing fades to 0 over durMs/2 (incoming stays at 0).
+      // Stage 2: incoming fades to 1 over durMs/2.
+      const half = Math.max(1, Math.floor(durMs / 2));
+      cur.style.setProperty("--transition-ms", half + "ms");
+      nxt.style.setProperty("--transition-ms", half + "ms");
+      // Don't promote the incoming layer yet — first phase is the
+      // outgoing fade-out only.
+      cur.classList.remove("active");
+      // After stage 1, promote the incoming layer (which is still at
+      // opacity 0) to fade it up.
+      setTimeout(() => {
+        nxt.classList.add("active");
+      }, half);
+    } else {
+      // Single-stage transitions: tag both layers with the mode class
+      // (so per-mode CSS rules apply) and flip .active in a layout
+      // flush so the browser sees both states and animates between.
+      if (mode !== "cut" && mode !== "fade") {
+        const txClass = "tx-" + mode;
+        cur.classList.add(txClass);
+        nxt.classList.add(txClass);
+        cur.classList.add("tx-outgoing");
+        nxt.classList.add("tx-incoming");
+      }
 
-    // Promote the new layer.
-    nxt.classList.add("active");
-    cur.classList.remove("active");
+      // Force a layout flush so the transition runs.
+      // eslint-disable-next-line no-unused-expressions
+      nxt.offsetHeight;
+
+      // Promote the new layer.
+      nxt.classList.add("active");
+      cur.classList.remove("active");
+    }
     activeIdx = next;
 
     // After the transition, tear down the now-hidden layer to free memory
@@ -180,6 +234,9 @@
           }
           cur.removeChild(child);
         }
+        // Strip mode classes from the now-hidden layer so the next
+        // transition starts from a clean slate.
+        TX_CLASSES.forEach((c) => cur.classList.remove(c));
       }
     }, cleanupDelay);
 

--- a/tests/test_player_shell_transitions.py
+++ b/tests/test_player_shell_transitions.py
@@ -1,0 +1,84 @@
+"""Contract test: player.js / player.css support the full CMS transition set.
+
+The CMS (cms.schemas.asset.SLIDE_TRANSITIONS) is the source of truth for
+which transition IDs are valid on the wire. The Pi player.js shell must
+accept all of them; unknown values fall back to ``cut``. This test pins
+the JS<->CMS contract by asserting:
+
+  * Every wire ID appears in player.js' ``KNOWN_TRANSITIONS`` array.
+  * Every non-trivial mode (anything that isn't ``cut`` or ``fade``,
+    both of which use the opacity-only path) has a matching ``.tx-<id>``
+    rule in player.css so it actually renders something different.
+
+If the CMS adds a new ID, this test fails until the player side ships.
+That's intentional — the player is allowed to lag the CMS for ONE
+release (unknown values fall back to ``cut``) but we want CI noise the
+moment they diverge.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAYER_JS = REPO_ROOT / "player" / "shell" / "player.js"
+PLAYER_CSS = REPO_ROOT / "player" / "shell" / "player.css"
+
+
+# Mirrors cms.schemas.asset.SLIDE_TRANSITIONS as of CMS PR adding the
+# expanded set. Updated here intentionally — keeping the list duplicated
+# rather than imported decouples the Pi tests from the CMS package.
+WIRE_TRANSITIONS = (
+    "cut",
+    "fade",
+    "fade_black",
+    "dissolve",
+    "push",
+    "wipe",
+    "zoom",
+)
+
+# Modes that require their own CSS rules. ``cut`` is JS-only (durMs=0)
+# and ``fade`` uses the default opacity transition on .layer.active.
+CSS_BACKED_MODES = tuple(m for m in WIRE_TRANSITIONS if m not in ("cut", "fade"))
+
+
+def test_player_js_knows_every_wire_transition():
+    text = PLAYER_JS.read_text(encoding="utf-8")
+    match = re.search(r"KNOWN_TRANSITIONS\s*=\s*\[([^\]]*)\]", text)
+    assert match, "KNOWN_TRANSITIONS array not found in player.js"
+    body = match.group(1)
+    for wire in WIRE_TRANSITIONS:
+        assert f'"{wire}"' in body, (
+            f"player.js KNOWN_TRANSITIONS is missing '{wire}'. "
+            f"Got: {body.strip()}"
+        )
+
+
+def test_player_css_has_rule_for_each_non_trivial_mode():
+    text = PLAYER_CSS.read_text(encoding="utf-8")
+    for mode in CSS_BACKED_MODES:
+        if mode == "fade_black":
+            # fade_black is sequenced JS-side and intentionally has no
+            # bespoke CSS rule. Skip.
+            continue
+        assert f".tx-{mode}" in text, (
+            f"player.css is missing a .tx-{mode} rule for the '{mode}' "
+            f"transition. Each non-trivial mode needs its own CSS so "
+            f"the rendered effect actually differs from a plain fade."
+        )
+
+
+def test_fade_black_is_documented_in_swap_to_docstring():
+    """fade_black has no CSS hook — pin a docstring breadcrumb so future
+    readers don't think it's missing by accident."""
+    text = PLAYER_JS.read_text(encoding="utf-8")
+    assert "fade_black" in text, "fade_black must be referenced in player.js"
+    # Sanity: the two-stage sequencing branch must exist.
+    assert 'mode === "fade_black"' in text, (
+        "fade_black requires a dedicated JS branch (two-stage opacity "
+        "fade through the black stage background); the simple class-flip "
+        "path can't produce a pause-on-black."
+    )


### PR DESCRIPTION
Implements the rest of the per-slide transition vocabulary in `player/shell/player.js` + `player.css`. Pairs with **agora-cms#629** which expands the CMS-side allowed set and adds the duration UI.

## Modes

| ID           | Description                                                  |
|--------------|--------------------------------------------------------------|
| `cut`        | Instant swap (durMs forced to 0).                            |
| `fade`       | Crossfade (opacity, default).                                |
| `fade_black` | Two-stage: out to 0 over durMs/2, then in to 1 over durMs/2. |
| `dissolve`   | Crossfade + outgoing scales 1.00 to 1.05 (Ken Burns).        |
| `push`       | Incoming slides in from right, outgoing off to left.         |
| `wipe`       | Incoming reveals L to R via clip-path inset.                 |
| `zoom`       | Incoming scales 0.9 to 1.0 + opacity 0 to 1.                 |

## Implementation

- **player.css**: per-mode `.tx-<id>` rules + `.tx-incoming` / `.tx-outgoing` helpers. The `.layer` `transition` declaration now covers `opacity`, `transform`, and `clip-path` so a single declaration handles every single-stage mode.
- **player.js**: `swapTo()` generalised to attach a `tx-<mode>` class before the layout flush, then toggle `.active` to fire CSS transitions. `fade_black` is a JS-sequenced special case (a single class-flip can't produce a pause-on-black).
- Cleanup: prior `tx-*` classes are stripped from both layers at the start of every swap and from the hidden layer after the transition completes.
- Unknown modes still fall back to `cut` with a log line.

## Tests

- `tests/test_player_shell_transitions.py`: contract test pinning the JS / CMS vocabulary + CSS rule coverage. <50 ms; catches the typical regression (CMS adds a mode, player forgets).
- All 96 existing slideshow / chromium-backend tests still pass.