### PR TITLE
fix(player): chromium overrun must not tear down kiosk

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -838,7 +838,17 @@ class AgoraPlayer:
                     if self._use_chromium_backend and self._chromium_player:
                         self._cancel_play_to_end_chromium_watchdog()
                         try:
-                            self._chromium_player.stop()
+                            # ``stop_playback`` clears the shell's video
+                            # layer via a ``{"cmd":"stop"}`` over the WS;
+                            # do NOT call ``stop()`` here -- that tears
+                            # down the kiosk + shell server entirely, and
+                            # the subsequent ``_play_next_slide`` would
+                            # then issue ``show_*`` commands into a dead
+                            # WebSocket (slideshow appears frozen on the
+                            # last frame until process restart).  Matches
+                            # the mpv branch below, which only kills the
+                            # current mpv subprocess.
+                            self._chromium_player.stop_playback()
                         except Exception:
                             logger.exception(
                                 "Slideshow %s: chromium stop raised "

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1161,3 +1161,63 @@ class TestAnchoredPlayback:
         player._chromium_player.show_image.assert_called_once()
         # show_video must not have been used for an image slide.
         player._chromium_player.show_video.assert_not_called()
+
+    def test_chromium_play_to_end_overrun_keeps_kiosk_alive(self, mpv_player):
+        """Regression: play_to_end overrun on the chromium backend used
+        to call ``ChromiumPlayer.stop()`` (full kiosk + shell server
+        teardown), which orphaned every subsequent ``show_*`` command
+        and left the device frozen on the runaway frame.  The overrun
+        path must call ``stop_playback()`` instead -- which clears the
+        layer via ``{"cmd":"stop"}`` but leaves the kiosk + WS alive
+        for the next slide.
+        """
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        (player.assets_dir / "images" / "n.png").touch()
+
+        from datetime import datetime, timedelta, timezone
+        # Anchor far in the past so the resync tick will compute a
+        # different target slide and treat the still-armed pending
+        # video as an overrun.
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=120)
+        self._write_anchored(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 10_000,
+             "play_to_end": True},
+            {"name": "n.png", "asset_type": "image", "duration_ms": 10_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.side_effect = (
+            lambda p: "/assets/" + Path(p).name
+        )
+
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 99
+            player._start_slideshow("Show", None)
+            ss = player._slideshow
+            # Force a clearly-overrun ``armed_at`` so the tick fires the
+            # overrun branch deterministically (the slideshow may have
+            # landed past slide 0 already; if so, manually re-arm).
+            ss["pending_play_to_end_chromium"] = {
+                "slide_index": 0,
+                "slide_name": "v.mp4",
+                "armed_at": datetime.now(timezone.utc) - timedelta(minutes=5),
+                "asset_url": "/assets/v.mp4",
+            }
+            # Reset the call log -- only the overrun-triggered calls
+            # should appear.
+            player._chromium_player.reset_mock()
+            player._on_anchored_resync_tick(ss["epoch"])
+
+        # The fix: stop_playback() (clears layers via WS, kiosk stays
+        # alive); stop() (full teardown) must NOT be called.
+        assert player._chromium_player.stop_playback.called, (
+            "overrun branch must call stop_playback() to clear the "
+            "current video without tearing down the kiosk"
+        )
+        assert not player._chromium_player.stop.called, (
+            "overrun branch must NOT call stop() -- that kills the "
+            "kiosk + shell server and orphans every subsequent show_*"
+        )


### PR DESCRIPTION
## Why

User report (Pi100, 2026-05-24): a slideshow with a `play_to_end=True` video slide ran past its declared duration, the player's overrun watchdog fired correctly with `Slideshow ...: play_to_end overrun ... force-advancing`, but then the device froze on the runaway frame.  Daemon logs showed it kept "advancing" through subsequent slides and the schedule eventually ending (`mode: splash`), but **nothing changed on screen** until `agora-player.service` was manually restarted.

`ps` confirmed: after the overrun, only `sway` + `swaybg` were running -- no `chromium` process at all.

## Root cause

`player/service.py` line 844 inside the play_to_end overrun branch called:

```python
self._chromium_player.stop()
```

`ChromiumPlayer.stop()` is the **full lifecycle teardown** -- it stops the kiosk scope **and** joins the FastAPI shell server thread.  The mirror legacy mpv branch a few lines below calls `_stop_mpv()`, which only kills the current mpv subprocess (not the entire player daemon) -- the two paths had drifted.

After `stop()` ran the WebSocket was dead, so every later `_chromium_player.show_image()` / `show_video()` / `show_splash()` call (slideshow advance, schedule end → splash, etc.) silently dispatched a JSON command into nothing.

## Fix

Call `stop_playback()` instead, which is the JSON-level "clear the current layer" command (`{"cmd":"stop"}` over the existing WS).  The kiosk + shell server stay alive; the next `show_*` lands as expected.  Behaviour now matches the legacy mpv branch.

## Tests

- New regression `test_chromium_play_to_end_overrun_keeps_kiosk_alive` in `tests/test_slideshow_player.py` -- stages a video slide armed in the past so the overrun threshold fires deterministically, then asserts `stop_playback` was called and `stop` was **not**.
- Full `test_slideshow_player.py`: 67/67 pass.

## Validation

Hot-patched Pi100 with the same edit prior to opening this PR; splash + slideshow swaps work end-to-end again.
