### PR TITLE
feat(player): make chromium the default backend

### DIFF
--- a/docs/chromium-player-demo.md
+++ b/docs/chromium-player-demo.md
@@ -1,26 +1,28 @@
-# Chromium Player Backend — Demo
+# Chromium Player Backend
 
-Status: **experimental demo, branch `feat/chromium-player-demo`** — not for production, not for merge.
+Status: **default backend** for image, video, splash, and slideshow playback on production Pis.
 
 ## What this is
 
-A second playback renderer for the agora player. Instead of driving mpv (video)
+The primary playback renderer for the agora player. Instead of driving mpv (video)
 and GStreamer (images/splash) directly, the player runs an in-process FastAPI
 server, launches **one** chromium-in-sway kiosk pointed at it, and drives
 playback by sending JSON commands over a WebSocket to a small SPA ("the shell").
 
-Goal: prototype richer still-image transitions (crossfade today, Ken Burns / wipe
-/ slide / etc. trivially next) without re-spawning a renderer every slide.
+Goal: a single persistent renderer that supports richer transitions
+(cut/fade/fade_black/dissolve/push/wipe/zoom today, more later) without
+re-spawning a process every slide.
 
-Default behaviour is unchanged. The chromium backend only activates when the
-environment variable `AGORA_PLAYER_BACKEND=chromium` is set on the
-`agora-player` service.
+The chromium backend is enabled by default.  Set the environment variable
+`AGORA_PLAYER_BACKEND=mpv` on the `agora-player` service to fall back to
+the legacy mpv / gstreamer code paths (kept around for board bring-up and
+as a safety net).
 
 ## Architecture
 
 ```
 agora-player (Python process)
-├── existing supervisor + mpv/gstreamer code paths (unchanged, still the default)
+├── legacy mpv/gstreamer code paths (opt-in via AGORA_PLAYER_BACKEND=mpv)
 └── ChromiumPlayer (player/chromium_backend.py)
     ├── uvicorn thread serving:
     │     GET  /                 →  player/shell/index.html
@@ -89,31 +91,25 @@ source of truth for transition selection. New named transitions are
   no layer swap) and emits a terminal `ended` that the daemon converts
   to a splash transition.
 
-## Enabling on a Pi 5
+## Opting back into mpv
 
-1. Push the branch's player files onto the device (or build a debian package
-   from the branch).
-2. Add a systemd drop-in:
+The chromium backend is the default on new images.  If you need to fall
+back to the legacy mpv / gstreamer path on a specific device (e.g. for
+board bring-up or to triage a chromium-only regression), add a systemd
+drop-in:
 
    ```bash
    sudo mkdir -p /etc/systemd/system/agora-player.service.d/
-   sudo tee /etc/systemd/system/agora-player.service.d/chromium.conf <<'EOF'
+   sudo tee /etc/systemd/system/agora-player.service.d/mpv.conf <<'EOF'
    [Service]
-   Environment=AGORA_PLAYER_BACKEND=chromium
+   Environment=AGORA_PLAYER_BACKEND=mpv
    EOF
    sudo systemctl daemon-reload
    sudo systemctl restart agora-player
    ```
 
-3. Watch logs: `journalctl -u agora-player -f`. On startup you should see
-   `chromium player backend enabled (port=8780)` and then chromium's stderr.
-4. Confirm the kiosk window appears with the black shell background.
-5. From the CMS, push an image asset and a video asset (HEVC if you want
-   to exercise hw decode) at a test device in this group. You should see
-   crossfade between them.
-
-To roll back: delete the drop-in and `systemctl restart agora-player`. The
-process returns to the mpv code path with no further changes.
+To return to the chromium backend, delete the drop-in and `systemctl
+restart agora-player`.
 
 ## Running the unit tests
 

--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -7,9 +7,11 @@ A single sway+chromium subprocess (wrapped in a transient systemd scope)
 is launched in kiosk mode pointing at that server, and the daemon drives
 the shell over the WebSocket with JSON commands.
 
-This is an opt-in alternative to mpv, intended to make rich image
-transitions and unified image/video rendering easy to iterate on.
-Enable by setting environment variable AGORA_PLAYER_BACKEND=chromium.
+This is the default playback backend on production Pis, intended to
+make rich image transitions and unified image/video rendering easy to
+iterate on.
+Opt out via environment variable AGORA_PLAYER_BACKEND=mpv to fall back
+to the legacy mpv path.
 
 The protocol is documented in ``player/shell/README.md``.
 

--- a/player/coordinator.py
+++ b/player/coordinator.py
@@ -67,7 +67,8 @@ class Coordinator:
     """Singleton orchestrator for sway + per-slot SlotStates.
 
     Constructed once per :class:`AgoraPlayer` instance when the
-    chromium backend is enabled (``AGORA_PLAYER_BACKEND=chromium``).
+    chromium backend is enabled (the default; opt out via
+    ``AGORA_PLAYER_BACKEND=mpv``).
     """
 
     def __init__(

--- a/player/service.py
+++ b/player/service.py
@@ -294,8 +294,8 @@ class AgoraPlayer:
     _applied_desired: Optional[DesiredState] = None
     _current_url: Optional[str] = None
     _slideshow_manifest_digest: Optional[str] = None
-    # Chromium-shell demo backend. Off by default; instances opted in
-    # via AGORA_PLAYER_BACKEND=chromium populate _chromium_player.
+    # Chromium-shell backend (default).  Opt-out via
+    # AGORA_PLAYER_BACKEND=mpv to fall back to the legacy mpv path.
     # Declared at class scope so tests that bypass __init__ see safe
     # defaults and the existing mpv code paths remain untouched.
     _use_chromium_backend: bool = False
@@ -348,15 +348,18 @@ class AgoraPlayer:
         self._display_probe = get_display_probe()
         self._player_backend = player_backend()
 
-        # ── Chromium player demo (opt-in, branch-only feature) ──
-        # When AGORA_PLAYER_BACKEND=chromium is set, image / video / splash
-        # / slideshow playback is routed through a persistent chromium
-        # kiosk + shell SPA instead of mpv. Streams and webpage assets
-        # keep their existing renderers (mpv-stream, sway+chromium for
-        # webpage assets) because the demo doesn't replace those. See
-        # player/shell/ and docs/chromium-player-demo.md.
+        # ── Chromium player (default backend) ──
+        # The chromium kiosk + shell SPA is the default playback path for
+        # images, videos, splash, and slideshows.  Set
+        # ``AGORA_PLAYER_BACKEND=mpv`` to fall back to the legacy mpv /
+        # gstreamer pipeline (kept around for board bring-up and as a
+        # safety net while the chromium backend stabilises).  Streams and
+        # webpage assets keep their existing renderers (mpv-stream,
+        # sway+chromium for webpage assets) because the chromium backend
+        # doesn't replace those.  See player/shell/ and
+        # docs/chromium-player-demo.md.
         self._use_chromium_backend = (
-            os.environ.get("AGORA_PLAYER_BACKEND") == "chromium"
+            os.environ.get("AGORA_PLAYER_BACKEND", "chromium").lower() != "mpv"
         )
         self._chromium_player: Optional[ChromiumPlayer] = None
         self._coordinator: Optional["Coordinator"] = None

--- a/requirements-player.txt
+++ b/requirements-player.txt
@@ -1,8 +1,9 @@
 pydantic>=2.10,<3.0
 inotify-simple>=1.3,<2.0
 PyGObject>=3.50,<4.0
-# Chromium player demo only (AGORA_PLAYER_BACKEND=chromium). The default
-# mpv path does not require these — they ship as dependencies of the API
-# service too, so on a real device they are already present.
+# Chromium player backend (the default).  Listed here for completeness;
+# they ship as dependencies of the API service too, so on a real device
+# they are already present.  Setting AGORA_PLAYER_BACKEND=mpv opts out
+# of the chromium path; the legacy mpv code does not require these.
 fastapi>=0.115,<1.0
 uvicorn[standard]>=0.34,<1.0

--- a/tests/test_sync_flicker.py
+++ b/tests/test_sync_flicker.py
@@ -6,6 +6,7 @@ trigger a pipeline rebuild — that causes a visible screen flicker.
 """
 
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -207,7 +208,11 @@ class TestPlayerSkipRebuild:
 
         import player.service as ps
 
-        player = ps.AgoraPlayer(base_path=str(tmp_path))
+        # These tests validate the mpv/GStreamer pipeline rebuild logic
+        # specifically, so force the legacy mpv backend regardless of
+        # the global default (chromium is now the default backend).
+        with patch.dict(os.environ, {"AGORA_PLAYER_BACKEND": "mpv"}):
+            player = ps.AgoraPlayer(base_path=str(tmp_path))
         player.state_dir.mkdir(parents=True, exist_ok=True)
         # Create asset directories and a test image
         (tmp_path / "assets" / "images").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Why

The chromium-shell SPA backend has been driving the recent slideshow + transitions work and is what we've been validating against on Pi100.  It's time to make it the default for fresh installs and OS rebakes -- new devices should land on chromium, not on legacy mpv.

This is also the precondition for closing #247 (streams + webpage assets routed through the chromium shell) -- the default needs to be chromium before that work is worth doing.

## What

Flips the backend selector in `player/service.py`:

```python
# before
self._use_chromium_backend = os.environ.get("AGORA_PLAYER_BACKEND") == "chromium"
# after
self._use_chromium_backend = os.environ.get("AGORA_PLAYER_BACKEND", "chromium").lower() != "mpv"
```

Devices already running with no `AGORA_PLAYER_BACKEND` set will pick up chromium on the next service restart after they install the new `.deb`.

Updates inline comments + module docstrings + `docs/chromium-player-demo.md` to describe chromium-as-default and document the **opt-out** path (systemd drop-in setting `AGORA_PLAYER_BACKEND=mpv`).

## Out of scope

- Streams (`mode=stream`) -- still mpv.  Tracked in #247.
- Webpage assets (`mode=webpage`) -- still a second sway+chromium scope.  Tracked in #247.

## Tests

Targeted suites pass (118/118):
- `tests/test_slideshow_player.py`
- `tests/test_chromium_backend.py`
- `tests/test_coordinator.py`

## Validation

Pi100 has been running on chromium (via systemd drop-in) for the last day -- slideshow, transitions, splash, schedule-end, and the overrun fix from #248 all behave correctly.  Devices that pull this `.deb` + the rc9 image will get the same default with no opt-in needed.
