### PR TITLE
feat(logs): capture all 8 agora-* units in Download logs default

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -75,6 +75,22 @@ LOGS_UPLOAD_MAX_BYTES = 22_020_096  # 21 MiB
 # tens of MB at most over a local network.
 LOGS_UPLOAD_TIMEOUT = 60.0
 
+# Default set of systemd units the CMS pulls when it asks the Pi for
+# logs without specifying ``services``.  Covers every agora-* unit
+# installed by the .deb (see ``debian/agora.install``) so the Settings
+# "Download logs" button captures OTA / slot-promote / watchdog data
+# without the operator having to remember to ask by name.
+DEFAULT_LOG_SERVICES = [
+    "agora-api",
+    "agora-cms-client",
+    "agora-fleet-provision",
+    "agora-os-updater",
+    "agora-player",
+    "agora-provision",
+    "agora-slot-mgr",
+    "agora-watchdog",
+]
+
 # Reconnect backoff: 2s, 4s, 8s, ... capped at 60s
 RECONNECT_BASE = 2
 RECONNECT_MAX = 60
@@ -2475,9 +2491,7 @@ class CMSClient:
         cannot carry because ``ws.send(bytes)`` is unsupported.
         """
         request_id = msg.get("request_id", "")
-        services = msg.get("services") or [
-            "agora-player", "agora-api", "agora-cms-client", "agora-provision",
-        ]
+        services = msg.get("services") or list(DEFAULT_LOG_SERVICES)
         since = msg.get("since", "24h")
         logger.info("Log request %s: services=%s since=%s", request_id, services, since)
 

--- a/tests/test_request_logs_http_upload.py
+++ b/tests/test_request_logs_http_upload.py
@@ -39,6 +39,7 @@ sys.modules.setdefault("aiohttp", MagicMock())
 
 from cms_client.service import (  # noqa: E402
     CMSClient,
+    DEFAULT_LOG_SERVICES,
     LOGS_JSON_MAX_BYTES,
     LOGS_UPLOAD_MAX_BYTES,
     PROTOCOL_VERSION,
@@ -371,6 +372,62 @@ def test_build_logs_tar_gz_roundtrip():
     assert blob[:2] == b"\x1f\x8b"
     extracted = _extract_tar_gz(blob)
     assert extracted == {"agora-api.log": "hello", "agora-player.log": "world"}
+
+
+def test_default_log_services_covers_every_installed_unit():
+    """Regression test for the gap that left agora-os-updater,
+    agora-slot-mgr, agora-watchdog, and agora-fleet-provision out of
+    the default capture set, forcing operators to ask for them by name
+    (or via the assistant) whenever an OTA / slot promote / watchdog
+    issue needed root-causing.
+
+    The intent is: if a new ``agora-*.service`` unit is added under
+    ``systemd/`` (and packaged in the .deb), it MUST also be in the
+    default journal capture list -- otherwise the Settings "Download
+    logs" button quietly omits its output.
+    """
+    systemd_dir = Path(__file__).resolve().parent.parent / "systemd"
+    installed_units = sorted(
+        p.stem for p in systemd_dir.glob("agora-*.service")
+    )
+    assert installed_units, "expected at least one agora-*.service unit"
+    missing = set(installed_units) - set(DEFAULT_LOG_SERVICES)
+    assert not missing, (
+        f"DEFAULT_LOG_SERVICES is missing units that are installed by the "
+        f".deb (and so would be silently omitted from Settings -> Download "
+        f"logs): {sorted(missing)}.  Add them to DEFAULT_LOG_SERVICES in "
+        f"cms_client/service.py."
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_logs_with_no_services_uses_default_set(tmp_path):
+    """When the CMS does not specify ``services``, the Pi must fan
+    journalctl out over every unit in ``DEFAULT_LOG_SERVICES`` -- not
+    a stale hard-coded subset.
+    """
+    client = _make_client(tmp_path)
+    ws = MagicMock()
+    ws.send = AsyncMock()
+
+    queried: list[str] = []
+
+    def fake_run(cmd, *a, **kw):
+        # cmd is ["journalctl", "-u", <service>, "--since=...", ...]
+        queried.append(cmd[2])
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = "ok"
+        r.stderr = ""
+        return r
+
+    with patch("cms_client.service.subprocess.run", side_effect=fake_run):
+        await client._handle_request_logs(
+            {"request_id": "rdef", "since": "1h"},  # no "services" key
+            ws,
+        )
+
+    assert sorted(queried) == sorted(DEFAULT_LOG_SERVICES)
 
 
 def test_logs_api_base_falls_back_to_active_ws_url(tmp_path):


### PR DESCRIPTION
## What

Expand the default `journalctl` capture list in `_handle_request_logs`
from 4 to all 8 `agora-*` systemd units, so the CMS "Download logs"
button surfaces everything needed to debug OTA / slot / watchdog /
provisioning issues without having to ask for them by name.

Adds a new module-level constant `DEFAULT_LOG_SERVICES` and replaces
the inline list at the request handler. Also adds a regression test
that fails if a new `agora-*.service` unit is added under `systemd/`
but not added to `DEFAULT_LOG_SERVICES`.

## Why

Mia's Pi5 OTA stuck-badge debug (last week) almost stalled because
the operator-facing "Download logs" only captured:

- `agora-api`
- `agora-cms-client`
- `agora-player`
- `agora-provision`

…which omits exactly the units you need for OTA root-causing:

- `agora-os-updater` — OTA download / verify / write loop
- `agora-slot-mgr` — slot promote / confirm
- `agora-watchdog` — service aging / restart loops
- `agora-fleet-provision` — adoption / onboarding

We had to fall back to ad-hoc per-unit requests via the assistant to
pull the missing logs. For a single device that's annoying; if we had
200 devices it would be a real triage tax.

## Why the existing tests didn't catch this

The HTTP-upload test suite (`test_request_logs_http_upload.py`) only
exercised the path where the CMS passes `services` explicitly. The
fallback (`msg.get("services") or [...]`) was uncovered. New test
`test_request_logs_with_no_services_uses_default_set` closes that
gap, and `test_default_log_services_covers_every_installed_unit`
prevents future drift between `systemd/*.service` and the constant.

## Risk

Tiny. `journalctl` for an unknown unit returns empty output, not an
error, so even an out-of-date Pi can't break by being asked for a unit
it doesn't have. Tarball size grows modestly (the 4 new units are
quiet relative to `agora-player`).

## Test plan

- `pytest tests/test_request_logs_http_upload.py` — 13 passed locally.
- Will rely on full CI suite in this PR.
- Post-merge: cut a new `agora-os` release so a flashable image picks
  this up; sanity-check on Mia's Pi5 by clicking Download logs and
  confirming all 8 `.log` files are in the tarball.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
