### PR TITLE
feat(composed): dispatch composed slides + assets/composed/ subdir

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings):
         return self.assets_dir / "slideshows"
 
     @property
+    def composed_dir(self) -> Path:
+        return self.assets_dir / "composed"
+
+    @property
     def state_dir(self) -> Path:
         return self.agora_base / "state"
 

--- a/api/ui.py
+++ b/api/ui.py
@@ -197,7 +197,7 @@ async def settings_page(
 
     # Device info
     asset_count = 0
-    for subdir in [settings.videos_dir, settings.images_dir]:
+    for subdir in [settings.videos_dir, settings.images_dir, settings.composed_dir]:
         if subdir.exists():
             asset_count += sum(1 for f in subdir.iterdir() if f.is_file())
 

--- a/cms_client/asset_manager.py
+++ b/cms_client/asset_manager.py
@@ -155,7 +155,13 @@ class AssetManager:
 
         return self.available_bytes >= needed_bytes
 
-    def rebuild_from_disk(self, videos_dir: Path, images_dir: Path, splash_dir: Path) -> None:
+    def rebuild_from_disk(
+        self,
+        videos_dir: Path,
+        images_dir: Path,
+        splash_dir: Path,
+        composed_dir: Path | None = None,
+    ) -> None:
         """Scan asset directories and rebuild manifest for files not already tracked."""
         import hashlib
 
@@ -166,7 +172,10 @@ class AssetManager:
             del self._manifest[name]
             logger.info("Pruned stale manifest entry: %s", name)
 
-        for dir_path in [videos_dir, images_dir, splash_dir]:
+        scan_dirs = [videos_dir, images_dir, splash_dir]
+        if composed_dir is not None:
+            scan_dirs.append(composed_dir)
+        for dir_path in scan_dirs:
             if not dir_path.exists():
                 continue
             for file_path in dir_path.iterdir():

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -393,6 +393,7 @@ class CMSClient:
         # Rebuild manifest from disk on startup (catches manually added/removed files)
         self.asset_manager.rebuild_from_disk(
             settings.videos_dir, settings.images_dir, settings.splash_dir,
+            settings.composed_dir,
         )
 
     def _get_cms_url(self) -> str:
@@ -1783,6 +1784,8 @@ class CMSClient:
                 target_dir = self.settings.videos_dir
             elif asset_type == "image":
                 target_dir = self.settings.images_dir
+            elif asset_type == "composed":
+                target_dir = self.settings.composed_dir
             else:
                 # Fallback: route by file extension (expanded list)
                 ext = Path(asset_name).suffix.lower()
@@ -1790,6 +1793,8 @@ class CMSClient:
                     target_dir = self.settings.videos_dir
                 elif ext in (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"):
                     target_dir = self.settings.images_dir
+                elif ext in (".html", ".htm"):
+                    target_dir = self.settings.composed_dir
                 else:
                     # Default to videos/ — player searches there (never root assets/)
                     target_dir = self.settings.videos_dir
@@ -2466,6 +2471,7 @@ class CMSClient:
         # Reinitialise the asset manager so in-memory state matches disk
         self.asset_manager.rebuild_from_disk(
             self.settings.videos_dir, self.settings.images_dir, self.settings.splash_dir,
+            self.settings.composed_dir,
         )
 
         logger.info("Asset wipe complete (reason: %s)", reason)

--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -326,6 +326,24 @@ class ChromiumPlayer:
             "duration_ms": 0,
         })
 
+    def show_html(
+        self,
+        path: Path,
+        transition: str = "cut",
+        duration_ms: int = DEFAULT_TRANSITION_MS,
+    ) -> None:
+        """Render a local HTML bundle (e.g. composed slide) in an iframe."""
+        url = self._asset_url(path)
+        if url is None:
+            logger.warning("ChromiumPlayer.show_html: not under assets dir: %s", path)
+            return
+        self._enqueue({
+            "cmd": "show_html",
+            "url": url,
+            "transition": transition,
+            "duration_ms": duration_ms,
+        })
+
     def stop_playback(self) -> None:
         self._enqueue({"cmd": "stop"})
 

--- a/player/service.py
+++ b/player/service.py
@@ -451,7 +451,7 @@ class AgoraPlayer:
     # ── Asset resolution ──
 
     def _resolve_asset(self, name: str) -> Optional[Path]:
-        for subdir in ["videos", "images", "splash"]:
+        for subdir in ["videos", "images", "splash", "composed"]:
             path = self.assets_dir / subdir / name
             if path.is_file():
                 return path
@@ -3337,6 +3337,7 @@ class AgoraPlayer:
             self.current_desired = desired
             self._health_retries = 0
             is_video = path.suffix.lower() == ".mp4"
+            is_composed = desired.asset_type == "composed"
             self._loops_completed = 0
 
             # Chromium backend (demo): route image/video through the shell.
@@ -3353,7 +3354,9 @@ class AgoraPlayer:
                     self._current_mtime = path.stat().st_mtime
                 except OSError:
                     self._current_mtime = None
-                if is_video:
+                if is_composed:
+                    self._chromium_player.show_html(path)
+                elif is_video:
                     # Finite-loop is owned by player.js: we hand it
                     # loop_count and the shell counts down, replays
                     # in-place, then emits a terminal "ended" we use

--- a/player/shell/player.js
+++ b/player/shell/player.js
@@ -13,6 +13,8 @@
  *    "loop":false,"loop_count":3,"muted":false,"transition":"<mode>",
  *    "duration_ms":600}
  *   {"cmd":"show_splash","url":"/assets/splash/default.png"}
+ *   {"cmd":"show_html","url":"/assets/composed/page.html",
+ *    "transition":"<mode>","duration_ms":600}
  *   {"cmd":"stop"}
  *
  * Transition modes (<mode> above): "cut" | "fade" | "fade_black" |
@@ -120,6 +122,20 @@
         }, { once: true });
       }
       return v;
+    }
+    if (cmd.cmd === "show_html") {
+      // Composed slide: render the local HTML bundle in an iframe so the
+      // shell document keeps its WebSocket connection. sandbox allows
+      // scripts (clock/ticker widgets) but not top-level navigation or
+      // popup escape from kiosk.
+      const f = document.createElement("iframe");
+      f.src = cmd.url;
+      f.setAttribute("sandbox", "allow-scripts allow-same-origin");
+      f.style.cssText = "width:100%;height:100%;border:0;display:block;background:#000";
+      f.addEventListener("error", () => {
+        send({ event: "error", asset: cmd.url, msg: "html load failed" });
+      });
+      return f;
     }
     // Default: image (show_image, show_splash)
     const img = document.createElement("img");
@@ -344,6 +360,7 @@
     switch (cmd.cmd) {
       case "show_image":
       case "show_splash":
+      case "show_html":
         swapTo(cmd);
         break;
       case "show_video":

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -301,6 +301,23 @@ class TestRebuildFromDisk:
         assert manager.has_asset("gone.mp4") is False
         assert manager.total_size_bytes == 0
 
+    def test_rebuild_discovers_composed_files(self, manager):
+        """Files in composed/ should be picked up when composed_dir is passed."""
+        bundle = manager.assets_dir / "composed" / "composed-x.html"
+        bundle.parent.mkdir(parents=True)
+        bundle.write_bytes(b"<!doctype html>")
+
+        manager.rebuild_from_disk(
+            manager.assets_dir / "videos",
+            manager.assets_dir / "images",
+            manager.assets_dir / "splash",
+            manager.assets_dir / "composed",
+        )
+
+        assert manager.has_asset("composed-x.html") is True
+        rel = manager.get_all()["composed-x.html"]["path"].replace("\\", "/")
+        assert rel == "composed/composed-x.html"
+
     def test_rebuild_keeps_existing_files(self, manager):
         """Manifest entries for files still on disk are preserved."""
         video = manager.assets_dir / "videos" / "still_here.mp4"

--- a/tests/test_chromium_backend.py
+++ b/tests/test_chromium_backend.py
@@ -85,6 +85,29 @@ def test_show_splash_uses_cut_transition(cp):
     }]
 
 
+def test_show_html_emits_expected_command(cp):
+    sent = _capture_commands(cp)
+    bundle = cp.assets_dir / "composed" / "composed-abc.html"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_text("<!doctype html><h1>hi</h1>", encoding="utf-8")
+
+    cp.show_html(bundle)
+
+    assert len(sent) == 1
+    cmd = sent[0]
+    assert cmd["cmd"] == "show_html"
+    assert cmd["url"] == "/assets/composed/composed-abc.html"
+    assert cmd["transition"] == "cut"
+
+
+def test_show_html_outside_sandbox_is_dropped(cp, tmp_path):
+    sent = _capture_commands(cp)
+    naughty = tmp_path / "naughty.html"
+    naughty.write_text("<h1>nope</h1>", encoding="utf-8")
+    cp.show_html(naughty)
+    assert sent == []
+
+
 def test_show_image_defaults_to_cut_transition(cp):
     sent = _capture_commands(cp)
     img = cp.assets_dir / "images" / "foo.jpg"

--- a/tests/test_cms_url_reconnect.py
+++ b/tests/test_cms_url_reconnect.py
@@ -49,6 +49,7 @@ def _make_settings(tmp_path: Path, initial_cms_url: str = "") -> object:
         videos_dir = assets / "videos"
         images_dir = assets / "images"
         splash_dir = assets / "splash"
+        composed_dir = assets / "composed"
         asset_budget_mb = 100
         device_name = "test-device"
 

--- a/tests/test_stream_support.py
+++ b/tests/test_stream_support.py
@@ -112,6 +112,8 @@ class TestDownloadRouting:
         settings.images_dir.mkdir()
         settings.splash_dir = tmp_path / "assets" / "splash"
         settings.splash_dir.mkdir()
+        settings.composed_dir = tmp_path / "assets" / "composed"
+        settings.composed_dir.mkdir()
         settings.manifest_path = tmp_path / "state" / "assets.json"
         settings.manifest_path.parent.mkdir(parents=True)
         settings.schedule_path = tmp_path / "state" / "schedule.json"
@@ -143,12 +145,16 @@ class TestDownloadRouting:
             return client.settings.videos_dir
         elif asset_type == "image":
             return client.settings.images_dir
+        elif asset_type == "composed":
+            return client.settings.composed_dir
         else:
             ext = Path(asset_name).suffix.lower()
             if ext in (".mp4", ".mkv", ".webm", ".mov", ".avi", ".ts"):
                 return client.settings.videos_dir
             elif ext in (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"):
                 return client.settings.images_dir
+            elif ext in (".html", ".htm"):
+                return client.settings.composed_dir
             else:
                 return client.settings.videos_dir
 
@@ -196,6 +202,16 @@ class TestDownloadRouting:
         """WebP files should route to images/."""
         target = self._get_target_dir_for_asset_type(tmp_path, "", "photo.webp")
         assert target.name == "images"
+
+    def test_composed_asset_type_routes_to_composed(self, tmp_path):
+        """asset_type='composed' → composed/ directory."""
+        target = self._get_target_dir_for_asset_type(tmp_path, "composed", "composed-abc.html")
+        assert target.name == "composed"
+
+    def test_html_extension_routes_to_composed(self, tmp_path):
+        """HTML files (no asset_type) should route to composed/ via extension fallback."""
+        target = self._get_target_dir_for_asset_type(tmp_path, "", "page.html")
+        assert target.name == "composed"
 
 
 # ── CMS client: stream schedule evaluation ──────────────────────

--- a/tests/test_wipe_assets.py
+++ b/tests/test_wipe_assets.py
@@ -136,6 +136,7 @@ class TestWipeAssetsHandler:
 
         client.asset_manager.rebuild_from_disk.assert_called_once_with(
             settings.videos_dir, settings.images_dir, settings.splash_dir,
+            settings.composed_dir,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

Adds firmware support for the new `asset_type=composed` (composed HTML slides authored in the CMS).

### Dispatch (chromium backend)
- `chromium_backend.show_html(path)` enqueues a sandboxed iframe load
- `player/shell/player.js` handles `show_html` via `<iframe sandbox='allow-scripts allow-same-origin'>`
- `player/service.py apply_desired()` routes `asset_type=='composed'` to `show_html()` instead of falling through to `show_image` (which produced the broken-image icon)

### Storage
- New `api.config.composed_dir` (`assets/composed/`)
- `_download_one_asset` routes `asset_type=composed` (and `.html/.htm` extension fallback) into `composed_dir`
- `asset_manager.rebuild_from_disk` accepts an optional `composed_dir` (backward-compatible signature)
- `player.service._resolve_asset` searches the `composed/` subdir
- `api/ui.py` asset_count loop includes `composed/`

## Tests
- chromium_backend: `show_html` emits expected command (and rejects out-of-sandbox paths)
- asset_manager: `rebuild_from_disk` discovers `composed/` files
- stream_support: composed `asset_type` and `.html` ext route to `composed/`
- wipe_assets: `rebuild_from_disk` is called with `composed_dir`

## Validation

End-to-end on Pi100 via hot-patch 2026-06-03: composed slide renders correctly. After this PR merges and a new agora-os image rolls, Pi100 will be revalidated on stock OTA and the hot-patch `.bak` files cleaned up.

## Migration note

Existing devices have composed bundles in `videos/`. After this ships, on next fetch the file lands in `composed/` and the old one in `videos/` is left orphaned until eviction or a full `rebuild_from_disk`. Acceptable for v1 (small file count, low risk).