### PR TITLE
Composed siblings v1: auto-deliver media referenced by composed slides

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -44,7 +44,7 @@ PROTOCOL_VERSION = 2
 # - "slideshow_v1": this firmware understands ``asset_type=slideshow``
 #   on FETCH_ASSET messages, fetches the manifest+slides, and stores
 #   them under ``assets/slideshows/<name>/``.
-DEVICE_CAPABILITIES = ["slideshow_v1"]
+DEVICE_CAPABILITIES = ["slideshow_v1", "composed_siblings_v1"]
 
 # Bootstrap v2 renewal policy (issue #420 stage B.3).
 # Minimum delay between JWT refreshes on the renewal task, so a clock
@@ -1697,6 +1697,16 @@ class CMSClient:
             await self._handle_fetch_slideshow(msg, ws)
             return
 
+        # Composed slides may carry a "siblings" list (Phase 1D, capability
+        # ``composed_siblings_v1``) — referenced media (videos/images) the
+        # bundle HTML loads from local cache. When present, route to the
+        # sibling-aware handler. Composed bundles without siblings (older
+        # CMS, or composed slides with no media) keep the simple path so
+        # this is fully backward compatible.
+        if asset_type == "composed" and msg.get("siblings"):
+            await self._handle_fetch_composed(msg, ws)
+            return
+
         if not asset_name or not download_url:
             logger.warning("Invalid fetch_asset message: missing fields")
             return
@@ -2149,6 +2159,353 @@ class CMSClient:
             if not slide_name:
                 return False
             if not self.asset_manager.has_asset(slide_name, slide_checksum):
+                return False
+        return True
+
+    # ── Composed-slide sibling fetch (capability: composed_siblings_v1) ──
+
+    @staticmethod
+    def _is_safe_sibling_name(name: str) -> bool:
+        """Reject sibling asset names that could escape the cache dir.
+
+        Sibling names land on disk as files under ``videos_dir`` /
+        ``images_dir`` etc. We require a flat filename — no path
+        separators, no NUL, no ``..``, and ``Path(name).name == name``
+        so ``Path`` traversal can't surprise us.
+        """
+        if not isinstance(name, str) or not name:
+            return False
+        if "/" in name or "\\" in name or "\x00" in name:
+            return False
+        if name in (".", "..") or ".." in name.split("/") or ".." in name.split("\\"):
+            return False
+        # Reject anything that, when round-tripped through Path, no
+        # longer looks like a single basename.
+        try:
+            if Path(name).name != name:
+                return False
+        except Exception:
+            return False
+        return True
+
+    async def _handle_fetch_composed(self, msg: dict, ws) -> None:
+        """Fetch a composed-slide bundle + its referenced sibling media.
+
+        The composed bundle is a single self-contained HTML file. Any
+        non-inline media it references (videos in v1) is delivered as
+        ``siblings`` so the device can cache each one alongside the
+        bundle. The bundle HTML loads siblings by local cache URL
+        (e.g. ``/assets/videos/foo.mp4``) served by the player shell.
+
+        Like the slideshow handler: dedupe missing siblings, bulk-evict
+        for the combined byte budget while protecting scheduled assets
+        and the in-flight sibling names, download siblings, then
+        download the bundle, write a ``.deps.json`` sidecar, ACK.
+        """
+        asset_name = msg.get("asset_name", "")
+        download_url = msg.get("download_url", "")
+        expected_checksum = msg.get("checksum", "")
+        siblings = msg.get("siblings") or []
+
+        if not asset_name or not download_url:
+            logger.warning(
+                "Invalid composed fetch_asset: missing asset_name/download_url"
+            )
+            await ws.send(json.dumps({
+                "type": "fetch_failed",
+                "protocol_version": PROTOCOL_VERSION,
+                "device_id": self.device_id,
+                "asset": asset_name,
+                "reason": "invalid_composed_payload",
+            }))
+            return
+
+        if not isinstance(siblings, list):
+            logger.warning("Invalid composed fetch_asset for %s: siblings not a list", asset_name)
+            await ws.send(json.dumps({
+                "type": "fetch_failed",
+                "protocol_version": PROTOCOL_VERSION,
+                "device_id": self.device_id,
+                "asset": asset_name,
+                "reason": "invalid_composed_payload",
+            }))
+            return
+
+        # Validate sibling descriptors up front (shape + path-traversal guard).
+        for i, sib in enumerate(siblings):
+            if not isinstance(sib, dict):
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "invalid_sibling_descriptor",
+                    "sibling_position": i,
+                }))
+                return
+            sib_name = sib.get("asset_name")
+            sib_url = sib.get("download_url")
+            if not sib_name or not sib_url:
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "invalid_sibling_descriptor",
+                    "sibling_position": i,
+                }))
+                return
+            if not self._is_safe_sibling_name(sib_name):
+                logger.warning(
+                    "Composed %s: rejecting unsafe sibling name %r",
+                    asset_name, sib_name,
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "invalid_sibling_name",
+                    "sibling_asset": sib_name,
+                }))
+                return
+
+        # Fast path: bundle + every sibling already cached with matching checksums.
+        if self._has_complete_composed(asset_name, expected_checksum, siblings):
+            # Rewrite sidecar if the sibling set drifted (e.g. CMS changed a
+            # sibling's checksum without renaming it). Cheap to do always.
+            existing = self._read_composed_sidecar(asset_name) or {}
+            if existing.get("siblings") != [
+                {
+                    "name": s["asset_name"],
+                    "asset_type": s.get("asset_type", "video"),
+                    "checksum": s.get("checksum", ""),
+                    "size_bytes": s.get("size_bytes", 0),
+                }
+                for s in siblings
+            ]:
+                self._write_composed_sidecar(asset_name, expected_checksum, siblings)
+            else:
+                logger.info("Composed already cached and complete: %s", asset_name)
+            await self._touch_composed_siblings(asset_name, siblings)
+            await ws.send(json.dumps({
+                "type": "asset_ack",
+                "protocol_version": PROTOCOL_VERSION,
+                "device_id": self.device_id,
+                "asset_name": asset_name,
+                "checksum": expected_checksum,
+            }))
+            return
+
+        # Dedupe siblings still needed by (name, checksum).
+        unique_missing: dict[tuple[str, str], dict] = {}
+        for sib in siblings:
+            key = (sib["asset_name"], sib.get("checksum", ""))
+            if key in unique_missing:
+                continue
+            if self.asset_manager.has_asset(sib["asset_name"], sib.get("checksum") or None):
+                continue
+            unique_missing[key] = sib
+
+        bundle_size = msg.get("size_bytes", 0) or 0
+        sibling_bytes = sum(s.get("size_bytes", 0) for s in unique_missing.values())
+        total_bytes = bundle_size + sibling_bytes
+
+        # Bulk evict for bundle + missing siblings together. Protect
+        # scheduled assets, the bundle name itself, and every sibling
+        # name we're about to bring in so we don't evict ourselves.
+        if total_bytes > 0:
+            scheduled_assets = self._get_scheduled_asset_names()
+            sync_data = self._read_schedule_cache()
+            default_asset = sync_data.get("default_asset") if sync_data else None
+            protected = (
+                scheduled_assets
+                | {asset_name}
+                | {s["asset_name"] for s in siblings}
+            )
+            ok = self.asset_manager.evict_for(total_bytes, protected, default_asset)
+            if not ok:
+                logger.error(
+                    "Cannot fit composed %s (%d bytes total): budget=%dMB",
+                    asset_name, total_bytes, self.asset_manager.budget_mb,
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "insufficient_storage",
+                    "budget_mb": self.asset_manager.budget_mb,
+                    "available_mb": self.asset_manager.available_bytes // (1024 * 1024),
+                    "required_mb": total_bytes // (1024 * 1024),
+                }))
+                return
+
+        # Download missing siblings first — the bundle is useless without them.
+        for sib in unique_missing.values():
+            actual = await self._download_one_asset(
+                sib["asset_name"],
+                sib.get("asset_type", "video"),
+                sib["download_url"],
+                sib.get("checksum", ""),
+            )
+            if actual is None:
+                logger.error(
+                    "Composed %s: sibling %s download failed",
+                    asset_name, sib["asset_name"],
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "sibling_download_failed",
+                    "sibling_asset": sib["asset_name"],
+                }))
+                return
+
+        # Download bundle itself (always — fast path above already short-circuited
+        # the cached case).
+        actual_bundle = await self._download_one_asset(
+            asset_name, "composed", download_url, expected_checksum,
+        )
+        if actual_bundle is None:
+            logger.error("Composed %s: bundle download failed", asset_name)
+            await ws.send(json.dumps({
+                "type": "fetch_failed",
+                "protocol_version": PROTOCOL_VERSION,
+                "device_id": self.device_id,
+                "asset": asset_name,
+                "reason": "bundle_download_failed",
+            }))
+            return
+
+        # Persist sidecar so future fast-path checks + eviction-protection
+        # can reconstruct the sibling list without the wire message.
+        self._write_composed_sidecar(asset_name, actual_bundle, siblings)
+        await self._touch_composed_siblings(asset_name, siblings)
+
+        # Re-trigger desired state if player is waiting for this composed asset.
+        desired = read_state(self.settings.desired_state_path, DesiredState)
+        if desired.asset == asset_name:
+            logger.info(
+                "Re-applying desired state for just-downloaded composed: %s",
+                asset_name,
+            )
+            desired.timestamp = datetime.now(timezone.utc)
+            write_state(self.settings.desired_state_path, desired)
+
+        logger.info(
+            "Composed fetched: %s (%d siblings, %d unique downloads)",
+            asset_name, len(siblings), len(unique_missing),
+        )
+        await ws.send(json.dumps({
+            "type": "asset_ack",
+            "protocol_version": PROTOCOL_VERSION,
+            "device_id": self.device_id,
+            "asset_name": asset_name,
+            "checksum": actual_bundle,
+        }))
+
+    def _write_composed_sidecar(
+        self,
+        asset_name: str,
+        expected_checksum: str,
+        siblings: list[dict],
+    ) -> None:
+        """Atomically write ``<composed_dir>/<name>.deps.json``.
+
+        Sibling files live in their own type-routed dirs (videos_dir /
+        images_dir) — the sidecar only records names + checksums so the
+        device can verify completeness and protect siblings from
+        eviction. ``.deps.json`` (not ``.json``) avoids any chance of
+        colliding with the bundle's own ``.html`` file if a user names
+        their composed slide oddly.
+        """
+        payload = {
+            "name": asset_name,
+            "checksum": expected_checksum,
+            "siblings": [
+                {
+                    "name": s["asset_name"],
+                    "asset_type": s.get("asset_type", "video"),
+                    "checksum": s.get("checksum", ""),
+                    "size_bytes": s.get("size_bytes", 0),
+                }
+                for s in siblings
+            ],
+        }
+        self.settings.composed_dir.mkdir(parents=True, exist_ok=True)
+        sidecar_path = self.settings.composed_dir / f"{asset_name}.deps.json"
+        atomic_write(sidecar_path, json.dumps(payload, indent=2))
+
+    def _read_composed_sidecar(self, asset_name: str) -> dict | None:
+        """Read and parse a composed sidecar. Returns None if missing/corrupt."""
+        path = self.settings.composed_dir / f"{asset_name}.deps.json"
+        try:
+            data = json.loads(path.read_text())
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        if not isinstance(data.get("siblings"), list):
+            return None
+        return data
+
+    def _is_composed_asset(self, asset_name: str) -> bool:
+        """True iff `asset_name` is registered as a composed bundle on this device."""
+        entry = self.asset_manager.get(asset_name)
+        if not isinstance(entry, dict):
+            return False
+        path = entry.get("path", "")
+        return isinstance(path, str) and path.startswith("composed/")
+
+    async def _touch_composed_siblings(self, _asset_name: str, siblings: list[dict]) -> None:
+        """Bump LRU timestamps for every sibling referenced by a composed bundle."""
+        seen: set[str] = set()
+        for sib in siblings:
+            name = sib.get("asset_name") or sib.get("name")
+            if name and name not in seen:
+                self.asset_manager.touch(name)
+                seen.add(name)
+
+    def _has_complete_composed(
+        self,
+        asset_name: str,
+        expected_checksum: str,
+        siblings: list[dict] | None = None,
+    ) -> bool:
+        """A composed slide is complete only when:
+
+        - the bundle is registered with a matching checksum,
+        - the sidecar parses and matches that checksum,
+        - every referenced sibling is in the asset_manager with a matching checksum.
+
+        If ``siblings`` is provided (e.g. fresh from a FETCH_ASSET
+        message), it is used as the authoritative list; otherwise the
+        sidecar's list is used.
+        """
+        if not self.asset_manager.has_asset(asset_name, expected_checksum):
+            return False
+        sidecar = self._read_composed_sidecar(asset_name)
+        if sidecar is None:
+            return False
+        if expected_checksum and sidecar.get("checksum") != expected_checksum:
+            return False
+        if siblings is not None:
+            sibling_list = [
+                {"name": s["asset_name"], "checksum": s.get("checksum") or None}
+                for s in siblings
+            ]
+        else:
+            sibling_list = [
+                {"name": s.get("name"), "checksum": s.get("checksum") or None}
+                for s in sidecar.get("siblings", [])
+            ]
+        for sib in sibling_list:
+            if not sib["name"]:
+                return False
+            if not self.asset_manager.has_asset(sib["name"], sib["checksum"]):
                 return False
         return True
 
@@ -2762,6 +3119,17 @@ class CMSClient:
                 slide_name = slide.get("name") or slide.get("asset_name")
                 if slide_name:
                     names.add(slide_name)
+        # Expand composed slides → sibling sources (Phase 1D)
+        for asset in list(names):
+            if not self._is_composed_asset(asset):
+                continue
+            sidecar = self._read_composed_sidecar(asset)
+            if sidecar is None:
+                continue
+            for sib in sidecar.get("siblings", []):
+                sib_name = sib.get("name") or sib.get("asset_name")
+                if sib_name:
+                    names.add(sib_name)
         if default_asset:
             # Caller may use default_asset as a separate protection axis;
             # leave it in `names` as well for safety but don't double-add.

--- a/tests/test_composed_fetch.py
+++ b/tests/test_composed_fetch.py
@@ -1,0 +1,457 @@
+"""Tests for composed-slide asset fetching with sibling media (Phase 1D).
+
+The CMS sends a ``fetch_asset`` message with ``asset_type="composed"``
+and an optional ``siblings`` list (videos / images the bundle HTML
+loads from local cache). The device must:
+
+* validate sibling descriptors (shape + safe name),
+* dedupe + bulk-evict for bundle + siblings together,
+* download siblings first, then the bundle,
+* write a ``.deps.json`` sidecar so future fast-path checks and
+  eviction protection can reconstruct the sibling list,
+* ACK with the resolved bundle checksum.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio  # noqa: F401  (registers asyncio fixtures)
+
+from cms_client.asset_manager import AssetManager  # noqa: E402
+from cms_client.service import (  # noqa: E402
+    DEVICE_CAPABILITIES,
+    CMSClient,
+)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture
+def cms_client(tmp_path):
+    """CMSClient wired to a real AssetManager + tmp dirs.
+
+    Mirrors the slideshow-fetch fixture so the test patterns line up.
+    """
+    settings = MagicMock()
+    settings.agora_base = tmp_path
+    settings.assets_dir = tmp_path / "assets"
+    settings.videos_dir = tmp_path / "assets" / "videos"
+    settings.images_dir = tmp_path / "assets" / "images"
+    settings.splash_dir = tmp_path / "assets" / "splash"
+    settings.slideshows_dir = tmp_path / "assets" / "slideshows"
+    settings.composed_dir = tmp_path / "assets" / "composed"
+    for d in (settings.assets_dir, settings.videos_dir, settings.images_dir,
+              settings.splash_dir, settings.slideshows_dir,
+              settings.composed_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    settings.manifest_path = tmp_path / "state" / "assets.json"
+    settings.manifest_path.parent.mkdir(parents=True)
+    settings.schedule_path = tmp_path / "state" / "schedule.json"
+    settings.desired_state_path = tmp_path / "state" / "desired.json"
+    settings.persist_dir = tmp_path / "persist"
+    settings.persist_dir.mkdir()
+    settings.asset_budget_mb = 100
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        client = CMSClient(settings)
+    client.settings = settings
+    client.device_id = "test-device"
+    client.asset_manager = AssetManager(
+        settings.manifest_path, settings.assets_dir, budget_mb=100,
+    )
+    client._ws = AsyncMock()
+    client._fetch_lock = asyncio.Lock()
+    client._fetch_tasks = {}
+    client._current_schedule_id = None
+    client._current_schedule_name = None
+    client._current_asset = None
+    client._eval_wake = asyncio.Event()
+    client._last_player_mode = None
+    return client
+
+
+def _make_sibling(name: str, body: bytes, asset_type: str = "video") -> dict:
+    return {
+        "asset_name": name,
+        "asset_type": asset_type,
+        "download_url": f"http://cms.test/{name}",
+        "checksum": _sha256(body),
+        "size_bytes": len(body),
+    }
+
+
+class _FakeAioHttpResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+        self.content = self
+
+    async def iter_chunked(self, _size):
+        yield self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeAioHttpSession:
+    def __init__(self, mapping: dict[str, bytes]):
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        body = self._mapping.get(url, b"")
+        status = 200 if url in self._mapping else 404
+        return _FakeAioHttpResponse(body, status)
+
+
+def _patch_aiohttp(mapping):
+    fake_session = _FakeAioHttpSession(mapping)
+    fake_module = MagicMock()
+    fake_module.ClientSession = lambda: fake_session
+    return fake_module, fake_session
+
+
+class TestComposedCapability:
+    def test_capability_advertised(self):
+        """Phase 1D capability flag must be in the global list so the
+        CMS gates sibling emission correctly."""
+        assert "composed_siblings_v1" in DEVICE_CAPABILITIES
+
+
+class TestComposedFetch:
+    @pytest.mark.asyncio
+    async def test_happy_path_bundle_plus_two_siblings(self, cms_client):
+        bundle_body = b"<html><body>composed bundle</body></html>"
+        v1_body = b"video-one-payload"
+        v2_body = b"video-two-payload"
+        siblings = [
+            _make_sibling("ad-clip-1.mp4", v1_body),
+            _make_sibling("ad-clip-2.mp4", v2_body),
+        ]
+        bundle_url = "http://cms.test/Composed Asset.html"
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Composed Asset.html",
+            "asset_type": "composed",
+            "download_url": bundle_url,
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": siblings,
+        }
+        mapping = {
+            bundle_url: bundle_body,
+            siblings[0]["download_url"]: v1_body,
+            siblings[1]["download_url"]: v2_body,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp(mapping)
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Bundle landed in composed_dir; siblings in videos_dir
+        assert (cms_client.settings.composed_dir / "Composed Asset.html").read_bytes() == bundle_body
+        assert (cms_client.settings.videos_dir / "ad-clip-1.mp4").read_bytes() == v1_body
+        assert (cms_client.settings.videos_dir / "ad-clip-2.mp4").read_bytes() == v2_body
+
+        # Sidecar persisted
+        sidecar = json.loads((cms_client.settings.composed_dir / "Composed Asset.html.deps.json").read_text())
+        assert sidecar["name"] == "Composed Asset.html"
+        assert sidecar["checksum"] == _sha256(bundle_body)
+        assert [s["name"] for s in sidecar["siblings"]] == ["ad-clip-1.mp4", "ad-clip-2.mp4"]
+        assert sidecar["siblings"][0]["asset_type"] == "video"
+
+        # AssetManager has all three
+        am = cms_client.asset_manager
+        assert am.has_asset("Composed Asset.html", _sha256(bundle_body))
+        assert am.has_asset("ad-clip-1.mp4", _sha256(v1_body))
+        assert am.has_asset("ad-clip-2.mp4", _sha256(v2_body))
+
+        # ACK on bundle checksum
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        acks = [m for m in sent if m["type"] == "asset_ack"]
+        assert len(acks) == 1
+        assert acks[0]["asset_name"] == "Composed Asset.html"
+        assert acks[0]["checksum"] == _sha256(bundle_body)
+        assert not [m for m in sent if m["type"] == "fetch_failed"]
+
+    @pytest.mark.asyncio
+    async def test_no_siblings_uses_simple_path(self, cms_client):
+        """Composed asset with no siblings keeps the legacy
+        ``_download_one_asset`` path so the change is fully backward
+        compatible with a CMS that doesn't know about sibling delivery yet."""
+        body = b"<html>plain composed</html>"
+        bundle_url = "http://cms.test/plain.html"
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "plain.html",
+            "asset_type": "composed",
+            "download_url": bundle_url,
+            "checksum": _sha256(body),
+            "size_bytes": len(body),
+        }
+        fake_aiohttp, _ = _patch_aiohttp({bundle_url: body})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Bundle present; NO sidecar (simple path doesn't write one)
+        assert (cms_client.settings.composed_dir / "plain.html").read_bytes() == body
+        assert not (cms_client.settings.composed_dir / "plain.html.deps.json").exists()
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert any(m["type"] == "asset_ack" and m["asset_name"] == "plain.html" for m in sent)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_name", [
+        "../escape.mp4",
+        "subdir/clip.mp4",
+        "C:\\windows\\boom.mp4",
+        "with\x00nul.mp4",
+        "..",
+        ".",
+        "",
+    ])
+    async def test_path_traversal_rejected(self, cms_client, bad_name):
+        bundle_body = b"<html></html>"
+        sibling_body = b"v"
+        siblings = [{
+            "asset_name": bad_name,
+            "asset_type": "video",
+            "download_url": "http://cms.test/whatever",
+            "checksum": _sha256(sibling_body),
+            "size_bytes": len(sibling_body),
+        }]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": "http://cms.test/bundle.html",
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": siblings,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        fails = [m for m in sent if m["type"] == "fetch_failed"]
+        assert len(fails) == 1
+        # Empty / "." / ".." are caught as descriptor errors (no asset_name);
+        # others as invalid_sibling_name.
+        assert fails[0]["reason"] in {"invalid_sibling_name", "invalid_sibling_descriptor"}
+        # No downloads at all
+        assert fake_session.calls == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_sibling_descriptor_missing_url(self, cms_client):
+        bundle_body = b"<html></html>"
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": "http://cms.test/bundle.html",
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": [{"asset_name": "vid.mp4"}],  # no download_url
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        fails = [m for m in sent if m["type"] == "fetch_failed"]
+        assert len(fails) == 1
+        assert fails[0]["reason"] == "invalid_sibling_descriptor"
+        assert fake_session.calls == []
+
+    @pytest.mark.asyncio
+    async def test_fast_path_all_cached_skips_download(self, cms_client):
+        """Bundle + every sibling already cached → no downloads, just ACK."""
+        bundle_body = b"<html>cached</html>"
+        v_body = b"video-cached"
+        siblings = [_make_sibling("c.mp4", v_body)]
+
+        # Pre-populate cache: write bundle + sibling on disk and register both.
+        bundle_path = cms_client.settings.composed_dir / "bundle.html"
+        bundle_path.write_bytes(bundle_body)
+        cms_client.asset_manager.register(
+            "bundle.html", "composed/bundle.html", len(bundle_body), _sha256(bundle_body),
+        )
+        sib_path = cms_client.settings.videos_dir / "c.mp4"
+        sib_path.write_bytes(v_body)
+        cms_client.asset_manager.register(
+            "c.mp4", "videos/c.mp4", len(v_body), _sha256(v_body),
+        )
+        # Pre-write sidecar so the fast-path check passes
+        cms_client._write_composed_sidecar("bundle.html", _sha256(bundle_body), siblings)
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": "http://cms.test/bundle.html",
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": siblings,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        assert fake_session.calls == []
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        acks = [m for m in sent if m["type"] == "asset_ack"]
+        assert len(acks) == 1
+        assert acks[0]["checksum"] == _sha256(bundle_body)
+
+    @pytest.mark.asyncio
+    async def test_missing_sibling_triggers_slow_path(self, cms_client):
+        """Bundle cached but sibling missing → slow path: download sibling
+        + (re-)download bundle, write sidecar, ACK."""
+        bundle_body = b"<html>bundle</html>"
+        v_body = b"missing-video"
+        siblings = [_make_sibling("v.mp4", v_body)]
+
+        # Pre-cache the bundle only.
+        (cms_client.settings.composed_dir / "bundle.html").write_bytes(bundle_body)
+        cms_client.asset_manager.register(
+            "bundle.html", "composed/bundle.html", len(bundle_body), _sha256(bundle_body),
+        )
+        # No sidecar yet; sibling not on disk.
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": "http://cms.test/bundle.html",
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": siblings,
+        }
+        mapping = {
+            msg["download_url"]: bundle_body,
+            siblings[0]["download_url"]: v_body,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Sibling downloaded; bundle re-downloaded (slow path always rewrites it)
+        assert siblings[0]["download_url"] in fake_session.calls
+        assert (cms_client.settings.videos_dir / "v.mp4").read_bytes() == v_body
+        # Sidecar now persisted
+        assert (cms_client.settings.composed_dir / "bundle.html.deps.json").exists()
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert any(m["type"] == "asset_ack" for m in sent)
+
+    @pytest.mark.asyncio
+    async def test_sibling_download_failure_aborts(self, cms_client):
+        """A sibling failing to download must short-circuit the bundle
+        download and emit a precise `fetch_failed`."""
+        bundle_body = b"<html>bundle</html>"
+        v_body = b"video"
+        sib = _make_sibling("v.mp4", v_body)
+        # mapping intentionally omits the sibling URL → 404
+        bundle_url = "http://cms.test/bundle.html"
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": bundle_url,
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": [sib],
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({bundle_url: bundle_body})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        fails = [m for m in sent if m["type"] == "fetch_failed"]
+        assert len(fails) == 1
+        assert fails[0]["reason"] == "sibling_download_failed"
+        assert fails[0]["sibling_asset"] == "v.mp4"
+        # Bundle was NOT downloaded
+        assert bundle_url not in fake_session.calls
+        # No ACK
+        assert not [m for m in sent if m["type"] == "asset_ack"]
+
+    @pytest.mark.asyncio
+    async def test_get_scheduled_asset_names_expands_composed(self, cms_client, tmp_path):
+        """Scheduled composed slide must expose its siblings to the
+        eviction-protection set."""
+        # Register a composed bundle in the manifest
+        cms_client.asset_manager.register(
+            "live.html", "composed/live.html", 10, "bundle-hash",
+        )
+        # Write its sidecar
+        cms_client._write_composed_sidecar(
+            "live.html",
+            "bundle-hash",
+            [
+                {"asset_name": "vid-a.mp4", "asset_type": "video",
+                 "download_url": "x", "checksum": "ha", "size_bytes": 1},
+                {"asset_name": "vid-b.mp4", "asset_type": "video",
+                 "download_url": "x", "checksum": "hb", "size_bytes": 1},
+            ],
+        )
+        # Schedule references the composed asset
+        cms_client.settings.schedule_path.write_text(json.dumps({
+            "schedules": [{"asset": "live.html"}],
+            "default_asset": None,
+        }))
+        names = cms_client._get_scheduled_asset_names()
+        assert "live.html" in names
+        assert "vid-a.mp4" in names
+        assert "vid-b.mp4" in names
+
+    @pytest.mark.asyncio
+    async def test_eviction_protects_sibling_names(self, cms_client):
+        """During bulk eviction for a composed fetch, siblings about to
+        be downloaded must be in the protected set so they are not
+        immediately evicted to make room for themselves."""
+        bundle_body = b"<html></html>"
+        v_body = b"v-bytes"
+        sib = _make_sibling("v.mp4", v_body)
+
+        # Pre-register the sibling in the manifest as if a previous schedule
+        # left it on disk; then verify it's still present after the fetch.
+        (cms_client.settings.videos_dir / "v.mp4").write_bytes(v_body)
+        cms_client.asset_manager.register(
+            "v.mp4", "videos/v.mp4", len(v_body), _sha256(v_body),
+        )
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "bundle.html",
+            "asset_type": "composed",
+            "download_url": "http://cms.test/bundle.html",
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": [sib],
+        }
+        mapping = {msg["download_url"]: bundle_body}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Sibling untouched (still cached with same checksum)
+        assert cms_client.asset_manager.has_asset("v.mp4", _sha256(v_body))
+        assert (cms_client.settings.videos_dir / "v.mp4").exists()


### PR DESCRIPTION
## Summary

Phase 1D firmware-side: when the CMS sends a `FETCH_ASSET` for a composed slide with a new `siblings` array, the device downloads the listed videos/images first, then the bundle, and writes a sidecar `.deps.json` so siblings are protected from eviction while the bundle is current.

Pairs with an upcoming CMS PR that emits the new payload when the device advertises `composed_siblings_v1`.

## Why

Today a composed slide that embeds a video only plays if the video happens to be independently assigned to the same device groups. That doesn't scale -- users shouldn't have to think about "this composed slide depends on these 3 videos, make sure they're all assigned everywhere this slide goes." The CMS already knows the dependency set at publish time; this PR lets it deliver the dependency set in the same `FETCH_ASSET` message.

## Backward compatibility

- New capability advertised: `composed_siblings_v1`. Existing CMS that doesn't gate on it keeps working (we just won't get sibling lists, falling through to the legacy single-URL path).
- Composed `FETCH_ASSET` **without** `siblings` falls through to the legacy `_download_one_asset` path -- no behavior change.
- Slideshow / image / video paths untouched.

## Safety

- Sibling names go through `_is_safe_sibling_name`: rejects `/`, `\`, NUL, `..`, `.`, empty, anything where `Path(name).name != name`. Covered by 7 parametrized tests.
- Bulk-evict before downloads protects: currently-scheduled assets + the bundle + every sibling name in the new descriptor. Test: `test_eviction_protects_sibling_names`.
- If any sibling download fails, the bundle is **not** downloaded and a failure NACK is sent. Test: `test_sibling_download_failure_aborts`.

## Sidecar

`composed_dir/<bundle_name>.deps.json`:
```json
{
  "name": "composed-abc.html",
  "checksum": "sha256...",
  "siblings": [
    {"name": "clip1.mp4", "asset_type": "video", "checksum": "...", "size_bytes": 12345}
  ]
}
```

`_get_scheduled_asset_names()` reads these on every eviction round so siblings stay protected as long as the bundle is current.

## Tests

16 new tests in `tests/test_composed_fetch.py`:
- capability advertised
- happy path (bundle + 2 siblings)
- backward compat (no siblings -> simple path)
- 7 path-traversal cases (parametrized)
- missing-URL sibling descriptor rejected
- fast path (all cached -> no downloads)
- slow path (one missing sibling triggers full re-evaluation)
- sibling download failure aborts before bundle download
- scheduled-asset expansion picks up sidecar siblings
- eviction explicitly protects sibling names

Full local suite: 1806 passed (cross-test pollution errors in `test_wss_support.py` are pre-existing and unrelated; the file passes in isolation).

## Rollout

1. Land this PR -> APT publishes new agora `.deb`.
2. Cut a `sslivins/agora-os` tag to bake the new firmware into an OS image.
3. Flash a Pi and ship the matching CMS PR (separate, gated on `composed_siblings_v1`).