### PR TITLE
fix(composed): accept CMS sibling key 'name' (was silently dropping fetches)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -2231,9 +2231,25 @@ class CMSClient:
             }))
             return
 
+        # Normalize sibling descriptor keys.  CMS wire format uses "name"
+        # (cms/schemas/protocol.py Sibling); earlier firmware drafts used
+        # "asset_name".  Accept either by populating both so downstream
+        # readers (cache fast-path, dedupe, download loop, sidecar writer)
+        # all work regardless of which key the sender used.
+        for sib in siblings:
+            if isinstance(sib, dict):
+                if "asset_name" not in sib and "name" in sib:
+                    sib["asset_name"] = sib["name"]
+                elif "name" not in sib and "asset_name" in sib:
+                    sib["name"] = sib["asset_name"]
+
         # Validate sibling descriptors up front (shape + path-traversal guard).
         for i, sib in enumerate(siblings):
             if not isinstance(sib, dict):
+                logger.warning(
+                    "Composed %s: sibling[%d] is not a dict (got %s)",
+                    asset_name, i, type(sib).__name__,
+                )
                 await ws.send(json.dumps({
                     "type": "fetch_failed",
                     "protocol_version": PROTOCOL_VERSION,
@@ -2246,6 +2262,10 @@ class CMSClient:
             sib_name = sib.get("asset_name")
             sib_url = sib.get("download_url")
             if not sib_name or not sib_url:
+                logger.warning(
+                    "Composed %s: sibling[%d] missing name/download_url; keys=%r",
+                    asset_name, i, sorted(sib.keys()),
+                )
                 await ws.send(json.dumps({
                     "type": "fetch_failed",
                     "protocol_version": PROTOCOL_VERSION,

--- a/tests/test_composed_fetch.py
+++ b/tests/test_composed_fetch.py
@@ -194,6 +194,54 @@ class TestComposedFetch:
         assert not [m for m in sent if m["type"] == "fetch_failed"]
 
     @pytest.mark.asyncio
+    async def test_happy_path_cms_wire_format_uses_name_key(self, cms_client):
+        """CMS protocol (cms/schemas/protocol.py Sibling model) sends
+        siblings keyed as ``name``, not ``asset_name``.  Earlier firmware
+        drafts only accepted ``asset_name`` and silently dropped real
+        CMS messages on the floor.  This test pins the wire format:
+        siblings with only ``name`` populated must work end-to-end."""
+        bundle_body = b"<html>composed wire-format test</html>"
+        sib_body = b"sibling-video-payload"
+        sib_url = "http://cms.test/wire-clip.mp4"
+        # Real CMS wire format: key is "name", no "asset_name"
+        siblings = [{
+            "name": "wire-clip.mp4",
+            "asset_type": "video",
+            "download_url": sib_url,
+            "checksum": _sha256(sib_body),
+            "size_bytes": len(sib_body),
+        }]
+        bundle_url = "http://cms.test/wire.html"
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "wire.html",
+            "asset_type": "composed",
+            "download_url": bundle_url,
+            "checksum": _sha256(bundle_body),
+            "size_bytes": len(bundle_body),
+            "siblings": siblings,
+        }
+        fake_aiohttp, _ = _patch_aiohttp({
+            bundle_url: bundle_body,
+            sib_url: sib_body,
+        })
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # Both files landed
+        assert (cms_client.settings.composed_dir / "wire.html").read_bytes() == bundle_body
+        assert (cms_client.settings.videos_dir / "wire-clip.mp4").read_bytes() == sib_body
+
+        # Sidecar emitted with "name" key (matches CMS schema)
+        sidecar = json.loads((cms_client.settings.composed_dir / "wire.html.deps.json").read_text())
+        assert sidecar["siblings"][0]["name"] == "wire-clip.mp4"
+
+        # ACK on bundle, no fetch_failed
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert any(m["type"] == "asset_ack" for m in sent)
+        assert not [m for m in sent if m["type"] == "fetch_failed"]
+
+    @pytest.mark.asyncio
     async def test_no_siblings_uses_simple_path(self, cms_client):
         """Composed asset with no siblings keeps the legacy
         ``_download_one_asset`` path so the change is fully backward


### PR DESCRIPTION
Phase 1D firmware (v1.11.95, PR #253) read sibling descriptors via `sib.get("asset_name")`, but the CMS protocol (`cms/schemas/protocol.py` `Sibling` model) sends them keyed as `name`. Result: every composed slide with siblings hit the missing-name branch and returned `fetch_failed` silently (no log), then on the next sync cycle CMS resent the same `fetch_asset`, looping forever. The slide bundle never downloaded, the sibling video never downloaded, and the player stayed on the splash.

## Fix

Normalize sibling descriptors at handler entry so both `name` and `asset_name` are populated. All downstream readers (cache fast-path, dedupe key, download loop, sidecar writer, scheduled-asset expansion) work unchanged regardless of which key the sender used. Both directions covered for resilience.

Also adds `logger.warning` calls on the two previously-silent `fetch_failed` branches (non-dict sibling, missing name/url) so the next shape mismatch surfaces in journalctl immediately instead of needing field hot-patching.

## Validation

Hardware-validated on Pi100 (192.168.1.100, agora v1.11.95 + agora-os v1.0.5-test + CMS PR #707 dev) 2026-06-04:

- `COMPOSED_NEEDS_DOWNLOAD` fires on the first `fetch_asset`
- `phase1d_test.mp4` downloads to `/data/agora/assets/videos/`
- composed bundle downloads to `/data/agora/assets/composed/`
- sidecar `.deps.json` correctly records sibling with `name` key
- player advances to `mode=play` for the composed asset, no fetch loop

## Tests

17/17 `tests/test_composed_fetch.py` pass. New test `test_happy_path_cms_wire_format_uses_name_key` pins the real CMS wire format end-to-end so future drift gets caught in CI rather than via 2-hour journalctl forensics on a hot-patched Pi.

## Risk

Low. 20-line defensive change inside `_handle_fetch_composed` only; no API surface change; pure normalization; backward compatible with both `name` and `asset_name` senders.