### PR TITLE
fix: de-duplicate outbound fetch_request per sync cycle

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -103,6 +103,11 @@ EVAL_INTERVAL = 15      # seconds between local schedule evaluations
 PLAYER_WATCH_INTERVAL = 2  # seconds between player-mode checks for end-of-stream
 FETCH_INTERVAL = 60     # seconds between proactive fetch checks
 FETCH_LOOKAHEAD_HOURS = 24  # how far ahead to look for missing assets
+# Safety net for the in-flight fetch_request de-dupe: if a request was sent
+# but no fetch_asset reply ever arrived (e.g. a dropped message), allow a
+# re-request after this many seconds. Active downloads suppress re-requests
+# independently (via _fetch_tasks), so this never interrupts a long download.
+FETCH_REQUEST_DEDUPE_TTL = 90  # seconds
 AUTH_REJECTED_RETRY = 10    # seconds to wait before retrying after auth rejection
 
 
@@ -378,6 +383,13 @@ class CMSClient:
         # ``_fetch_lock`` so AssetManager eviction math stays correct.
         self._fetch_tasks: dict[str, asyncio.Task] = {}
         self._fetch_lock = asyncio.Lock()
+        # Outstanding fetch_request de-dupe, keyed by asset_name → monotonic
+        # send time. Three uncoordinated emitters (direct sync eval, woken
+        # eval loop, proactive fetch loop) would otherwise each ask the CMS
+        # for the same still-missing asset every cycle. Suppressed while a
+        # request awaits its fetch_asset reply (within FETCH_REQUEST_DEDUPE_TTL)
+        # or a download for the asset is active (_fetch_tasks).
+        self._inflight_fetches: dict[str, float] = {}
         # Bootstrap v2 state (only populated when settings.bootstrap_v2 is true)
         self._bootstrap_identity = None  # shared.bootstrap_identity.DeviceIdentity
         self._bootstrap_pairing_secret: str | None = None
@@ -719,6 +731,10 @@ class CMSClient:
 
         async with transport as ws:
             self._ws = ws
+            # Fresh connection: drop stale in-flight markers so a missing
+            # asset is re-requested immediately rather than waiting out the
+            # TTL of a request that died with the previous socket.
+            self._inflight_fetches.clear()
             logger.info("WebSocket connected (transport=%s)", transport_mode)
 
             auth_token = _read_auth_token(self.settings.auth_token_path)
@@ -1425,8 +1441,64 @@ class CMSClient:
         self._current_schedule_name = None
         self._current_asset = None
 
+    def _should_send_fetch_request(self, asset_name: str) -> bool:
+        """Decide whether a ``fetch_request`` for ``asset_name`` should be sent.
+
+        De-dupes the three uncoordinated request emitters (direct sync eval,
+        woken eval loop, proactive fetch loop) so the device asks the CMS for
+        a still-missing asset at most once per outstanding request. Returns
+        False (suppress) while either:
+
+        * a download task for the asset is already active (``_fetch_tasks``), or
+        * a prior request is still awaiting its ``fetch_asset`` reply, i.e. the
+          in-flight marker is younger than ``FETCH_REQUEST_DEDUPE_TTL``.
+
+        When it returns True it records the send time so subsequent emitters
+        in the same cycle are suppressed. Keyed by name only: a checksum change
+        on the same name is bounded-delayed behind an active download for the
+        old bytes, which the next cycle corrects.
+        """
+        task = self._fetch_tasks.get(asset_name)
+        if task is not None and not task.done():
+            return False
+        ts = self._inflight_fetches.get(asset_name)
+        if ts is not None and (time.monotonic() - ts) < FETCH_REQUEST_DEDUPE_TTL:
+            return False
+        self._inflight_fetches[asset_name] = time.monotonic()
+        return True
+
+    async def _send_fetch_request(self, asset_name: str) -> bool:
+        """Send a single de-duped ``fetch_request`` for ``asset_name``.
+
+        Returns True iff a request was actually put on the wire. Re-raises
+        ``websockets.ConnectionClosed`` so iterating callers can stop early;
+        the in-flight marker is cleared on any send failure so the next cycle
+        retries.
+        """
+        ws = self._ws
+        if not ws:
+            return False
+        if not self._should_send_fetch_request(asset_name):
+            return False
+        msg = json.dumps({
+            "type": "fetch_request",
+            "protocol_version": PROTOCOL_VERSION,
+            "device_id": self.device_id,
+            "asset": asset_name,
+        })
+        try:
+            await ws.send(msg)
+            return True
+        except websockets.ConnectionClosed:
+            self._inflight_fetches.pop(asset_name, None)
+            raise
+        except Exception:
+            self._inflight_fetches.pop(asset_name, None)
+            logger.exception("Error requesting asset %s", asset_name)
+            return False
+
     def _request_asset_fetch(self, asset_name: str) -> None:
-        """Fire-and-forget a fetch_request for a missing asset via WebSocket."""
+        """Fire-and-forget a de-duped fetch_request for a missing asset."""
         ws = self._ws
         if not ws:
             return
@@ -1434,13 +1506,16 @@ class CMSClient:
             loop = asyncio.get_event_loop()
         except RuntimeError:
             return
-        msg = json.dumps({
-            "type": "fetch_request",
-            "protocol_version": PROTOCOL_VERSION,
-            "device_id": self.device_id,
-            "asset": asset_name,
-        })
-        loop.create_task(ws.send(msg))
+
+        async def _go() -> None:
+            try:
+                await self._send_fetch_request(asset_name)
+            except Exception:
+                logger.debug(
+                    "fetch_request send failed for %s", asset_name, exc_info=True,
+                )
+
+        loop.create_task(_go())
 
     def _send_playback_event(self, event_type: str, schedule_id: str,
                              schedule_name: str, asset: str) -> None:
@@ -1583,17 +1658,9 @@ class CMSClient:
             else:
                 logger.info("Requesting missing asset: %s", asset_name)
             try:
-                request_msg = {
-                    "type": "fetch_request",
-                    "protocol_version": PROTOCOL_VERSION,
-                    "device_id": self.device_id,
-                    "asset": asset_name,
-                }
-                await ws.send(json.dumps(request_msg))
+                await self._send_fetch_request(asset_name)
             except websockets.ConnectionClosed:
                 break
-            except Exception:
-                logger.exception("Error requesting asset %s", asset_name)
 
     # ── Direct commands ──
 
@@ -1640,6 +1707,11 @@ class CMSClient:
         if not asset_name:
             logger.warning("Invalid fetch_asset message: missing asset_name")
             return
+        # Reply received — the outstanding request is satisfied. Drop the
+        # in-flight marker; suppression of further requests is now owned by
+        # the download task tracked in _fetch_tasks below (so a long download
+        # isn't re-requested, and a failed one is retried once the task ends).
+        self._inflight_fetches.pop(asset_name, None)
         prior = self._fetch_tasks.get(asset_name)
         if prior is not None and not prior.done():
             prior.cancel()

--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -1470,10 +1470,12 @@ class CMSClient:
     async def _send_fetch_request(self, asset_name: str) -> bool:
         """Send a single de-duped ``fetch_request`` for ``asset_name``.
 
-        Returns True iff a request was actually put on the wire. Re-raises
-        ``websockets.ConnectionClosed`` so iterating callers can stop early;
-        the in-flight marker is cleared on any send failure so the next cycle
-        retries.
+        Returns True iff a request was actually put on the wire (False if
+        suppressed by de-dup or if the send failed). On any send failure
+        (e.g. the connection closed) the in-flight marker is cleared so the
+        next cycle retries. Deliberately catches a broad ``Exception`` rather
+        than ``websockets.ConnectionClosed`` specifically so the path stays
+        robust even when ``websockets`` is replaced by a test mock.
         """
         ws = self._ws
         if not ws:
@@ -1489,12 +1491,9 @@ class CMSClient:
         try:
             await ws.send(msg)
             return True
-        except websockets.ConnectionClosed:
-            self._inflight_fetches.pop(asset_name, None)
-            raise
         except Exception:
             self._inflight_fetches.pop(asset_name, None)
-            logger.exception("Error requesting asset %s", asset_name)
+            logger.debug("fetch_request send failed for %s", asset_name, exc_info=True)
             return False
 
     def _request_asset_fetch(self, asset_name: str) -> None:
@@ -1657,10 +1656,7 @@ class CMSClient:
                 logger.info("Requesting asset: %s (checksum mismatch or missing)", asset_name)
             else:
                 logger.info("Requesting missing asset: %s", asset_name)
-            try:
-                await self._send_fetch_request(asset_name)
-            except websockets.ConnectionClosed:
-                break
+            await self._send_fetch_request(asset_name)
 
     # ── Direct commands ──
 

--- a/tests/test_checksum_fetch.py
+++ b/tests/test_checksum_fetch.py
@@ -81,6 +81,8 @@ def cms_client(tmp_path):
     client.device_id = "test-device"
     client.asset_manager = MagicMock()
     client._ws = AsyncMock()
+    client._fetch_tasks = {}
+    client._inflight_fetches = {}
     client._current_schedule_id = None
     client._current_schedule_name = None
     client._current_asset = None

--- a/tests/test_fetch_background.py
+++ b/tests/test_fetch_background.py
@@ -35,6 +35,7 @@ def client(tmp_path):
     c.device_id = "d1"
     c.asset_manager = MagicMock()
     c._fetch_tasks = {}
+    c._inflight_fetches = {}
     c._fetch_lock = asyncio.Lock()
     return c
 

--- a/tests/test_fetch_request_dedupe.py
+++ b/tests/test_fetch_request_dedupe.py
@@ -1,0 +1,179 @@
+"""Tests for de-duplication of outbound ``fetch_request`` messages.
+
+A single CMS sync cycle used to emit the same ``fetch_request`` ~3x for one
+still-missing asset: ``_handle_sync`` evaluates the schedule directly, then
+wakes the eval loop to evaluate it again, and the proactive ``_fetch_loop``
+runs on its own timer — three uncoordinated emitters, none tracking whether a
+request was already outstanding. The CMS faithfully answered each with a
+``fetch_asset`` (deduped device-side, but a wasted round-trip).
+
+The device now suppresses a duplicate ``fetch_request`` while either a prior
+request is awaiting its reply (``_inflight_fetches`` marker, bounded by
+``FETCH_REQUEST_DEDUPE_TTL``) or a download for the asset is already active
+(``_fetch_tasks``). The marker is cleared when the reply arrives (the download
+task then owns suppression) and on send failure / reconnect so a genuinely lost
+request still recovers.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cms_client.service import FETCH_REQUEST_DEDUPE_TTL, CMSClient
+
+
+def _schedule_json(asset: str = "a.mp4", checksum: str = "c1") -> str:
+    """A schedule with one entry that is active at any wall-clock time."""
+    return json.dumps({
+        "schedules": [{
+            "asset": asset,
+            "asset_checksum": checksum,
+            "start_time": "00:00:00",
+            "end_time": "23:59:59",
+        }],
+        "timezone": "UTC",
+    })
+
+
+@pytest.fixture
+def client(tmp_path):
+    settings = MagicMock()
+    settings.schedule_path = tmp_path / "schedule.json"
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        c = CMSClient(settings)
+    c.settings = settings
+    c.device_id = "d1"
+    c.asset_manager = MagicMock()
+    c.asset_manager.has_asset.return_value = False
+    c._fetch_tasks = {}
+    c._inflight_fetches = {}
+    c._ws = AsyncMock()
+    return c
+
+
+async def _drain():
+    # Let any fire-and-forget tasks scheduled via create_task run.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_two_fetch_cycles_send_single_request(client):
+    """Two proactive fetch cycles for the same missing asset send one request."""
+    client.settings.schedule_path.write_text(_schedule_json())
+
+    await client._check_and_fetch_missing()
+    await client._check_and_fetch_missing()
+
+    assert client._ws.send.await_count == 1
+    sent = json.loads(client._ws.send.await_args.args[0])
+    assert sent["type"] == "fetch_request"
+    assert sent["asset"] == "a.mp4"
+
+
+@pytest.mark.asyncio
+async def test_eval_request_suppresses_fetch_loop(client):
+    """A request from schedule eval suppresses the proactive loop's duplicate."""
+    client.settings.schedule_path.write_text(_schedule_json())
+
+    client._request_asset_fetch("a.mp4")
+    await _drain()
+    assert client._ws.send.await_count == 1
+
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_active_download_suppresses_request(client):
+    """No new request while a download task for the asset is in flight."""
+    client.settings.schedule_path.write_text(_schedule_json())
+
+    async def _never():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    client._fetch_tasks["a.mp4"] = task
+    try:
+        await client._check_and_fetch_missing()
+        assert client._ws.send.await_count == 0
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_should_send_transitions(client):
+    """First request allowed; marker then active task each suppress; clears recover."""
+    assert client._should_send_fetch_request("a.mp4") is True
+    # Marker now set → suppressed.
+    assert client._should_send_fetch_request("a.mp4") is False
+
+    # Reply received clears the marker (mirrors _spawn_fetch_asset).
+    client._inflight_fetches.pop("a.mp4", None)
+
+    task = asyncio.create_task(asyncio.sleep(10))
+    client._fetch_tasks["a.mp4"] = task
+    try:
+        # Active download suppresses regardless of TTL.
+        assert client._should_send_fetch_request("a.mp4") is False
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_retry_after_task_completes_and_still_missing(client):
+    """Once the download task ends and the asset is still missing, re-request."""
+    client.settings.schedule_path.write_text(_schedule_json())
+
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 1
+
+    # Reply arrived (marker cleared) and the download task has finished.
+    client._inflight_fetches.pop("a.mp4", None)
+    done = asyncio.create_task(asyncio.sleep(0))
+    await done
+    client._fetch_tasks["a.mp4"] = done
+
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_allows_resend(client):
+    """A request with no reply is retried after the dedupe TTL elapses."""
+    client.settings.schedule_path.write_text(_schedule_json())
+
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 1
+
+    # Age the in-flight marker past the safety-net TTL.
+    client._inflight_fetches["a.mp4"] -= FETCH_REQUEST_DEDUPE_TTL + 1
+
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_send_failure_clears_marker(client):
+    """A failed send drops the marker so the next cycle retries."""
+    client.settings.schedule_path.write_text(_schedule_json())
+    client._ws.send.side_effect = RuntimeError("boom")
+
+    await client._check_and_fetch_missing()
+    assert "a.mp4" not in client._inflight_fetches
+
+    client._ws.send.side_effect = None
+    await client._check_and_fetch_missing()
+    assert client._ws.send.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_receipt_pops_inflight_marker(client):
+    """Receiving a fetch_asset reply clears the outstanding-request marker."""
+    client._inflight_fetches["a.mp4"] = 123.0
+    # Heavy download machinery is irrelevant here; stub it out.
+    with patch.object(client, "_fetch_asset_locked", new=AsyncMock()):
+        client._spawn_fetch_asset({"asset_name": "a.mp4"}, ws=AsyncMock())
+    assert "a.mp4" not in client._inflight_fetches

--- a/tests/test_play_without_asset.py
+++ b/tests/test_play_without_asset.py
@@ -90,6 +90,8 @@ def cms_client(tmp_path):
     client.device_id = "test-device"
     client.asset_manager = MagicMock()
     client._ws = AsyncMock()
+    client._fetch_tasks = {}
+    client._inflight_fetches = {}
     client._last_eval_state = None
     client._current_schedule_id = None
     client._current_schedule_name = None

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -61,6 +61,7 @@ def cms_client(tmp_path):
     client._ws = AsyncMock()
     client._fetch_lock = asyncio.Lock()
     client._fetch_tasks = {}
+    client._inflight_fetches = {}
     client._current_schedule_id = None
     client._current_schedule_name = None
     client._current_asset = None


### PR DESCRIPTION
## What

De-duplicates outbound `fetch_request` messages so the device sends
**one** request per missing asset per sync cycle instead of ~3.

## Why

Each CMS sync currently triggers three uncoordinated `fetch_request`
emitters for the same missing asset:

1. `_handle_sync` → inline `_evaluate_schedule` → `_request_asset_fetch`
2. `_handle_sync` sets `_eval_wake` → `_schedule_eval_loop` runs
   `_evaluate_schedule` **again** → another request
3. `_fetch_loop` (every 60s) → `_check_and_fetch_missing` builds its
   own identical request

The CMS replies to all three with `fetch_asset`. Downloads were already
de-duplicated device-side (`_fetch_tasks`), so this was **harmless** but
wasted WS round-trips and bandwidth, and showed up as a confusing
3-burst in `journalctl`.

## How

- New `_send_fetch_request(asset_name)` helper is the single send path;
  both emitters now go through it.
- `_should_send_fetch_request(asset_name)` suppresses a send while:
  - a download task for that asset is active (`_fetch_tasks`), **or**
  - a previous request is still awaiting its `fetch_asset` reply
    (`_inflight_fetches` TTL marker, `FETCH_REQUEST_DEDUPE_TTL = 90s`).
- Marker lifecycle (avoids the "large asset never finishes" trap):
  - **cleared on reply receipt** in `_spawn_fetch_asset` — the active
    download task then owns suppression (so a download longer than the
    eval tick is never re-requested mid-flight)
  - **cleared on send failure / WS reconnect** — failed or cancelled
    fetches retry immediately with no TTL wait
  - TTL only covers the pathological lost-reply case
- No wire/API change. Name-only keying matches the existing protocol
  (`fetch_request` carries only `asset`). A checksum change on the same
  name while a download is active is bounded-delayed behind that
  download — documented, acceptable for v1.

## Tests

- New `tests/test_fetch_request_dedupe.py` (8 tests): two cycles → one
  send; eval request suppresses fetch loop; active download suppresses;
  `_should_send` state transitions; retry after task completes & still
  missing; TTL expiry allows resend; send failure clears marker;
  receipt pops marker.
- Updated 3 existing fetch fixtures (`test_checksum_fetch`,
  `test_slideshow_fetch`, `test_fetch_background`) to initialise the new
  `_inflight_fetches` (and `_fetch_tasks` where absent) since they build
  the client with a no-op `__init__`.
- Local fetch/sync suites green (112 passed). Full suite deferred to CI.
