### PR TITLE
fix: play composed slides through background bundle updates

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -375,6 +376,15 @@ class CMSClient:
         self._current_schedule_id: str | None = None
         self._current_schedule_name: str | None = None
         self._current_asset: str | None = None
+        # Filename of the bundle actually on screen right now. Tracked
+        # separately from ``_last_eval_state`` because, during a hot edit,
+        # ``_last_eval_state`` advances to ("updating", <new-name>, ...)
+        # while the *old* bundle keeps playing through the background
+        # download. Composed slides embed their content hash in the
+        # filename, so an edit yields a brand-new filename — this field
+        # holds the on-screen name so play-through stays stable across the
+        # intermediate "updating" evals.
+        self._displayed_asset: str | None = None
         self._eval_wake = asyncio.Event()      # triggers immediate schedule re-eval
         self._last_player_mode: str | None = None
         # In-flight asset fetch tasks, keyed by asset_name. Fetch handlers run
@@ -1141,6 +1151,67 @@ class CMSClient:
             return False
         return st[0] in ("play", "default", "updating") and st[1] == asset
 
+    # Composed slide bundles are named ``composed-<uuid>-<hash>.html`` where
+    # <hash> is a content digest that changes on every edit. Matching the
+    # leading ``composed-<uuid>`` lets us recognise an edit as the *same
+    # logical slide* even though the filename changed.
+    _COMPOSED_BUNDLE_RE = re.compile(
+        r"^(composed-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12})-[0-9a-fA-F]+\.html$"
+    )
+
+    def _logical_asset_id(self, asset: str) -> str:
+        """Stable identity for an asset across edits.
+
+        For composed slides, strips the trailing ``-<hash>.html`` so every
+        edit of the same slide maps to one id. For every other asset type
+        the filename is already stable across edits, so it's returned
+        unchanged.
+        """
+        m = self._COMPOSED_BUNDLE_RE.match(asset)
+        if m:
+            return m.group(1)
+        return asset
+
+    def _displayed_asset_name(self) -> str | None:
+        """Filename of the bundle currently on screen, or ``None``.
+
+        Prefers the explicit ``_displayed_asset`` tracking field (stable
+        across the 'updating' evals while a hot edit downloads), falling
+        back to ``_last_eval_state`` for paths that haven't recorded it.
+        """
+        displayed = getattr(self, "_displayed_asset", None)
+        if displayed is not None:
+            return displayed
+        st = self._last_eval_state
+        if (
+            isinstance(st, tuple)
+            and len(st) >= 2
+            and st[0] in ("play", "default", "updating")
+            and isinstance(st[1], str)
+        ):
+            return st[1]
+        return None
+
+    def _can_play_through_update(self, new_asset: str) -> bool:
+        """True if a hot edit can keep playing the current bytes while the
+        new bundle downloads in the background.
+
+        Handles two edit shapes:
+          * stable-filename assets (image/video): same filename, new
+            checksum.
+          * composed slides: a new filename for the same logical slide.
+
+        In both cases a prior version of the on-screen bundle must still be
+        on disk to keep showing it.
+        """
+        displayed = self._displayed_asset_name()
+        if not displayed:
+            return False
+        if self._logical_asset_id(displayed) != self._logical_asset_id(new_asset):
+            return False
+        return self.asset_manager.has_asset(displayed)
+
     def _evaluate_schedule(self, sync_data: dict) -> None:
         """Evaluate the cached schedule and update desired state."""
         schedules = sync_data.get("schedules", [])
@@ -1350,7 +1421,7 @@ class CMSClient:
                 # showing, keep playing it (leave desired.json untouched)
                 # while the new bundle downloads, then swap once it lands.
                 # Only a genuinely cold show splashes while fetching.
-                if self.asset_manager.has_asset(asset) and self._is_displaying_asset(asset):
+                if self._can_play_through_update(asset):
                     if self._last_eval_state != ("updating", asset, checksum):
                         logger.info(
                             "Schedule: asset %s edited, playing current "
@@ -1395,6 +1466,7 @@ class CMSClient:
             self._current_schedule_id = new_schedule_id
             self._current_schedule_name = new_schedule_name
             self._current_asset = asset
+            self._displayed_asset = asset
             if new_schedule_id:
                 self._send_playback_event(
                     "playback_started", new_schedule_id, new_schedule_name, asset,
@@ -1408,7 +1480,7 @@ class CMSClient:
                 self._request_asset_fetch(default_asset)
                 # Play-through-update (see scheduled branch above): keep
                 # showing the current default while its new bytes download.
-                if self.asset_manager.has_asset(default_asset) and self._is_displaying_asset(default_asset):
+                if self._can_play_through_update(default_asset):
                     if self._last_eval_state != ("updating", default_asset, default_checksum):
                         logger.info(
                             "Schedule: default asset %s edited, playing "
@@ -1450,6 +1522,7 @@ class CMSClient:
             write_state(self.settings.desired_state_path, desired)
             self.asset_manager.touch(default_asset)
             self._last_eval_state = state_key
+            self._displayed_asset = default_asset
             logger.info(
                 "Schedule: playing default asset %s%s",
                 default_asset,
@@ -1466,6 +1539,7 @@ class CMSClient:
             desired = DesiredState(mode=PlaybackMode.SPLASH)
             write_state(self.settings.desired_state_path, desired)
             self._last_eval_state = state_key
+            self._displayed_asset = None
             logger.info("Schedule: no active schedule, showing splash")
 
     def _end_current_playback(self) -> None:

--- a/tests/test_play_through_update.py
+++ b/tests/test_play_through_update.py
@@ -42,7 +42,7 @@ def _make_client(tmp_path):
     return CMSClient(settings)
 
 
-def _schedule_sync(asset, checksum):
+def _schedule_sync(asset, checksum, asset_type="video"):
     """A sync payload with one always-active schedule for ``asset``."""
     return {
         "type": "sync",
@@ -55,7 +55,7 @@ def _schedule_sync(asset, checksum):
                 "priority": 1,
                 "asset": asset,
                 "asset_checksum": checksum,
-                "asset_type": "video",
+                "asset_type": asset_type,
                 "loop_count": None,
                 "start_time": "00:00:00",
                 "end_time": "23:59:59",
@@ -233,3 +233,141 @@ class TestDefaultPlayThroughUpdate:
         desired = _read_desired(client)
         assert desired.mode == PlaybackMode.SPLASH
         assert client._last_eval_state == ("waiting", "d.mp4", "B")
+
+
+# Composed slide bundles embed the content hash in the *filename*
+# (``composed-<uuid>-<hash>.html``), so every edit yields a brand-new
+# filename for the same logical slide. The play-through logic must match
+# on the logical id (filename minus the hash) rather than exact filename.
+_OLD_COMPOSED = "composed-83d695d2-1384-4e32-a898-0ed33233d439-601ed9272f72.html"
+_NEW_COMPOSED = "composed-83d695d2-1384-4e32-a898-0ed33233d439-23e37ab5afb8.html"
+_OTHER_COMPOSED = "composed-11111111-2222-3333-4444-555555555555-aaaaaaaaaaaa.html"
+
+
+class TestComposedPlayThroughUpdate:
+    def test_edit_currently_playing_composed_slide_does_not_splash(self, tmp_path):
+        client = _make_client(tmp_path)
+        client._request_asset_fetch = MagicMock()
+
+        # Device is showing the old composed bundle @ checksum A.
+        client.asset_manager.register(_OLD_COMPOSED, f"videos/{_OLD_COMPOSED}", 10, "A")
+        client._last_eval_state = ("play", _OLD_COMPOSED, "A", None, "composed", None)
+        client._displayed_asset = _OLD_COMPOSED
+        write_state(
+            client.settings.desired_state_path,
+            DesiredState(
+                mode=PlaybackMode.PLAY,
+                asset=_OLD_COMPOSED,
+                asset_type="composed",
+                loop=True,
+                expected_checksum="A",
+            ),
+        )
+
+        # Edit lands: NEW filename (new hash), checksum B, not on disk yet.
+        client._evaluate_schedule(
+            _schedule_sync(_NEW_COMPOSED, "B", asset_type="composed")
+        )
+
+        # Must keep playing the OLD bundle — no splash.
+        desired = _read_desired(client)
+        assert desired.mode == PlaybackMode.PLAY
+        assert desired.asset == _OLD_COMPOSED
+        # New bundle is requested.
+        client._request_asset_fetch.assert_called_with(_NEW_COMPOSED)
+        # Marker tracks the new (not-yet-on-disk) name.
+        assert client._last_eval_state == ("updating", _NEW_COMPOSED, "B")
+        # Still displaying the old bundle until the new one lands.
+        assert client._displayed_asset == _OLD_COMPOSED
+
+    def test_swaps_to_new_composed_bundle_once_download_completes(self, tmp_path):
+        client = _make_client(tmp_path)
+        client._request_asset_fetch = MagicMock()
+
+        client.asset_manager.register(_OLD_COMPOSED, f"videos/{_OLD_COMPOSED}", 10, "A")
+        client._last_eval_state = ("play", _OLD_COMPOSED, "A", None, "composed", None)
+        client._displayed_asset = _OLD_COMPOSED
+        write_state(
+            client.settings.desired_state_path,
+            DesiredState(
+                mode=PlaybackMode.PLAY,
+                asset=_OLD_COMPOSED,
+                asset_type="composed",
+                loop=True,
+                expected_checksum="A",
+            ),
+        )
+
+        # Edit → hold (no splash).
+        client._evaluate_schedule(
+            _schedule_sync(_NEW_COMPOSED, "B", asset_type="composed")
+        )
+        assert _read_desired(client).mode == PlaybackMode.PLAY
+        assert _read_desired(client).asset == _OLD_COMPOSED
+        assert client._last_eval_state == ("updating", _NEW_COMPOSED, "B")
+
+        # Download completes — new bundle on disk.
+        client.asset_manager.register(_NEW_COMPOSED, f"videos/{_NEW_COMPOSED}", 12, "B")
+        client._evaluate_schedule(
+            _schedule_sync(_NEW_COMPOSED, "B", asset_type="composed")
+        )
+
+        desired = _read_desired(client)
+        assert desired.mode == PlaybackMode.PLAY
+        assert desired.asset == _NEW_COMPOSED
+        assert desired.expected_checksum == "B"
+        assert client._last_eval_state[0] == "play"
+        assert client._last_eval_state[1] == _NEW_COMPOSED
+        # Tracking field advances to the now-on-screen bundle.
+        assert client._displayed_asset == _NEW_COMPOSED
+
+    def test_cold_composed_slide_still_splashes(self, tmp_path):
+        """First-ever composed slide (nothing on screen) → splash."""
+        client = _make_client(tmp_path)
+        client._request_asset_fetch = MagicMock()
+
+        client._evaluate_schedule(
+            _schedule_sync(_NEW_COMPOSED, "B", asset_type="composed")
+        )
+
+        desired = _read_desired(client)
+        assert desired.mode == PlaybackMode.SPLASH
+        client._request_asset_fetch.assert_called_with(_NEW_COMPOSED)
+        assert client._last_eval_state == ("waiting", _NEW_COMPOSED, "B")
+
+    def test_different_composed_slide_splashes(self, tmp_path):
+        """Switching to a *different* logical slide is a cold swap → splash."""
+        client = _make_client(tmp_path)
+        client._request_asset_fetch = MagicMock()
+
+        client.asset_manager.register(_OLD_COMPOSED, f"videos/{_OLD_COMPOSED}", 10, "A")
+        client._last_eval_state = ("play", _OLD_COMPOSED, "A", None, "composed", None)
+        client._displayed_asset = _OLD_COMPOSED
+        write_state(
+            client.settings.desired_state_path,
+            DesiredState(
+                mode=PlaybackMode.PLAY,
+                asset=_OLD_COMPOSED,
+                asset_type="composed",
+                loop=True,
+                expected_checksum="A",
+            ),
+        )
+
+        # A genuinely different composed slide (different uuid).
+        client._evaluate_schedule(
+            _schedule_sync(_OTHER_COMPOSED, "C", asset_type="composed")
+        )
+
+        desired = _read_desired(client)
+        assert desired.mode == PlaybackMode.SPLASH
+        assert client._last_eval_state == ("waiting", _OTHER_COMPOSED, "C")
+
+    def test_logical_asset_id_strips_composed_hash(self, tmp_path):
+        client = _make_client(tmp_path)
+        logical = "composed-83d695d2-1384-4e32-a898-0ed33233d439"
+        assert client._logical_asset_id(_OLD_COMPOSED) == logical
+        assert client._logical_asset_id(_NEW_COMPOSED) == logical
+        # Non-composed names are returned unchanged.
+        assert client._logical_asset_id("v.mp4") == "v.mp4"
+        assert client._logical_asset_id("image.png") == "image.png"


### PR DESCRIPTION
Composed slide bundles are named `composed-<uuid>-<hash>.html` where the trailing hash changes on every edit. The play-through-update guard keyed on an exact filename match, so a composed edit was never recognized as the same logical asset and the player dropped to the splash screen for ~3-5s while the new bundle downloaded.

This adds logical-asset matching: `_logical_asset_id()` strips the trailing `-<hash>.html` so old and new edits map to the same `composed-<uuid>` id; a `_displayed_asset` field holds the on-screen bundle name stably across the 'updating' evals; `_can_play_through_update()` replaces the old exact-match guard at both play/default sites and keeps showing the prior on-disk version when logical ids match.

Image/video play-through unchanged (stable filenames still match).

Tests: 12 play-through tests (5 new composed) + full play-without-asset suite green; 535 cms_client/service/schedule/play tests pass locally.