### PR TITLE
feat: support COMPOSED slides as members inside slideshows

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -45,7 +45,16 @@ PROTOCOL_VERSION = 2
 # - "slideshow_v1": this firmware understands ``asset_type=slideshow``
 #   on FETCH_ASSET messages, fetches the manifest+slides, and stores
 #   them under ``assets/slideshows/<name>/``.
-DEVICE_CAPABILITIES = ["slideshow_v1", "composed_siblings_v1"]
+# - "composed_siblings_v1": this firmware fetches a composed-slide
+#   bundle plus its referenced ``siblings`` media and renders the
+#   bundle HTML via the chromium ``show_html`` path.
+# - "slideshow_composed_v1": this firmware accepts composed slides
+#   (``asset_type=composed``) as members *inside* a slideshow manifest
+#   — downloading each composed member's bundle + per-slide siblings,
+#   persisting them, and rendering the member via ``show_html`` in the
+#   slideshow loop. The CMS gates composed-bearing slideshows on this
+#   flag so pre-feature firmware never receives one.
+DEVICE_CAPABILITIES = ["slideshow_v1", "composed_siblings_v1", "slideshow_composed_v1"]
 
 # Bootstrap v2 renewal policy (issue #420 stage B.3).
 # Minimum delay between JWT refreshes on the renewal task, so a clock
@@ -2099,6 +2108,86 @@ class CMSClient:
                 }))
                 return
 
+        # Composed slide members (capability ``slideshow_composed_v1``) carry
+        # a ``siblings`` list of referenced media the bundle HTML loads from
+        # the local cache (e.g. ``/assets/videos/foo.mp4``). Normalize +
+        # validate them exactly like the standalone composed handler so the
+        # budget / eviction / download / sidecar logic below can treat a
+        # composed member uniformly.  Normalization mutates each slide's
+        # ``siblings`` in place to populate both ``name`` and ``asset_name``.
+        for i, slide in enumerate(slides):
+            if slide.get("asset_type") != "composed":
+                continue
+            sibs = slide.get("siblings") or []
+            if not isinstance(sibs, list):
+                logger.warning(
+                    "Slideshow %s: composed slide %d siblings not a list", asset_name, i,
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "invalid_composed_payload",
+                    "slide_position": i,
+                }))
+                return
+            for sib in sibs:
+                if isinstance(sib, dict):
+                    if "asset_name" not in sib and "name" in sib:
+                        sib["asset_name"] = sib["name"]
+                    elif "name" not in sib and "asset_name" in sib:
+                        sib["name"] = sib["asset_name"]
+            for j, sib in enumerate(sibs):
+                if not isinstance(sib, dict):
+                    logger.warning(
+                        "Slideshow %s: composed slide %d sibling[%d] not a dict",
+                        asset_name, i, j,
+                    )
+                    await ws.send(json.dumps({
+                        "type": "fetch_failed",
+                        "protocol_version": PROTOCOL_VERSION,
+                        "device_id": self.device_id,
+                        "asset": asset_name,
+                        "reason": "invalid_sibling_descriptor",
+                        "slide_position": i,
+                        "sibling_position": j,
+                    }))
+                    return
+                sib_name = sib.get("asset_name")
+                sib_url = sib.get("download_url")
+                if not sib_name or not sib_url:
+                    logger.warning(
+                        "Slideshow %s: composed slide %d sibling[%d] missing "
+                        "name/download_url; keys=%r",
+                        asset_name, i, j, sorted(sib.keys()),
+                    )
+                    await ws.send(json.dumps({
+                        "type": "fetch_failed",
+                        "protocol_version": PROTOCOL_VERSION,
+                        "device_id": self.device_id,
+                        "asset": asset_name,
+                        "reason": "invalid_sibling_descriptor",
+                        "slide_position": i,
+                        "sibling_position": j,
+                    }))
+                    return
+                if not self._is_safe_sibling_name(sib_name):
+                    logger.warning(
+                        "Slideshow %s: composed slide %d rejecting unsafe "
+                        "sibling name %r", asset_name, i, sib_name,
+                    )
+                    await ws.send(json.dumps({
+                        "type": "fetch_failed",
+                        "protocol_version": PROTOCOL_VERSION,
+                        "device_id": self.device_id,
+                        "asset": asset_name,
+                        "reason": "invalid_sibling_name",
+                        "sibling_asset": sib_name,
+                    }))
+                    return
+            slide["siblings"] = sibs
+
         # Fast path: slideshow + every slide already cached with matching checksums.
         if self._has_complete_slideshow(asset_name, expected_checksum, slides):
             # Even on the fast path we may need to rewrite the manifest:
@@ -2156,16 +2245,49 @@ class CMSClient:
                 continue
             unique_missing[key] = slide
 
+        # Composed slide members reference sibling media (videos/images) the
+        # bundle HTML loads from the local cache. Dedup those across every
+        # composed slide by (name, checksum), skipping any already cached.
+        unique_missing_sibs: dict[tuple[str, str], dict] = {}
+        for slide in slides:
+            if slide.get("asset_type") != "composed":
+                continue
+            for sib in slide.get("siblings") or []:
+                sib_key = (sib["asset_name"], sib.get("checksum", ""))
+                if sib_key in unique_missing_sibs:
+                    continue
+                if self.asset_manager.has_asset(
+                    sib["asset_name"], sib.get("checksum") or None
+                ):
+                    continue
+                unique_missing_sibs[sib_key] = sib
+
         # Bulk eviction once for the sum of missing-slide bytes (the slideshow
-        # manifest itself is sub-1 KB JSON, ignored in budgeting).
-        if unique_missing:
-            total_bytes = sum(s.get("size_bytes", 0) for s in unique_missing.values())
+        # manifest itself is sub-1 KB JSON, ignored in budgeting). Composed
+        # sibling bytes are included so a composed-bearing slideshow is
+        # budgeted as a whole.
+        if unique_missing or unique_missing_sibs:
+            total_bytes = (
+                sum(s.get("size_bytes", 0) for s in unique_missing.values())
+                + sum(s.get("size_bytes", 0) for s in unique_missing_sibs.values())
+            )
             scheduled_assets = self._get_scheduled_asset_names()
             sync_data = self._read_schedule_cache()
             default_asset = sync_data.get("default_asset") if sync_data else None
-            # Slides we are about to download must also be protected during eviction
-            # so the loop doesn't evict siblings out from under us.
-            protected = scheduled_assets | {key[0] for key in unique_missing.keys()}
+            # Slides + composed siblings we are about to download must also be
+            # protected during eviction so the loop doesn't evict them out from
+            # under us.
+            sib_names = {
+                sib["asset_name"]
+                for slide in slides
+                if slide.get("asset_type") == "composed"
+                for sib in (slide.get("siblings") or [])
+            }
+            protected = (
+                scheduled_assets
+                | {key[0] for key in unique_missing.keys()}
+                | sib_names
+            )
 
             ok = self.asset_manager.evict_for(total_bytes, protected, default_asset)
             if not ok:
@@ -2182,6 +2304,30 @@ class CMSClient:
                     "budget_mb": self.asset_manager.budget_mb,
                     "available_mb": self.asset_manager.available_bytes // (1024 * 1024),
                     "required_mb": total_bytes // (1024 * 1024),
+                }))
+                return
+
+        # Download composed siblings first — a composed bundle is useless
+        # without the media it references.
+        for sib in unique_missing_sibs.values():
+            actual_sib = await self._download_one_asset(
+                sib["asset_name"],
+                sib.get("asset_type", "video"),
+                sib["download_url"],
+                sib.get("checksum", ""),
+            )
+            if actual_sib is None:
+                logger.error(
+                    "Slideshow %s: composed sibling %s download failed",
+                    asset_name, sib["asset_name"],
+                )
+                await ws.send(json.dumps({
+                    "type": "fetch_failed",
+                    "protocol_version": PROTOCOL_VERSION,
+                    "device_id": self.device_id,
+                    "asset": asset_name,
+                    "reason": "sibling_download_failed",
+                    "sibling_asset": sib["asset_name"],
                 }))
                 return
 
@@ -2207,6 +2353,18 @@ class CMSClient:
                     "slide_asset": slide["asset_name"],
                 }))
                 return
+
+        # Composed slide members need a sidecar (so cold-start completeness +
+        # eviction-protection can reconstruct their sibling list) and an LRU
+        # touch on each sibling. Mirror the standalone composed handler.
+        for slide in slides:
+            if slide.get("asset_type") != "composed":
+                continue
+            sibs = slide.get("siblings") or []
+            self._write_composed_sidecar(
+                slide["asset_name"], slide.get("checksum", ""), sibs,
+            )
+            await self._touch_composed_siblings(slide["asset_name"], sibs)
 
         # All slides verified. Write the slideshow manifest with per-slide
         # checksums so the completeness check has all the data it needs.
@@ -2277,6 +2435,23 @@ class CMSClient:
                     "play_to_end": bool(s.get("play_to_end", False)),
                     "transition": s.get("transition", "cut"),
                     "transition_ms": int(s.get("transition_ms", 600)),
+                    # Composed members persist their sibling list so cold-start
+                    # completeness + eviction-protection survive a reboot.
+                    **(
+                        {
+                            "siblings": [
+                                {
+                                    "name": sib["asset_name"],
+                                    "asset_type": sib.get("asset_type", "video"),
+                                    "checksum": sib.get("checksum", ""),
+                                    "size_bytes": sib.get("size_bytes", 0),
+                                }
+                                for sib in (s.get("siblings") or [])
+                            ]
+                        }
+                        if s.get("asset_type") == "composed"
+                        else {}
+                    ),
                 }
                 for s in slides
             ],
@@ -2351,6 +2526,14 @@ class CMSClient:
                 return False
             if not self.asset_manager.has_asset(slide_name, slide_checksum):
                 return False
+            # Composed members additionally require their sidecar + every
+            # referenced sibling to be cached. Reuse the standalone composed
+            # completeness check, which reads the sidecar's own sibling list
+            # (persisted-shape ``name`` keys) so we don't depend on the
+            # in-message vs persisted descriptor shape here.
+            if slide.get("asset_type") == "composed":
+                if not self._has_complete_composed(slide_name, slide_checksum or ""):
+                    return False
         return True
 
     # ── Composed-slide sibling fetch (capability: composed_siblings_v1) ──

--- a/player/service.py
+++ b/player/service.py
@@ -702,6 +702,7 @@ class AgoraPlayer:
 
         self._cancel_slide_timeout()
         is_video_slide = (slide.get("asset_type") == "video")
+        is_composed_slide = (slide.get("asset_type") == "composed")
         play_to_end = bool(slide.get("play_to_end")) and is_video_slide
 
         logger.info(
@@ -737,6 +738,15 @@ class AgoraPlayer:
                     transition=slide_transition,
                     transition_ms=slide_transition_ms,
                     start_offset_ms=start_offset_ms,
+                )
+            elif is_composed_slide:
+                # Composed members render as a self-contained HTML bundle
+                # in the shell iframe. The anchored resync tick (armed
+                # below) drives advance, same as images.
+                self._chromium_player.show_html(
+                    path,
+                    transition=slide_transition,
+                    duration_ms=slide_transition_ms,
                 )
             elif is_video_slide:
                 self._chromium_player.show_video(
@@ -942,6 +952,7 @@ class AgoraPlayer:
 
         self._cancel_slide_timeout()
         is_video_slide = (slide.get("asset_type") == "video")
+        is_composed_slide = (slide.get("asset_type") == "composed")
         play_to_end = bool(slide.get("play_to_end")) and is_video_slide
 
         logger.info(
@@ -975,6 +986,14 @@ class AgoraPlayer:
                 # next-slide timeout drives advance.
                 self._chromium_player.show_video(
                     path, loop=True, muted=False,
+                    transition=slide_transition,
+                    duration_ms=slide_transition_ms,
+                )
+            elif is_composed_slide:
+                # Composed members render as a self-contained HTML bundle
+                # in the shell iframe; the next-slide timeout drives advance.
+                self._chromium_player.show_html(
+                    path,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
                 )

--- a/tests/test_slideshow_composed_fetch.py
+++ b/tests/test_slideshow_composed_fetch.py
@@ -1,0 +1,414 @@
+"""Tests for COMPOSED slide members inside a SLIDESHOW asset (Phase 5).
+
+The CMS may include a slide whose ``asset_type == "composed"`` inside a
+slideshow's ``slides`` list. Such a slide's ``download_url`` is the
+published bundle HTML and it carries a per-slide ``siblings`` list of
+referenced media (videos/images) the bundle loads from local cache.
+
+The device must, for each composed member:
+
+* validate + normalize sibling descriptors (shape + safe name),
+* dedupe + bulk-evict for slides + composed siblings together,
+* download composed siblings first, then the bundle (as a normal slide),
+* write a ``.deps.json`` sidecar so cold-start completeness + eviction
+  protection can reconstruct the sibling list,
+* persist the sibling list in the slideshow manifest,
+* honor composed completeness on the fast path.
+
+This is gated by the ``slideshow_composed_v1`` capability so pre-feature
+firmware never receives composed slideshow members.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio  # noqa: F401  (registers asyncio fixtures)
+
+from cms_client.asset_manager import AssetManager  # noqa: E402
+from cms_client.service import (  # noqa: E402
+    DEVICE_CAPABILITIES,
+    CMSClient,
+)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture
+def cms_client(tmp_path):
+    """CMSClient wired to a real AssetManager + tmp dirs.
+
+    Mirrors the slideshow-fetch / composed-fetch fixtures, with a
+    ``composed_dir`` so composed bundles + sidecars land correctly.
+    """
+    settings = MagicMock()
+    settings.agora_base = tmp_path
+    settings.assets_dir = tmp_path / "assets"
+    settings.videos_dir = tmp_path / "assets" / "videos"
+    settings.images_dir = tmp_path / "assets" / "images"
+    settings.splash_dir = tmp_path / "assets" / "splash"
+    settings.slideshows_dir = tmp_path / "assets" / "slideshows"
+    settings.composed_dir = tmp_path / "assets" / "composed"
+    for d in (settings.assets_dir, settings.videos_dir, settings.images_dir,
+              settings.splash_dir, settings.slideshows_dir,
+              settings.composed_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    settings.manifest_path = tmp_path / "state" / "assets.json"
+    settings.manifest_path.parent.mkdir(parents=True)
+    settings.schedule_path = tmp_path / "state" / "schedule.json"
+    settings.desired_state_path = tmp_path / "state" / "desired.json"
+    settings.persist_dir = tmp_path / "persist"
+    settings.persist_dir.mkdir()
+    settings.asset_budget_mb = 100
+
+    with patch.object(CMSClient, "__init__", lambda self, s: None):
+        client = CMSClient(settings)
+    client.settings = settings
+    client.device_id = "test-device"
+    client.asset_manager = AssetManager(
+        settings.manifest_path, settings.assets_dir, budget_mb=100,
+    )
+    client._ws = AsyncMock()
+    client._fetch_lock = asyncio.Lock()
+    client._fetch_tasks = {}
+    client._inflight_fetches = {}
+    client._current_schedule_id = None
+    client._current_schedule_name = None
+    client._current_asset = None
+    client._eval_wake = asyncio.Event()
+    client._last_player_mode = None
+    return client
+
+
+def _make_slide(name: str, body: bytes, *, asset_type: str = "video",
+                duration_ms: int = 5000, play_to_end: bool = False,
+                siblings: list[dict] | None = None) -> dict:
+    slide = {
+        "asset_name": name,
+        "asset_type": asset_type,
+        "download_url": f"http://cms.test/{name}",
+        "checksum": _sha256(body),
+        "size_bytes": len(body),
+        "duration_ms": duration_ms,
+        "play_to_end": play_to_end,
+    }
+    if siblings is not None:
+        slide["siblings"] = siblings
+    return slide
+
+
+def _make_sibling(name: str, body: bytes, *, asset_type: str = "video",
+                  key: str = "name") -> dict:
+    """Build a sibling descriptor.
+
+    ``key`` selects which name key the CMS uses on the wire — the real
+    CMS protocol Sibling model uses ``name`` (not ``asset_name``); the
+    device normalizes to populate both.
+    """
+    return {
+        key: name,
+        "asset_type": asset_type,
+        "download_url": f"http://cms.test/{name}",
+        "checksum": _sha256(body),
+        "size_bytes": len(body),
+    }
+
+
+class _FakeAioHttpResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+        self.content = self
+
+    async def iter_chunked(self, _size):
+        yield self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeAioHttpSession:
+    def __init__(self, mapping: dict[str, bytes]):
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    def get(self, url, headers=None):
+        self.calls.append(url)
+        body = self._mapping.get(url, b"")
+        status = 200 if url in self._mapping else 404
+        return _FakeAioHttpResponse(body, status)
+
+
+def _patch_aiohttp(mapping):
+    fake_session = _FakeAioHttpSession(mapping)
+    fake_module = MagicMock()
+    fake_module.ClientSession = lambda: fake_session
+    return fake_module, fake_session
+
+
+class TestSlideshowComposedCapability:
+    def test_capability_advertised(self):
+        """Phase 5 capability flag must be in the global list so the CMS
+        only emits composed slideshow members to capable firmware."""
+        assert "slideshow_composed_v1" in DEVICE_CAPABILITIES
+
+
+class TestSlideshowComposedFetch:
+    @pytest.mark.asyncio
+    async def test_happy_path_composed_member_with_sibling(self, cms_client):
+        """A slideshow with an image slide + a composed member that
+        references a video sibling: device downloads all three, writes a
+        sidecar for the composed member, persists siblings in the
+        manifest, and ACKs once."""
+        img_body = b"image-slide-bytes"
+        bundle_body = b"<html><body>composed bundle</body></html>"
+        vid_body = b"sibling-video-payload"
+
+        sibling = _make_sibling("composed-clip.mp4", vid_body)
+        composed = _make_slide(
+            "Promo.html", bundle_body, asset_type="composed",
+            duration_ms=8000, siblings=[sibling],
+        )
+        image = _make_slide("hero.jpg", img_body, asset_type="image",
+                            duration_ms=4000)
+        slides = [image, composed]
+
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Mixed Slideshow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "manifest-hash-xyz",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.2",
+            "slides": slides,
+        }
+        mapping = {
+            image["download_url"]: img_body,
+            composed["download_url"]: bundle_body,
+            sibling["download_url"]: vid_body,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp(mapping)
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        # All three assets downloaded.
+        assert len(fake_session.calls) == 3
+
+        am = cms_client.asset_manager
+        assert am.has_asset("hero.jpg", _sha256(img_body))
+        assert am.has_asset("Promo.html", _sha256(bundle_body))
+        assert am.has_asset("composed-clip.mp4", _sha256(vid_body))
+        assert am.has_asset("Mixed Slideshow.slideshow", "manifest-hash-xyz")
+
+        # Bundle landed in composed/, sibling in videos/.
+        assert (cms_client.settings.composed_dir / "Promo.html").read_bytes() == bundle_body
+        assert (cms_client.settings.videos_dir / "composed-clip.mp4").read_bytes() == vid_body
+
+        # Composed sidecar written using the persisted ``name`` key.
+        sidecar_path = cms_client.settings.composed_dir / "Promo.html.deps.json"
+        sidecar = json.loads(sidecar_path.read_text())
+        assert sidecar["name"] == "Promo.html"
+        assert [s["name"] for s in sidecar["siblings"]] == ["composed-clip.mp4"]
+
+        # Slideshow manifest persists per-slide siblings for the composed
+        # member (and nothing for the image slide).
+        manifest_path = (
+            cms_client.settings.slideshows_dir / "Mixed Slideshow.slideshow.json"
+        )
+        manifest = json.loads(manifest_path.read_text())
+        slide_dicts = {s["name"]: s for s in manifest["slides"]}
+        assert "siblings" not in slide_dicts["hero.jpg"]
+        assert slide_dicts["Promo.html"]["asset_type"] == "composed"
+        assert [s["name"] for s in slide_dicts["Promo.html"]["siblings"]] == [
+            "composed-clip.mp4"
+        ]
+
+        # Single ACK, no failures.
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        acks = [m for m in sent if m["type"] == "asset_ack"]
+        assert len(acks) == 1
+        assert acks[0]["asset_name"] == "Mixed Slideshow.slideshow"
+        assert not [m for m in sent if m["type"] == "fetch_failed"]
+
+    @pytest.mark.asyncio
+    async def test_fast_path_complete_when_sidecar_and_siblings_present(
+        self, cms_client,
+    ):
+        """After a first successful fetch, re-sending the same slideshow
+        hits the fast path (no re-download) because the composed member's
+        sidecar + sibling are cached and complete."""
+        bundle_body = b"<html>bundle2</html>"
+        vid_body = b"sib-2-payload"
+        sibling = _make_sibling("clip2.mp4", vid_body)
+        composed = _make_slide(
+            "Deck.html", bundle_body, asset_type="composed",
+            duration_ms=6000, siblings=[sibling],
+        )
+        slides = [composed]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Solo.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "solo-hash",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.2",
+            "slides": slides,
+        }
+        mapping = {
+            composed["download_url"]: bundle_body,
+            sibling["download_url"]: vid_body,
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp(mapping)
+
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+        assert len(fake_session.calls) == 2
+
+        # _has_complete_slideshow must now report complete (uses the
+        # composed sidecar's sibling list).
+        assert cms_client._has_complete_slideshow(
+            "Solo.slideshow", "solo-hash", slides,
+        )
+
+        # Second fetch: fast path, zero new downloads, still one ACK.
+        cms_client._ws.reset_mock()
+        fake_aiohttp2, fake_session2 = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp2}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+        assert len(fake_session2.calls) == 0
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        assert [m["type"] for m in sent] == ["asset_ack"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_when_sibling_evicted(self, cms_client):
+        """If a composed member's sibling is missing, the slideshow is
+        not complete even though the bundle + manifest are present."""
+        bundle_body = b"<html>bundle3</html>"
+        vid_body = b"sib-3-payload"
+        sibling = _make_sibling("clip3.mp4", vid_body)
+        composed = _make_slide(
+            "Show.html", bundle_body, asset_type="composed",
+            duration_ms=6000, siblings=[sibling],
+        )
+        slides = [composed]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Evict.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "evict-hash",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.2",
+            "slides": slides,
+        }
+        mapping = {
+            composed["download_url"]: bundle_body,
+            sibling["download_url"]: vid_body,
+        }
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        assert cms_client._has_complete_slideshow("Evict.slideshow", "evict-hash", slides)
+
+        # Drop the sibling from the asset manager -> no longer complete.
+        cms_client.asset_manager.remove("clip3.mp4")
+        assert not cms_client._has_complete_slideshow(
+            "Evict.slideshow", "evict-hash", slides,
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_sibling_name_rejected(self, cms_client):
+        """A composed member with a path-traversal sibling name is
+        rejected with fetch_failed and nothing is downloaded."""
+        bundle_body = b"<html>bad</html>"
+        bad_sibling = {
+            "name": "../../etc/passwd",
+            "asset_type": "video",
+            "download_url": "http://cms.test/evil",
+            "checksum": "deadbeef",
+            "size_bytes": 10,
+        }
+        composed = _make_slide(
+            "Bad.html", bundle_body, asset_type="composed",
+            duration_ms=6000, siblings=[bad_sibling],
+        )
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "BadShow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "bad-hash",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.2",
+            "slides": [composed],
+        }
+        fake_aiohttp, fake_session = _patch_aiohttp({})
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        sent = [json.loads(c.args[0]) for c in cms_client._ws.send.call_args_list]
+        failures = [m for m in sent if m["type"] == "fetch_failed"]
+        assert failures
+        assert failures[0]["reason"] == "invalid_sibling_name"
+        assert not [m for m in sent if m["type"] == "asset_ack"]
+        # Nothing downloaded.
+        assert len(fake_session.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_sibling_name_key_normalized(self, cms_client):
+        """The CMS wire format uses ``name`` for siblings; the device
+        normalizes so the download + sidecar path works regardless."""
+        bundle_body = b"<html>norm</html>"
+        vid_body = b"norm-vid"
+        # Use the wire-shape ``name`` key only.
+        sibling = _make_sibling("normclip.mp4", vid_body, key="name")
+        assert "asset_name" not in sibling
+        composed = _make_slide(
+            "Norm.html", bundle_body, asset_type="composed",
+            duration_ms=6000, siblings=[sibling],
+        )
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "NormShow.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "norm-hash",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.2",
+            "slides": [composed],
+        }
+        mapping = {
+            composed["download_url"]: bundle_body,
+            sibling["download_url"]: vid_body,
+        }
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        am = cms_client.asset_manager
+        assert am.has_asset("normclip.mp4", _sha256(vid_body))
+        sidecar = json.loads(
+            (cms_client.settings.composed_dir / "Norm.html.deps.json").read_text()
+        )
+        assert [s["name"] for s in sidecar["siblings"]] == ["normclip.mp4"]

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1162,6 +1162,35 @@ class TestAnchoredPlayback:
         # show_video must not have been used for an image slide.
         player._chromium_player.show_video.assert_not_called()
 
+    def test_chromium_anchored_composed_routes_to_show_html(self, mpv_player):
+        """A composed slideshow member must dispatch through
+        ``show_html`` (self-contained bundle in the shell iframe), not
+        ``show_image`` (which would render a broken-image icon) or
+        ``show_video``."""
+        player, svc = mpv_player
+        (player.assets_dir / "composed").mkdir()
+        (player.assets_dir / "composed" / "c.html").touch()
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self._write_anchored(player, "Show", [
+            {"name": "c.html", "asset_type": "composed", "duration_ms": 60_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/c.html"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_html.assert_called_once()
+        # Composed members are not images or videos.
+        player._chromium_player.show_image.assert_not_called()
+        player._chromium_player.show_video.assert_not_called()
+        # The bundle path on disk is what gets handed to show_html.
+        args, kwargs = player._chromium_player.show_html.call_args
+        passed = args[0] if args else kwargs.get("path")
+        assert str(passed).endswith("c.html")
+
     def test_chromium_play_to_end_overrun_keeps_kiosk_alive(self, mpv_player):
         """Regression: play_to_end overrun on the chromium backend used
         to call ``ChromiumPlayer.stop()`` (full kiosk + shell server


### PR DESCRIPTION
Phase 5 firmware (PR B of the composed-in-slideshow lift). Lets a slideshow asset contain **composed slide members**, delivered exactly like a standalone composed asset but inside the slideshow manifest. Capability-gated via `slideshow_composed_v1` so pre-feature firmware never receives composed slideshow members.

## Changes
- **`cms_client/service.py`**
  - Advertise `slideshow_composed_v1` in `DEVICE_CAPABILITIES`.
  - `_handle_fetch_slideshow`: accept `asset_type=="composed"` slides; normalize/validate per-slide siblings (populate both `name` and `asset_name` keys), dedup missing siblings, include sibling bytes in the cache budget + protect sibling names from eviction, download composed bundles + siblings first, write per-composed sidecar + touch siblings.
  - `_write_slideshow_manifest`: persist `siblings` for composed slides.
  - `_has_complete_slideshow`: composed sub-check via `_has_complete_composed` (presence-only when checksum absent).
- **`player/service.py`**
  - `_play_anchored_slide` and `_play_next_slide`: composed member -> `show_html` (iframe bundle) instead of show_image/show_video. `_resolve_asset` already resolves the `composed` subdir.

## Tests
- New `tests/test_slideshow_composed_fetch.py` (6 tests): capability advertisement, happy-path fetch w/ sibling, fast-path completeness, eviction incompleteness, invalid sibling-name rejection, name-key normalization.
- New player-dispatch test asserting composed anchored members route to `show_html`.
- Local: `test_slideshow_player` (68), `test_slideshow_fetch` + `test_composed_fetch` + `test_slideshow_composed_fetch` (43) all green.

Pairs with CMS PR A (agora-cms #734, shipped). CMS UI (PR C) follows.