### PR TITLE
feat(player): render per-slide fit and ken_burns effect in slideshow playback

### DIFF
--- a/player/chromium_backend.py
+++ b/player/chromium_backend.py
@@ -262,17 +262,36 @@ class ChromiumPlayer:
         path: Path,
         transition: str = "cut",
         duration_ms: int = DEFAULT_TRANSITION_MS,
+        fit: Optional[str] = None,
+        effect: Optional[str] = None,
+        effect_duration_ms: Optional[int] = None,
     ) -> None:
         url = self._asset_url(path)
         if url is None:
             logger.warning("ChromiumPlayer.show_image: not under assets dir: %s", path)
             return
-        self._enqueue({
+        payload: dict = {
             "cmd": "show_image",
             "url": url,
             "transition": transition,
             "duration_ms": duration_ms,
-        })
+        }
+        # Per-slide object-fit (cover|contain) from the slideshow builder.
+        # Emit whenever provided — the shell's legacy default is
+        # object-fit:contain, so even "contain" must be sent to be explicit
+        # and "cover" must be sent to override. Omit when None so older
+        # callers stay byte-for-byte backward-compatible.
+        if fit:
+            payload["fit"] = fit
+        # Ken Burns slow-pan/zoom. Only emit a real effect (skip "none")
+        # so the default render path is unchanged. effect_duration_ms is
+        # the slide's on-screen dwell so the animation spans the slide;
+        # the shell falls back to a sane default when it's absent/zero.
+        if effect and effect != "none":
+            payload["effect"] = effect
+            if effect_duration_ms and int(effect_duration_ms) > 0:
+                payload["effect_duration_ms"] = int(effect_duration_ms)
+        self._enqueue(payload)
 
     def show_video(
         self,
@@ -283,6 +302,7 @@ class ChromiumPlayer:
         duration_ms: int = DEFAULT_TRANSITION_MS,
         loop_count: Optional[int] = None,
         start_offset_ms: int = 0,
+        fit: Optional[str] = None,
     ) -> None:
         url = self._asset_url(path)
         if url is None:
@@ -296,6 +316,9 @@ class ChromiumPlayer:
             "transition": transition,
             "duration_ms": duration_ms,
         }
+        # Per-slide object-fit (cover|contain). No Ken Burns on video.
+        if fit:
+            payload["fit"] = fit
         # loop_count drives finite-loop playback in player.js: the shell
         # counts down on each video.ended, replays in-place (no layer
         # swap, no fade hiccup) until the count is exhausted, then emits

--- a/player/service.py
+++ b/player/service.py
@@ -728,6 +728,8 @@ class AgoraPlayer:
             # the browser snaps to the nearest decodable frame. Only
             # meaningful for videos; images ignore the field.
             slide_duration_ms = int(slide.get("duration_ms") or 0)
+            slide_fit = slide.get("fit") or None
+            slide_effect = slide.get("effect") or None
             start_offset_ms = (
                 max(0, slide_duration_ms - remaining_ms)
                 if is_video_slide and slide_duration_ms > 0 else 0
@@ -754,12 +756,16 @@ class AgoraPlayer:
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
                     start_offset_ms=start_offset_ms,
+                    fit=slide_fit,
                 )
             else:
                 self._chromium_player.show_image(
                     path,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
+                    fit=slide_fit,
+                    effect=slide_effect,
+                    effect_duration_ms=slide_duration_ms or None,
                 )
             self._update_current(
                 mode=PlaybackMode.PLAY,
@@ -974,6 +980,12 @@ class AgoraPlayer:
             # slide's on-screen duration (that's duration_ms below).
             slide_transition = slide.get("transition") or "cut"
             slide_transition_ms = int(slide.get("transition_ms") or 600)
+            slide_fit = slide.get("fit") or None
+            slide_effect = slide.get("effect") or None
+            # On-screen dwell for this slide (drives the next-slide
+            # timeout below AND the Ken Burns animation length). Computed
+            # up-front so it can be passed to show_image as effect_duration_ms.
+            slide_dwell_ms = int(slide.get("duration_ms") or 0)
             if is_video_slide and play_to_end:
                 self._play_slide_to_end_chromium(
                     slide, slide_name, path, ss,
@@ -988,6 +1000,7 @@ class AgoraPlayer:
                     path, loop=True, muted=False,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
+                    fit=slide_fit,
                 )
             elif is_composed_slide:
                 # Composed members render as a self-contained HTML bundle
@@ -1002,8 +1015,11 @@ class AgoraPlayer:
                     path,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
+                    fit=slide_fit,
+                    effect=slide_effect,
+                    effect_duration_ms=slide_dwell_ms or None,
                 )
-            duration_ms = int(slide.get("duration_ms") or 0)
+            duration_ms = slide_dwell_ms
             if duration_ms <= 0:
                 duration_ms = 10000
             ss["timeout_id"] = GLib.timeout_add(
@@ -1148,6 +1164,7 @@ class AgoraPlayer:
                 path, loop=True, muted=False,
                 transition=transition, duration_ms=transition_ms,
                 start_offset_ms=start_offset_ms,
+                fit=slide.get("fit") or None,
             )
             duration_ms = int(slide.get("duration_ms") or 0)
             if duration_ms <= 0:
@@ -1166,6 +1183,7 @@ class AgoraPlayer:
             path, loop=False, muted=False,
             transition=transition, duration_ms=transition_ms,
             start_offset_ms=start_offset_ms,
+            fit=slide.get("fit") or None,
         )
 
         # Watchdog: 2× hinted duration with a 60s floor, capped at the

--- a/player/shell/player.css
+++ b/player/shell/player.css
@@ -116,3 +116,19 @@ html, body {
 /* fade_black is sequenced JS-side (two half-duration fades through the
  * black stage background) — no extra CSS needed here. */
 
+/* Ken Burns (slideshow per-slide effect, images only). Applied to the
+ * <img> element itself rather than .layer, because .layer's transform is
+ * reserved for the push/zoom/dissolve transitions above — animating both
+ * on the same element would conflict. player.js sets --fx-duration-ms
+ * from the command's effect_duration_ms (default 8000ms). */
+@keyframes fx-ken-burns {
+  from { transform: scale(1) translate(0, 0); }
+  to   { transform: scale(1.12) translate(-2%, -2%); }
+}
+.layer img.fx-ken-burns {
+  animation: fx-ken-burns var(--fx-duration-ms, 8000ms) ease-out both;
+  transform-origin: center center;
+  will-change: transform;
+}
+
+

--- a/player/shell/player.js
+++ b/player/shell/player.js
@@ -6,9 +6,11 @@
  *
  * Protocol (server -> client):
  *   {"cmd":"show_image","url":"/assets/images/foo.jpg",
- *    "transition":"<mode>","duration_ms":600}
+ *    "transition":"<mode>","duration_ms":600,
+ *    "fit":"cover","effect":"ken_burns","effect_duration_ms":8000}
  *   {"cmd":"show_video","url":"/assets/videos/bar.mp4",
- *    "loop":true,"muted":false,"transition":"<mode>","duration_ms":600}
+ *    "loop":true,"muted":false,"transition":"<mode>","duration_ms":600,
+ *    "fit":"cover"}
  *   {"cmd":"show_video","url":"/assets/videos/bar.mp4",
  *    "loop":false,"loop_count":3,"muted":false,"transition":"<mode>",
  *    "duration_ms":600}
@@ -28,6 +30,16 @@
  * and then emits {event:"ended", asset, completed_loops:N}. When absent
  * or 0, the cmd.loop field is honored as-is (HTML <video loop>).
  *
+ * fit (slideshow per-slide, images + videos): "cover" | "contain".
+ * Applied as CSS object-fit on the media element, overriding the shell's
+ * default of object-fit: contain. Unknown values are ignored.
+ *
+ * effect (slideshow per-slide, images only): "ken_burns" applies a slow
+ * scale/pan animation (see .fx-ken-burns in player.css) to the <img>.
+ * effect_duration_ms sets the animation length (--fx-duration-ms),
+ * falling back to 8000ms when absent or non-positive. Videos never get
+ * the effect.
+ *
  * Client -> server (informational):
  *   {"event":"ready"}                          (on initial connect)
  *   {"event":"ended","asset":"<url>"}           (single-play video ended)
@@ -43,6 +55,18 @@
     document.getElementById("layer-b"),
   ];
   let activeIdx = 0; // which layer is currently visible
+
+  // Per-slide object-fit allow-list. The CMS slideshow builder emits a
+  // ``fit`` field (cover|contain) per slide in manifest schema 1.3; the
+  // shell applies it as CSS object-fit on the image/video element. Only
+  // these two values are honored so a malformed manifest can't inject
+  // arbitrary CSS. The shell's legacy default is ``object-fit: contain``
+  // (player.css), so "cover" must be applied explicitly to override it.
+  const KNOWN_FITS = ["cover", "contain"];
+
+  // Default Ken Burns animation length when the command omits (or sends a
+  // non-positive) effect_duration_ms. Matches the slide's typical dwell.
+  const KEN_BURNS_DEFAULT_MS = 8000;
 
   let ws = null;
   let reconnectTimer = null;
@@ -121,6 +145,11 @@
           } catch (_) { /* ignore -- play from start */ }
         }, { once: true });
       }
+      // Per-slide object-fit override (slideshow schema 1.3). Videos
+      // honor cover/contain but never the Ken Burns effect.
+      if (KNOWN_FITS.indexOf(cmd.fit) !== -1) {
+        v.style.objectFit = cmd.fit;
+      }
       return v;
     }
     if (cmd.cmd === "show_html") {
@@ -143,6 +172,22 @@
     img.addEventListener("error", () => {
       send({ event: "error", asset: cmd.url, msg: "image load failed" });
     });
+    // Per-slide object-fit override (slideshow schema 1.3).
+    if (KNOWN_FITS.indexOf(cmd.fit) !== -1) {
+      img.style.objectFit = cmd.fit;
+    }
+    // Ken Burns: a slow scale/pan applied to the <img> itself (not the
+    // layer, which is reserved for push/zoom/dissolve transitions). The
+    // keyframes in player.css read --fx-duration-ms for the animation
+    // length; we plumb the slide dwell here, falling back to a sane
+    // default when the command omits or sends a non-positive value.
+    if (cmd.effect === "ken_burns") {
+      const durMs = Number.isFinite(cmd.effect_duration_ms)
+        && cmd.effect_duration_ms > 0
+        ? cmd.effect_duration_ms : KEN_BURNS_DEFAULT_MS;
+      img.style.setProperty("--fx-duration-ms", durMs + "ms");
+      img.classList.add("fx-ken-burns");
+    }
     return img;
   }
 
@@ -325,7 +370,7 @@
       // Inherit the same fit/sizing as <img>/<video> in player.css.
       canvas.style.width = "100%";
       canvas.style.height = "100%";
-      canvas.style.objectFit = "contain";
+      canvas.style.objectFit = v.style.objectFit || "contain";
       canvas.style.background = "#000";
       try { v.pause(); v.removeAttribute("src"); v.load(); } catch (_) {}
       layer.replaceChild(canvas, v);

--- a/tests/test_chromium_backend.py
+++ b/tests/test_chromium_backend.py
@@ -130,6 +130,80 @@ def test_show_video_defaults_to_cut_transition(cp):
     assert sent[0]["transition"] == "cut"
 
 
+# ── Per-slide fit / Ken Burns effect (manifest schema 1.3) ──────────
+#
+# CMS emits per-slide ``fit`` (cover|contain) and ``effect``
+# (none|ken_burns) on slideshow image members. These must be wired
+# through to the shell as OPT-IN fields so old manifests / callers that
+# don't pass them keep producing the exact legacy command shape.
+
+
+def _make_img(cp):
+    img = cp.assets_dir / "images" / "foo.jpg"
+    img.parent.mkdir(parents=True, exist_ok=True)
+    img.write_bytes(b"\xff\xd8\xff")
+    return img
+
+
+def test_show_image_without_fit_effect_is_backward_compatible(cp):
+    """No fit/effect args -> the original 4-key command, unchanged."""
+    sent = _capture_commands(cp)
+    cp.show_image(_make_img(cp), transition="fade", duration_ms=800)
+    assert sent == [{
+        "cmd": "show_image",
+        "url": "/assets/images/foo.jpg",
+        "transition": "fade",
+        "duration_ms": 800,
+    }]
+
+
+def test_show_image_includes_fit_when_provided(cp):
+    sent = _capture_commands(cp)
+    cp.show_image(_make_img(cp), fit="cover")
+    assert sent[0]["fit"] == "cover"
+    # effect not requested -> absent.
+    assert "effect" not in sent[0]
+    assert "effect_duration_ms" not in sent[0]
+
+
+def test_show_image_includes_effect_and_duration(cp):
+    sent = _capture_commands(cp)
+    cp.show_image(
+        _make_img(cp), fit="contain",
+        effect="ken_burns", effect_duration_ms=8000,
+    )
+    assert sent[0]["fit"] == "contain"
+    assert sent[0]["effect"] == "ken_burns"
+    assert sent[0]["effect_duration_ms"] == 8000
+
+
+def test_show_image_effect_none_is_omitted(cp):
+    """effect='none' is the default -> don't pollute the payload."""
+    sent = _capture_commands(cp)
+    cp.show_image(_make_img(cp), effect="none", effect_duration_ms=5000)
+    assert "effect" not in sent[0]
+    assert "effect_duration_ms" not in sent[0]
+
+
+def test_show_video_includes_fit_when_provided(cp):
+    """fit applies to video too (cover/contain object-fit)."""
+    sent = _capture_commands(cp)
+    vid = cp.assets_dir / "videos" / "clip.mp4"
+    vid.parent.mkdir(parents=True)
+    vid.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+    cp.show_video(vid, fit="cover")
+    assert sent[0]["fit"] == "cover"
+
+
+def test_show_video_without_fit_omits_field(cp):
+    sent = _capture_commands(cp)
+    vid = cp.assets_dir / "videos" / "clip.mp4"
+    vid.parent.mkdir(parents=True)
+    vid.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+    cp.show_video(vid)
+    assert "fit" not in sent[0]
+
+
 def test_show_video_with_loop_count_includes_field(cp):
     sent = _capture_commands(cp)
     vid = cp.assets_dir / "videos" / "clip.mp4"

--- a/tests/test_player_shell_fit_effect.py
+++ b/tests/test_player_shell_fit_effect.py
@@ -1,0 +1,82 @@
+"""Contract test: player.js / player.css support per-slide fit + Ken Burns.
+
+The CMS slideshow builder emits, per slide, a ``fit`` (cover|contain) and
+an ``effect`` (none|ken_burns) field in manifest schema 1.3. The device
+shell must honor both:
+
+  * ``fit`` -> CSS ``object-fit`` on the image (and video) element.
+  * ``effect == "ken_burns"`` -> a CSS animation scoped to the <img>.
+
+This test pins the shell side of that contract by scraping player.js /
+player.css for the required tokens. It deliberately does NOT import the
+shell (it's browser JS) — substring assertions mirror the existing
+``test_player_shell_transitions.py`` pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAYER_JS = REPO_ROOT / "player" / "shell" / "player.js"
+PLAYER_CSS = REPO_ROOT / "player" / "shell" / "player.css"
+
+
+def _js() -> str:
+    return PLAYER_JS.read_text(encoding="utf-8")
+
+
+def _css() -> str:
+    return PLAYER_CSS.read_text(encoding="utf-8")
+
+
+# ── fit (object-fit) ────────────────────────────────────────────────
+
+def test_player_js_defines_known_fits_allowlist():
+    js = _js()
+    assert "KNOWN_FITS" in js
+    # Both legal values must be allow-listed so the shell can override
+    # its legacy ``object-fit: contain`` default with either.
+    assert '"cover"' in js
+    assert '"contain"' in js
+
+
+def test_player_js_applies_object_fit_from_cmd():
+    js = _js()
+    assert "objectFit" in js
+    assert "cmd.fit" in js
+
+
+# ── Ken Burns effect ────────────────────────────────────────────────
+
+def test_player_js_handles_ken_burns_effect():
+    js = _js()
+    assert "ken_burns" in js
+    assert "fx-ken-burns" in js
+    # Duration plumbed via a CSS custom property the keyframes consume.
+    assert "--fx-duration-ms" in js
+    assert "cmd.effect" in js
+
+
+def test_player_css_defines_ken_burns_keyframes():
+    css = _css()
+    assert "@keyframes fx-ken-burns" in css
+    assert "fx-ken-burns" in css
+    # Scoped to the <img> so it doesn't fight the layer-level transform
+    # used by push/zoom/dissolve transitions.
+    assert "img.fx-ken-burns" in css
+
+
+def test_player_css_ken_burns_uses_duration_variable():
+    css = _css()
+    assert "--fx-duration-ms" in css
+
+
+# ── protocol doc ────────────────────────────────────────────────────
+
+def test_player_js_header_documents_fit_and_effect():
+    js = _js()
+    head = js[:2000]
+    assert "fit" in head
+    assert "effect" in head

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1191,6 +1191,52 @@ class TestAnchoredPlayback:
         passed = args[0] if args else kwargs.get("path")
         assert str(passed).endswith("c.html")
 
+    def test_chromium_anchored_image_passes_fit_and_effect(self, mpv_player):
+        """Per-slide fit + Ken Burns effect (manifest schema 1.3) are
+        forwarded to ``show_image`` so the shell can render object-fit
+        and the Ken Burns animation. effect_duration_ms is the slide's
+        on-screen dwell so the animation spans the whole slide."""
+        player, svc = mpv_player
+        (player.assets_dir / "images" / "a.png").touch()
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self._write_anchored(player, "Show", [
+            {"name": "a.png", "asset_type": "image", "duration_ms": 8_000,
+             "play_to_end": False, "fit": "contain", "effect": "ken_burns"},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/a.png"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_image.assert_called_once()
+        kwargs = player._chromium_player.show_image.call_args.kwargs
+        assert kwargs["fit"] == "contain"
+        assert kwargs["effect"] == "ken_burns"
+        assert kwargs["effect_duration_ms"] == 8_000
+
+    def test_chromium_anchored_video_passes_fit(self, mpv_player):
+        """A per-slide ``fit`` on a video member reaches ``show_video``."""
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=2)
+        self._write_anchored(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 60_000,
+             "play_to_end": False, "fit": "cover"},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/v.mp4"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_video.assert_called_once()
+        kwargs = player._chromium_player.show_video.call_args.kwargs
+        assert kwargs["fit"] == "cover"
+
+
     def test_chromium_play_to_end_overrun_keeps_kiosk_alive(self, mpv_player):
         """Regression: play_to_end overrun on the chromium backend used
         to call ``ChromiumPlayer.stop()`` (full kiosk + shell server


### PR DESCRIPTION
## Summary

agora-cms emits per-slide **Fit** (`cover`/`contain`) and **Ken Burns effect** (`none`/`ken_burns`) in slideshow manifest schema 1.3, but the Pi Chromium player ignored both. This wires the firmware to render what the slideshow builder already lets users configure.

## Changes

- **`player/chromium_backend.py`** — `show_image` / `show_video` accept `fit`, `effect`, and `effect_duration_ms`. Emitted conditionally:
  - `fit` emitted when truthy (must be sent for `cover` since the legacy CSS default is `object-fit: contain`).
  - `effect` + `effect_duration_ms` emitted only when `effect != "none"` and duration > 0.
  - `show_video` never emits `ken_burns`.
- **`player/service.py`** — plumbs fit/effect/dwell through the anchored, normal, and play-to-end Chromium slideshow paths.
- **`player/shell/player.js`** — applies `cmd.fit` as `object-fit` on both `<img>` and `<video>`; applies Ken Burns on the `<img>` via an `fx-ken-burns` class + a `--fx-duration-ms` CSS var (falls back to 8000 ms when absent/zero); `_freezeOutgoingVideo` inherits the slide's `object-fit`.
- **`player/shell/player.css`** — `@keyframes fx-ken-burns` + `.layer img.fx-ken-burns` rule. The keyframes animate the `<img>`, **not** `.layer`, to avoid clashing with the layer's push/zoom/dissolve transition transforms.

## Notes

- `effect_duration_ms` is the slide **dwell** time, plumbed separately from the command's `duration_ms` (which is the transition animation length).
- No manual version bump — `create-release.yml`'s `bump-main` job auto-increments the patch version after release.

## Testing

- 114 passed (`test_slideshow_player.py`, `test_chromium_backend.py`, `test_player_shell_fit_effect.py`).
- `node --check player/shell/player.js` clean.

🤖 Generated with GitHub Copilot
