### PR TITLE
feat: slideshow blur-fill backdrop (contain_blur fit)

### DIFF
--- a/player/shell/player.css
+++ b/player/shell/player.css
@@ -131,4 +131,41 @@ html, body {
   will-change: transform;
 }
 
+/* Blur-fill backdrop (slideshow roadmap, agora#261). The foreground image
+ * renders contained over a blurred, zoomed cover copy of itself, filling the
+ * letterbox bars with the image's own colours instead of black. player.js
+ * builds: .layer > .fit-blur-wrap > (img.fit-blur-backdrop + img.fit-blur-fg).
+ * The two-class selectors (specificity 0,0,2,1) outrank the base
+ * ".layer img" rule (0,0,1,1) so the per-element object-fit / background win.
+ * The foreground may also carry .fx-ken-burns (animation only; no object-fit
+ * conflict). */
+.layer .fit-blur-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #000;
+}
+.layer img.fit-blur-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  /* scale past the edges so the blur halo never reveals the black wrapper */
+  transform: scale(1.12);
+  filter: blur(24px);
+  background: transparent;
+}
+.layer img.fit-blur-fg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: transparent;
+}
+
 

--- a/player/shell/player.js
+++ b/player/shell/player.js
@@ -146,7 +146,9 @@
         }, { once: true });
       }
       // Per-slide object-fit override (slideshow schema 1.3). Videos
-      // honor cover/contain but never the Ken Burns effect.
+      // honor cover/contain but never the Ken Burns effect. "contain_blur"
+      // is not in KNOWN_FITS, so video falls through to the default
+      // object-fit:contain (no blurred backdrop for video in v1).
       if (KNOWN_FITS.indexOf(cmd.fit) !== -1) {
         v.style.objectFit = cmd.fit;
       }
@@ -187,6 +189,28 @@
         ? cmd.effect_duration_ms : KEN_BURNS_DEFAULT_MS;
       img.style.setProperty("--fx-duration-ms", durMs + "ms");
       img.classList.add("fx-ken-burns");
+    }
+    // Blur-fill backdrop (slideshow roadmap, agora#261). When fit is
+    // "contain_blur" the image renders contained over a blurred, zoomed
+    // cover copy of itself, so letterbox bars are filled with the image's
+    // own colours instead of black. The foreground <img> built above (and
+    // any Ken Burns animation it carries) becomes .fit-blur-fg; a sibling
+    // backdrop <img> sits behind it inside a wrapper. "contain_blur" is
+    // deliberately NOT in KNOWN_FITS — the styling is driven by CSS classes,
+    // not a direct object-fit assignment. Pre-blur shells never see this
+    // branch and fall through to plain contain (graceful). Video never uses
+    // this path (no blurred backdrop for video in v1).
+    if (cmd.fit === "contain_blur") {
+      img.classList.add("fit-blur-fg");
+      const wrap = document.createElement("div");
+      wrap.className = "fit-blur-wrap";
+      const backdrop = document.createElement("img");
+      backdrop.src = cmd.url;
+      backdrop.className = "fit-blur-backdrop";
+      backdrop.setAttribute("aria-hidden", "true");
+      wrap.appendChild(backdrop);
+      wrap.appendChild(img);
+      return wrap;
     }
     return img;
   }

--- a/tests/test_player_shell_fit_effect.py
+++ b/tests/test_player_shell_fit_effect.py
@@ -73,6 +73,39 @@ def test_player_css_ken_burns_uses_duration_variable():
     assert "--fx-duration-ms" in css
 
 
+# ── blur-fill backdrop (contain_blur) ───────────────────────────────
+
+def test_player_js_handles_contain_blur_fit():
+    js = _js()
+    # The contain_blur branch builds a wrapper + backdrop instead of a
+    # bare object-fit assignment.
+    assert "contain_blur" in js
+    assert "fit-blur-wrap" in js
+    assert "fit-blur-backdrop" in js
+    assert "fit-blur-fg" in js
+
+
+def test_player_js_contain_blur_not_in_known_fits():
+    js = _js()
+    # contain_blur must NOT be allow-listed in KNOWN_FITS: it is styled
+    # via CSS classes, not a direct object-fit value (which would be an
+    # invalid CSS keyword).
+    start = js.index("KNOWN_FITS")
+    snippet = js[start:start + 120]
+    assert "contain_blur" not in snippet
+
+
+def test_player_css_defines_blur_fill_rules():
+    css = _css()
+    assert ".fit-blur-wrap" in css
+    # Two-class selectors so they outrank the base ".layer img" object-fit.
+    assert "img.fit-blur-backdrop" in css
+    assert "img.fit-blur-fg" in css
+    # Backdrop is a blurred cover copy.
+    assert "blur(" in css
+    assert "object-fit: cover" in css
+
+
 # ── protocol doc ────────────────────────────────────────────────────
 
 def test_player_js_header_documents_fit_and_effect():


### PR DESCRIPTION
## Slideshow blur-fill backdrop (firmware half)

Adds a `contain_blur` fit value for slideshow image slides. The image
renders **contained** over a **blurred, zoomed cover copy of itself**, so
letterbox bars are filled with the image's own colours instead of black.

### Changes
- **player.js**: `cmd.fit === "contain_blur"` wraps the foreground
  `<img>` (with any Ken Burns animation) inside `.fit-blur-wrap` behind
  a `.fit-blur-backdrop` cover copy. `contain_blur` is intentionally
  **not** added to `KNOWN_FITS` — it's CSS-class driven, not a direct
  `object-fit` value. Old shells receiving `contain_blur` fall through
  to plain `contain` (black bars, graceful).
- **player.css**: `.fit-blur-wrap` / `img.fit-blur-backdrop`
  (cover + `blur(24px)` + `scale(1.12)`) / `img.fit-blur-fg`,
  two-class selectors to outrank the base `.layer img` rule.
- **tests**: 3 new contract assertions in
  `test_player_shell_fit_effect.py` (9 passing total).

### Notes
- No manifest schema version bump — `contain_blur` is a new enum value
  on the existing `fit` field, not a new field.
- Video slides are unaffected (no blurred backdrop for video in v1).
- CMS half: sslivins/agora-cms#792.
- Part of slideshow roadmap sslivins/agora#261.

CI on this repo doesn't exercise the browser JS/CSS; tests are
substring-contract assertions that pass locally.
