### PR TITLE
fix(slideshow): persist effect_direction in device manifest cache

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -2442,6 +2442,13 @@ class CMSClient:
                     # a no-op (contain / no effect) rather than a missing key.
                     "fit": s.get("fit"),
                     "effect": s.get("effect"),
+                    # Ken Burns pan/zoom direction (manifest schema 1.4). Without
+                    # this the player reads ``effect_direction`` as absent ->
+                    # ``None`` and every ken_burns slide falls back to the
+                    # centered zoom-in (``fx-kb-in``) regardless of the authored
+                    # direction. Persist verbatim; default None so pre-1.4
+                    # manifests stay a no-op.
+                    "effect_direction": s.get("effect_direction"),
                     # Composed members persist their sibling list so cold-start
                     # completeness + eviction-protection survive a reboot.
                     **(

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -305,6 +305,7 @@ class TestSlideshowFetch:
         slide = _make_slide("a.png", b1, asset_type="image", duration_ms=8000)
         slide["fit"] = "cover"
         slide["effect"] = "ken_burns"
+        slide["effect_direction"] = "out_down_right"
         msg = {
             "type": "fetch_asset",
             "asset_name": "KenBurns.slideshow",
@@ -312,7 +313,7 @@ class TestSlideshowFetch:
             "download_url": "",
             "checksum": "h",
             "size_bytes": 0,
-            "manifest_schema_version": "1.3",
+            "manifest_schema_version": "1.4",
             "slides": [slide],
         }
         mapping = {slide["download_url"]: b1}
@@ -324,6 +325,7 @@ class TestSlideshowFetch:
         manifest = json.loads(manifest_path.read_text())
         assert manifest["slides"][0]["fit"] == "cover"
         assert manifest["slides"][0]["effect"] == "ken_burns"
+        assert manifest["slides"][0]["effect_direction"] == "out_down_right"
 
     @pytest.mark.asyncio
     async def test_fit_effect_default_when_absent(self, cms_client):
@@ -352,6 +354,7 @@ class TestSlideshowFetch:
         )
         assert manifest["slides"][0]["fit"] is None
         assert manifest["slides"][0]["effect"] is None
+        assert manifest["slides"][0]["effect_direction"] is None
 
     @pytest.mark.asyncio
     async def test_wall_clock_fields_absent_persist_as_none(self, cms_client):


### PR DESCRIPTION
## Problem

On Pi100, a Ken Burns slide authored with any pan direction (e.g. "zoom out + down-right") always rendered as a **centered zoom-in**. Confirmed via on-device forensics: every cached slideshow manifest — including freshly-created `manifest_schema_version: "1.4"` ones — had `effect: "ken_burns"` but **no `effect_direction` key**.

## Root cause

The CMS resolver correctly emits `effect_direction` on the wire (verified on deployed 1.38.187), but the **firmware's** slideshow manifest cache writer (`_persist_slideshow_manifest` in `cms_client/service.py`) builds the persisted slide dict field-by-field and copied `fit` + `effect` but **not** `effect_direction`. The player then reads `slide.get("effect_direction")` from that cached file → always `None` → `fx-kb-in` fallback (centered zoom-in).

All other firmware paths (`player/service.py`, `chromium_backend.py`, `player.js`, `player.css`) already fully support `effect_direction` — only the cache-writer plumbing dropped it.

## Fix

Persist `effect_direction` verbatim from the wire descriptor (default `None` so pre-1.4 manifests stay a no-op).

## Tests

- Extended `test_fit_effect_fields_propagated_from_wire` to assert `effect_direction == "out_down_right"` round-trips (schema 1.4).
- Extended `test_fit_effect_default_when_absent` to assert `effect_direction is None` for legacy manifests.
- `tests/test_slideshow_fetch.py`: 22 passed locally.

## Deploy note

After merge: agora `.deb` publishes to the APT repo, then a new `agora-os` image must be cut for Pi100 to pick up the fix (Pi100 will be hot-patched for immediate validation in the meantime).
