### PR TITLE
feat(slideshow): device-side per-slide visibility windows (schema 1.5)

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -54,7 +54,21 @@ PROTOCOL_VERSION = 2
 #   persisting them, and rendering the member via ``show_html`` in the
 #   slideshow loop. The CMS gates composed-bearing slideshows on this
 #   flag so pre-feature firmware never receives one.
-DEVICE_CAPABILITIES = ["slideshow_v1", "composed_siblings_v1", "slideshow_composed_v1"]
+# - "slideshow_visibility_v1": this firmware evaluates per-slide
+#   visibility windows (manifest schema 1.5: ``valid_from``/``valid_to``
+#   date range, ``active_days`` weekday mask, ``active_start``/
+#   ``active_end`` time-of-day window) on-device in device-local civil
+#   time, showing/hiding individual slides at the exact local-clock
+#   boundary even while network-isolated. The CMS sends the full deck
+#   (including currently-closed slides) to such devices and lets the
+#   firmware do the windowing; pre-feature firmware keeps receiving the
+#   server-side filtered deck.
+DEVICE_CAPABILITIES = [
+    "slideshow_v1",
+    "composed_siblings_v1",
+    "slideshow_composed_v1",
+    "slideshow_visibility_v1",
+]
 
 # Bootstrap v2 renewal policy (issue #420 stage B.3).
 # Minimum delay between JWT refreshes on the renewal task, so a clock

--- a/player/service.py
+++ b/player/service.py
@@ -37,10 +37,14 @@ from player.slideshow_engine import (  # noqa: E402
     is_forward_schema as _is_forward_schema,
     locate_slide_at as _locate_slide_at,
     ordered_slides_for_cycle as _ordered_slides_for_cycle,
+    next_window_boundary as _next_window_boundary,
     parse_iso8601_utc as _parse_iso8601_utc,
     parse_schema_version as _parse_schema_version,
     read_slideshow_manifest as _read_slideshow_manifest_pure,
     resolve_anchored_target as _resolve_anchored_target_pure,
+    slide_has_window as _slide_has_window,
+    visible_slides as _visible_slides,
+    WINDOW_BOUNDARY_MAX_SLEEP_S as _WINDOW_BOUNDARY_MAX_SLEEP_S,
 )
 
 logger = logging.getLogger("agora.player")
@@ -636,19 +640,70 @@ class AgoraPlayer:
           can surface skew differently.
         """
         now = datetime.now(timezone.utc)
+        # Naive system-local civil time for per-slide visibility windows.
+        # On the Pi the OS timezone is set by cms_client, so a naive
+        # ``datetime.now()`` reads the device's local wall clock — exactly
+        # what the CMS predicate evaluates against. Softplayer on Windows
+        # gets Windows-local time (a dev-tool caveat, not a fleet concern).
+        local_now = datetime.now()
         base_slides = ss.get("slides") or []
-        cycle_ms = int(ss.get("cycle_duration_ms") or 0)
         anchor = ss.get("anchor")
 
-        # Default: play the manifest order. Shuffle only ever reorders
-        # the anchored path; the legacy timer chain below reads
+        # --- Per-slide visibility windows (manifest schema 1.5) ----------
+        # Filter the deck to the slides whose civil-clock window is open
+        # right now, mirroring the server-side scheduler predicate so the
+        # device flips slides open/closed at exact local-clock boundaries
+        # even while network-isolated. Windowless decks (no slide carries
+        # any window metadata) skip every branch below and behave
+        # byte-identically to schema <= 1.4.
+        windowed = any(_slide_has_window(s) for s in base_slides)
+        # Only trust the local clock for window evaluation once the
+        # wall-clock anchor is within the clock-skew tolerance. A pre-NTP
+        # boot (now << anchor) has a bogus ``local_now``, so windowing is
+        # suppressed until the clock catches up — the full deck plays for
+        # that brief transient, matching the legacy timer chain.
+        clock_trustworthy = (
+            anchor is None
+            or (anchor - now).total_seconds() <= _CLOCK_SKEW_TOLERANCE_S
+        )
+        if windowed and clock_trustworthy:
+            active_base = _visible_slides(base_slides, local_now)
+            # Recompute the cycle over the visible deck and persist it so
+            # the dispatch/resync overrun math (which reads
+            # ``ss["cycle_duration_ms"]``) stays consistent with what is
+            # actually on screen.
+            cycle_ms = sum(
+                max(int(s.get("duration_ms") or 0), 0) for s in active_base
+            )
+            ss["cycle_duration_ms"] = cycle_ms
+            # Earliest strictly-future civil instant the visible set may
+            # change, so the dispatch + hold timers can wake precisely on
+            # the boundary (see ``_anchored_tick_ms``).
+            ss["window_boundary"] = _next_window_boundary(base_slides, local_now)
+            if not active_base:
+                # Every slide is currently closed by its window. The
+                # anchored math can't run on an empty deck and the legacy
+                # timer chain would replay the FULL (unfiltered) deck, so
+                # signal the caller to enter the all-closed holding state.
+                ss["windows_all_closed"] = True
+                ss["active_cycle_slides"] = []
+                return None
+        else:
+            active_base = base_slides
+            cycle_ms = int(ss.get("cycle_duration_ms") or 0)
+            ss["window_boundary"] = None
+        ss["windows_all_closed"] = False
+        ss["windows_closed_shown"] = False
+
+        # Default: play the (visible) manifest order. Shuffle only ever
+        # reorders the anchored path; the legacy timer chain below reads
         # ``ss["slides"]`` directly and is intentionally left untouched.
-        ordered_slides = list(base_slides)
+        ordered_slides = list(active_base)
         if (
             ss.get("shuffle")
             and anchor is not None
             and cycle_ms > 0
-            and len(base_slides) > 1
+            and len(active_base) > 1
         ):
             # Gate the reshuffle on the same clock-skew tolerance the pure
             # resolver uses, so a pre-NTP boot (now << anchor) doesn't
@@ -659,7 +714,7 @@ class AgoraPlayer:
                 elapsed_ms = int((now - anchor).total_seconds() * 1000)
                 cycle_index = _cycle_index_at(elapsed_ms, cycle_ms)
                 ordered_slides = _ordered_slides_for_cycle(
-                    base_slides,
+                    active_base,
                     shuffle=True,
                     shuffle_seed=int(ss.get("shuffle_seed") or 0),
                     cycle_index=cycle_index,
@@ -698,6 +753,55 @@ class AgoraPlayer:
         if resolution.status is _AnchorStatus.OK:
             return resolution.target
         return None
+
+    def _anchored_tick_ms(self, ss: dict, remaining_ms: int) -> int:
+        """Clamp the next resync/hold tick.
+
+        Always bounded by the resync cap. When the deck carries
+        per-slide visibility windows (manifest 1.5) the tick is *also*
+        clamped to the next civil window boundary so a slide flips
+        open/closed at the exact local-clock instant rather than up to
+        ``_RESYNC_CAP_MS`` late. The boundary clamp is itself capped at
+        ``_WINDOW_BOUNDARY_MAX_SLEEP_S`` as a daily safety net.
+        """
+        tick = min(max(int(remaining_ms), 1), _RESYNC_CAP_MS)
+        boundary = ss.get("window_boundary")
+        if boundary is not None:
+            ms_to_boundary = int(
+                (boundary - datetime.now()).total_seconds() * 1000
+            )
+            ms_to_boundary = max(
+                1,
+                min(ms_to_boundary, _WINDOW_BOUNDARY_MAX_SLEEP_S * 1000),
+            )
+            tick = min(tick, ms_to_boundary)
+        return tick
+
+    def _enter_windows_closed(self, ss: dict) -> bool:
+        """Holding state when every slide is closed by its window.
+
+        Shows the splash once and arms a re-check timer at the next
+        window boundary (capped) so the deck reappears at the exact
+        local-clock instant a slide opens — even while network-isolated.
+        Re-uses the anchored resync tick as the wake callback: when a
+        slide opens, ``_resolve_anchored_target`` returns a real target
+        and playback resumes; while still closed it routes back here.
+        """
+        self._cancel_slide_timeout()
+        if not ss.get("windows_closed_shown"):
+            logger.info(
+                "Slideshow %s: all slides closed by visibility windows "
+                "— holding on splash until next window boundary",
+                ss["name"],
+            )
+            self._show_splash()
+            ss["windows_closed_shown"] = True
+            ss["anchored_current_idx"] = -1
+        tick_ms = self._anchored_tick_ms(ss, _RESYNC_CAP_MS)
+        ss["timeout_id"] = GLib.timeout_add(
+            tick_ms, self._on_anchored_resync_tick, ss["epoch"],
+        )
+        return False
 
     def _play_anchored_slide(
         self, ss: dict, target_idx: int, remaining_ms: int,
@@ -839,7 +943,7 @@ class AgoraPlayer:
                 started_at=datetime.now(timezone.utc),
             )
 
-        tick_ms = min(max(remaining_ms, 1), _RESYNC_CAP_MS)
+        tick_ms = self._anchored_tick_ms(ss, remaining_ms)
         epoch = ss["epoch"]
         ss["timeout_id"] = GLib.timeout_add(
             tick_ms, self._on_anchored_resync_tick, epoch,
@@ -860,6 +964,10 @@ class AgoraPlayer:
 
         target = self._resolve_anchored_target(ss)
         if target is None:
+            if ss.get("windows_all_closed"):
+                # Every slide is window-closed — keep holding on splash
+                # and re-arm the boundary timer instead of advancing.
+                return self._enter_windows_closed(ss)
             # Anchor became unusable (e.g. someone replaced the manifest
             # mid-flight).  Fall back to a legacy natural advance so
             # playback keeps moving.
@@ -938,7 +1046,7 @@ class AgoraPlayer:
                     return self._play_next_slide()
 
         # Same target, no overrun — just arm another tick.
-        tick_ms = min(max(remaining_ms, 1), _RESYNC_CAP_MS)
+        tick_ms = self._anchored_tick_ms(ss, remaining_ms)
         ss["timeout_id"] = GLib.timeout_add(
             tick_ms, self._on_anchored_resync_tick, epoch,
         )
@@ -969,6 +1077,12 @@ class AgoraPlayer:
         anchored = self._resolve_anchored_target(ss)
         if anchored is not None:
             return self._play_anchored_slide(ss, *anchored)
+
+        if ss.get("windows_all_closed"):
+            # Anchored deck is entirely window-closed: hold on splash and
+            # re-check at the next boundary rather than falling through to
+            # the legacy chain (which would replay the unfiltered deck).
+            return self._enter_windows_closed(ss)
 
         if ss["index"] >= len(ss["slides"]):
             ss["loops_completed"] += 1

--- a/player/slideshow_engine.py
+++ b/player/slideshow_engine.py
@@ -30,7 +30,7 @@ import hashlib
 import json
 import random
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -42,7 +42,7 @@ from typing import Optional
 #: with a higher version are still played back (best-effort) but log a
 #: one-shot "CMS is ahead of this player" INFO message.  Older versions
 #: are accepted unconditionally.
-PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.4"
+PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.5"
 
 
 def parse_schema_version(version: str) -> tuple[int, int]:
@@ -209,6 +209,208 @@ def ordered_slides_for_cycle(
     return [base_slides[i] for i in order]
 
 
+# ── Per-slide visibility windows (agora#226 Phase 2, manifest 1.5) ──
+
+#: Safety net for the window-boundary wake timer in ``player/service.py``.
+#: ``next_window_boundary`` returns the exact civil instant a slide flips
+#: open/closed, but a caller never sleeps longer than this between
+#: re-evaluations so a missed/!misjudged boundary self-heals within ~15min
+#: even on a drifting clock.
+WINDOW_BOUNDARY_MAX_SLEEP_S = 900
+
+
+def _parse_window_date(value: object) -> Optional[date]:
+    """Parse an ISO ``YYYY-MM-DD`` string → :class:`date`; fail-open to None."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_window_time(value: object) -> Optional[time]:
+    """Parse an ISO ``HH:MM:SS[.ffffff]`` string → :class:`time`; fail-open."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_window_days(value: object) -> Optional[list[int]]:
+    """Normalize ``active_days`` → sorted unique ints in [0,6], or None.
+
+    Empty list, None, wrong type, or all-invalid entries → None
+    (always-open for the weekday dimension).
+    """
+    if not isinstance(value, (list, tuple)):
+        return None
+    days = sorted({
+        int(d) for d in value
+        if isinstance(d, int) and not isinstance(d, bool) and 0 <= d <= 6
+    })
+    return days or None
+
+
+def parse_window(slide: dict) -> dict:
+    """Extract + normalize the per-slide visibility window off a manifest slide.
+
+    Returns a dict with keys ``valid_from``/``valid_to`` (:class:`date` | None),
+    ``active_days`` (sorted ``list[int]`` | None), and
+    ``active_start``/``active_end`` (:class:`time` | None).
+
+    **Fail-open per dimension:** any missing, wrong-typed, or unparseable
+    field becomes ``None`` (always-open for that dimension) rather than
+    crashing playback or stranding a slide.  A slide with no window fields
+    yields an all-``None`` dict, which :func:`slide_window_open` treats as
+    always visible — byte-identical to pre-1.5 behaviour.
+    """
+    return {
+        "valid_from": _parse_window_date(slide.get("valid_from")),
+        "valid_to": _parse_window_date(slide.get("valid_to")),
+        "active_days": _parse_window_days(slide.get("active_days")),
+        "active_start": _parse_window_time(slide.get("active_start")),
+        "active_end": _parse_window_time(slide.get("active_end")),
+    }
+
+
+def slide_has_window(slide: dict) -> bool:
+    """True iff ``slide`` carries at least one (well-formed) window constraint."""
+    return any(parse_window(slide).values())
+
+
+def slide_window_open(slide: dict, local_now: datetime) -> bool:
+    """Return True iff ``slide``'s visibility window is open at ``local_now``.
+
+    ``local_now`` is device-local civil time — on the Pi a naive
+    ``datetime.now()`` (the OS timezone is set by cms_client, so the naive
+    system clock already reads device-local wall time).
+
+    Ported verbatim from the CMS resolver predicate
+    (``cms.services.slideshow_resolver._slide_window_open``) so the firmware
+    flips a slide open/closed at the exact same instant the server would.
+
+    A slide is VISIBLE iff ALL configured constraints pass; any unset
+    (None) constraint is "always open" for that dimension:
+
+      * Date range ``[valid_from, valid_to]`` — both ends INCLUSIVE.
+      * Weekday set ``active_days`` (0=Mon..6=Sun) — empty/None = all days.
+      * Time-of-day ``[active_start, active_end)`` — start INCLUSIVE, end
+        EXCLUSIVE; ``active_start > active_end`` is an overnight wrap.
+
+    Wrap + weekday interaction: in the post-midnight tail of a wrapped
+    window the effective weekday is *yesterday's* (the window belongs to
+    the day it opened).
+    """
+    w = parse_window(slide)
+    d = local_now.date()
+    t = local_now.time()
+
+    valid_from = w["valid_from"]
+    valid_to = w["valid_to"]
+    if valid_from is not None and d < valid_from:
+        return False
+    if valid_to is not None and d > valid_to:
+        return False
+
+    start = w["active_start"]
+    end = w["active_end"]
+    days = w["active_days"]
+
+    if start is not None and end is not None and start > end and t < end:
+        effective_wd = (local_now - timedelta(days=1)).weekday()
+    else:
+        effective_wd = local_now.weekday()
+
+    if days and effective_wd not in days:
+        return False
+
+    if start is not None and end is not None:
+        if start < end:
+            if not (start <= t < end):
+                return False
+        else:  # overnight wrap
+            if not (t >= start or t < end):
+                return False
+    elif start is not None:
+        if t < start:
+            return False
+    elif end is not None:
+        if t >= end:
+            return False
+
+    return True
+
+
+def visible_slides(slides: list[dict], local_now: datetime) -> list[dict]:
+    """Filter ``slides`` to those whose visibility window is open at
+    ``local_now``, preserving order.  Windowless slides always pass.
+    """
+    return [s for s in slides if slide_window_open(s, local_now)]
+
+
+def next_window_boundary(
+    slides: list[dict], local_now: datetime,
+) -> Optional[datetime]:
+    """Earliest strictly-future civil instant at which the visible set may
+    change, or ``None`` if no slide carries a window.
+
+    Returns a naive local-civil :class:`datetime` (same clock domain as
+    ``local_now``).  We over-generate candidates — a redundant wake is
+    harmless because the caller re-evaluates :func:`visible_slides` on every
+    wake — but never under-generate, so a boundary is never missed.
+
+    Candidates per windowed slide:
+      * ``valid_from`` @ 00:00 (opens that calendar day)
+      * ``valid_to + 1 day`` @ 00:00 (inclusive end → closes next midnight)
+      * today's + tomorrow's ``active_start`` / ``active_end``
+      * midnight tomorrow for weekday-restricted slides (weekday rolls over)
+
+    Deliberately uses civil ``datetime.combine`` candidates (never
+    ``local_now + timedelta``) so a DST transition shifts the wake to the
+    correct wall-clock instant instead of an absolute offset.
+    """
+    today = local_now.date()
+    midnight_tomorrow = datetime.combine(today + timedelta(days=1), time(0, 0))
+    candidates: list[datetime] = []
+    has_window = False
+
+    for s in slides:
+        w = parse_window(s)
+        if not any(w.values()):
+            continue
+        has_window = True
+        valid_from = w["valid_from"]
+        valid_to = w["valid_to"]
+        start = w["active_start"]
+        end = w["active_end"]
+        days = w["active_days"]
+
+        if valid_from is not None:
+            candidates.append(datetime.combine(valid_from, time(0, 0)))
+        if valid_to is not None:
+            candidates.append(
+                datetime.combine(valid_to + timedelta(days=1), time(0, 0))
+            )
+        for base in (today, today + timedelta(days=1)):
+            if start is not None:
+                candidates.append(datetime.combine(base, start))
+            if end is not None:
+                candidates.append(datetime.combine(base, end))
+        if days is not None:
+            candidates.append(midnight_tomorrow)
+
+    future = [c for c in candidates if c > local_now]
+    if future:
+        return min(future)
+    # Windowed slides exist but every computed boundary is in the past
+    # (e.g. a permanently-closed expired slide): re-evaluate at the next
+    # midnight as a daily safety net rather than never waking.
+    if has_window:
+        return midnight_tomorrow
+    return None
 
 
 

--- a/tests/test_slideshow_engine.py
+++ b/tests/test_slideshow_engine.py
@@ -7,7 +7,7 @@ upcoming consumption of the same module.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -17,14 +17,20 @@ from player.slideshow_engine import (
     CLOCK_SKEW_TOLERANCE_S,
     PLAYER_MAX_MANIFEST_SCHEMA_VERSION,
     RESYNC_CAP_MS,
+    WINDOW_BOUNDARY_MAX_SLEEP_S,
     cycle_index_at,
     is_forward_schema,
     locate_slide_at,
+    next_window_boundary,
     ordered_slides_for_cycle,
     parse_iso8601_utc,
     parse_schema_version,
+    parse_window,
     read_slideshow_manifest,
     resolve_anchored_target,
+    slide_has_window,
+    slide_window_open,
+    visible_slides,
 )
 
 
@@ -219,7 +225,7 @@ class TestConstants:
         # docs and the CMS-side scheduler.
         assert CLOCK_SKEW_TOLERANCE_S == 3600
         assert RESYNC_CAP_MS == 5000
-        assert PLAYER_MAX_MANIFEST_SCHEMA_VERSION == "1.4"
+        assert PLAYER_MAX_MANIFEST_SCHEMA_VERSION == "1.5"
 
 
 class TestCycleIndexAt:
@@ -326,3 +332,251 @@ class TestOrderedSlidesForCycle:
         base = self._slides(5)
         out = ordered_slides_for_cycle(base, True, 33, -1)
         assert sorted(s["name"] for s in out) == sorted(s["name"] for s in base)
+
+
+# ---------------------------------------------------------------------------
+# Per-slide visibility windows (manifest schema 1.5)
+# ---------------------------------------------------------------------------
+
+
+def _wslide(**kw) -> dict:
+    """A minimal slide dict exposing only the five window fields.
+
+    ``slide_window_open`` reads nothing else off the slide for the
+    predicate, so this keeps the predicate tests focused.
+    """
+    d = {
+        "valid_from": None,
+        "valid_to": None,
+        "active_days": None,
+        "active_start": None,
+        "active_end": None,
+    }
+    d.update(kw)
+    return d
+
+
+def _ln(y, m, d, hh=12, mm=0) -> datetime:
+    """A naive local-civil datetime (the clock domain the predicate uses)."""
+    return datetime(y, m, d, hh, mm)
+
+
+class TestSlideWindowOpen:
+    """Verbatim parity with the CMS resolver predicate
+    (``cms.services.slideshow_resolver._slide_window_open``) — the firmware
+    MUST flip a slide open/closed at the exact same civil instant the
+    server would.  Cases ported 1:1 from agora-cms
+    ``tests/test_slideshow_visibility.py::TestSlideWindowOpen``.
+    """
+
+    def test_no_window_is_always_open(self):
+        assert slide_window_open(_wslide(), _ln(2026, 12, 25, 3, 0)) is True
+
+    def test_date_range_inclusive_both_ends(self):
+        row = _wslide(valid_from="2026-12-01", valid_to="2026-12-26")
+        assert slide_window_open(row, _ln(2026, 11, 30)) is False
+        assert slide_window_open(row, _ln(2026, 12, 1)) is True
+        assert slide_window_open(row, _ln(2026, 12, 26)) is True
+        assert slide_window_open(row, _ln(2026, 12, 27)) is False
+
+    def test_only_valid_from(self):
+        row = _wslide(valid_from="2026-06-01")
+        assert slide_window_open(row, _ln(2026, 5, 31)) is False
+        assert slide_window_open(row, _ln(2026, 6, 1)) is True
+        assert slide_window_open(row, _ln(2030, 1, 1)) is True
+
+    def test_only_valid_to(self):
+        row = _wslide(valid_to="2026-06-01")
+        assert slide_window_open(row, _ln(2026, 6, 1)) is True
+        assert slide_window_open(row, _ln(2026, 6, 2)) is False
+
+    def test_normal_time_window_start_incl_end_excl(self):
+        row = _wslide(active_start="13:00:00", active_end="14:00:00")
+        assert slide_window_open(row, _ln(2026, 6, 1, 12, 59)) is False
+        assert slide_window_open(row, _ln(2026, 6, 1, 13, 0)) is True
+        assert slide_window_open(row, _ln(2026, 6, 1, 13, 59)) is True
+        assert slide_window_open(row, _ln(2026, 6, 1, 14, 0)) is False
+
+    def test_only_active_start(self):
+        row = _wslide(active_start="09:00:00")
+        assert slide_window_open(row, _ln(2026, 6, 1, 8, 59)) is False
+        assert slide_window_open(row, _ln(2026, 6, 1, 9, 0)) is True
+
+    def test_only_active_end(self):
+        row = _wslide(active_end="17:00:00")
+        assert slide_window_open(row, _ln(2026, 6, 1, 16, 59)) is True
+        assert slide_window_open(row, _ln(2026, 6, 1, 17, 0)) is False
+
+    def test_overnight_wrap_window(self):
+        row = _wslide(active_start="22:00:00", active_end="02:00:00")
+        assert slide_window_open(row, _ln(2026, 6, 1, 21, 59)) is False
+        assert slide_window_open(row, _ln(2026, 6, 1, 22, 0)) is True
+        assert slide_window_open(row, _ln(2026, 6, 1, 23, 30)) is True
+        assert slide_window_open(row, _ln(2026, 6, 2, 1, 59)) is True
+        assert slide_window_open(row, _ln(2026, 6, 2, 2, 0)) is False
+
+    def test_weekday_only(self):
+        # 2026-06-01 is a Monday (weekday 0).
+        row = _wslide(active_days=[0, 2, 4])  # Mon, Wed, Fri
+        assert slide_window_open(row, _ln(2026, 6, 1)) is True   # Mon
+        assert slide_window_open(row, _ln(2026, 6, 2)) is False  # Tue
+        assert slide_window_open(row, _ln(2026, 6, 3)) is True   # Wed
+
+    def test_empty_weekday_list_is_every_day(self):
+        assert slide_window_open(_wslide(active_days=[]), _ln(2026, 6, 2)) is True
+
+    def test_wrap_tail_belongs_to_opening_days_weekday(self):
+        # Fri 22:00 .. Sat 02:00, allowed only on Friday (weekday 4).
+        row = _wslide(
+            active_start="22:00:00", active_end="02:00:00", active_days=[4],
+        )
+        assert slide_window_open(row, _ln(2026, 6, 5, 23, 0)) is True
+        # Sat 00:30 wrap tail -> effective weekday Friday -> open.
+        assert slide_window_open(row, _ln(2026, 6, 6, 0, 30)) is True
+        # Sat 22:00 is a fresh Saturday opening -> not allowed.
+        assert slide_window_open(row, _ln(2026, 6, 6, 22, 0)) is False
+
+    def test_full_mixture_all_constraints(self):
+        # Christmas-week flash sale: Dec 1-26, 1-2pm, weekdays only.
+        row = _wslide(
+            valid_from="2026-12-01",
+            valid_to="2026-12-26",
+            active_start="13:00:00",
+            active_end="14:00:00",
+            active_days=[0, 1, 2, 3, 4],
+        )
+        assert slide_window_open(row, _ln(2026, 12, 4, 13, 30)) is True
+        assert slide_window_open(row, _ln(2026, 11, 27, 13, 30)) is False
+        assert slide_window_open(row, _ln(2026, 12, 4, 9, 0)) is False
+        assert slide_window_open(row, _ln(2026, 12, 5, 13, 30)) is False
+
+    def test_fractional_second_time_parses(self):
+        # CMS may serialise times with microseconds; both ends parse.
+        row = _wslide(active_start="13:00:00.000000", active_end="14:00:00")
+        assert slide_window_open(row, _ln(2026, 6, 1, 13, 30)) is True
+
+
+class TestParseWindowFailOpen:
+    """Each dimension fails OPEN (-> None) on missing/garbage input so a
+    malformed manifest never strands a slide closed."""
+
+    def test_all_none_when_no_fields(self):
+        assert parse_window({}) == {
+            "valid_from": None, "valid_to": None, "active_days": None,
+            "active_start": None, "active_end": None,
+        }
+
+    def test_garbage_date_is_none(self):
+        w = parse_window({"valid_from": "not-a-date", "valid_to": 12345})
+        assert w["valid_from"] is None
+        assert w["valid_to"] is None
+
+    def test_garbage_time_is_none(self):
+        w = parse_window({"active_start": "25:99:99", "active_end": None})
+        assert w["active_start"] is None
+
+    def test_active_days_deduped_sorted_clamped(self):
+        # Out-of-range + duplicate + bool entries are dropped/normalised.
+        w = parse_window({"active_days": [4, 0, 0, 9, -1, True]})
+        assert w["active_days"] == [0, 4]
+
+    def test_active_days_empty_becomes_none(self):
+        assert parse_window({"active_days": []})["active_days"] is None
+
+    def test_garbage_slide_window_open_is_visible(self):
+        # A fully-garbage window dict -> all dimensions open -> visible.
+        garbage = {
+            "valid_from": "xx", "valid_to": object(), "active_days": "nope",
+            "active_start": "99:99", "active_end": [],
+        }
+        assert slide_window_open(garbage, _ln(2026, 6, 1)) is True
+
+
+class TestSlideHasWindow:
+    def test_false_when_no_fields(self):
+        assert slide_has_window({}) is False
+        assert slide_has_window({"name": "x", "duration_ms": 5000}) is False
+
+    def test_false_when_all_unparseable(self):
+        assert slide_has_window({"valid_from": "garbage"}) is False
+
+    def test_true_when_any_valid_constraint(self):
+        assert slide_has_window({"valid_from": "2026-12-01"}) is True
+        assert slide_has_window({"active_start": "09:00:00"}) is True
+        assert slide_has_window({"active_days": [0, 1]}) is True
+
+
+class TestVisibleSlides:
+    def test_windowless_deck_all_pass_in_order(self):
+        deck = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+        assert visible_slides(deck, _ln(2026, 6, 1)) == deck
+
+    def test_filters_closed_and_preserves_order(self):
+        deck = [
+            {"name": "always"},
+            {"name": "morning", "active_start": "09:00:00",
+             "active_end": "12:00:00"},
+            {"name": "afternoon", "active_start": "13:00:00",
+             "active_end": "17:00:00"},
+        ]
+        out = visible_slides(deck, _ln(2026, 6, 1, 13, 30))
+        assert [s["name"] for s in out] == ["always", "afternoon"]
+
+    def test_all_closed_yields_empty(self):
+        deck = [
+            {"name": "x", "active_start": "09:00:00", "active_end": "10:00:00"},
+            {"name": "y", "active_start": "11:00:00", "active_end": "12:00:00"},
+        ]
+        assert visible_slides(deck, _ln(2026, 6, 1, 15, 0)) == []
+
+
+class TestNextWindowBoundary:
+    def test_none_for_windowless_deck(self):
+        deck = [{"name": "a"}, {"name": "b"}]
+        assert next_window_boundary(deck, _ln(2026, 6, 1, 10, 0)) is None
+
+    def test_intraday_returns_next_time_edge(self):
+        # Slide opens 13:00, closes 14:00.  At 10:00 the next edge is 13:00.
+        deck = [{"name": "s", "active_start": "13:00:00", "active_end": "14:00:00"}]
+        b = next_window_boundary(deck, _ln(2026, 6, 1, 10, 0))
+        assert b == _ln(2026, 6, 1, 13, 0)
+
+    def test_after_open_returns_close_edge(self):
+        deck = [{"name": "s", "active_start": "13:00:00", "active_end": "14:00:00"}]
+        b = next_window_boundary(deck, _ln(2026, 6, 1, 13, 30))
+        assert b == _ln(2026, 6, 1, 14, 0)
+
+    def test_valid_to_closes_next_midnight(self):
+        # valid_to is inclusive, so the slide closes at midnight after it.
+        deck = [{"name": "s", "valid_to": "2026-12-26"}]
+        b = next_window_boundary(deck, _ln(2026, 12, 26, 10, 0))
+        assert b == _ln(2026, 12, 27, 0, 0)
+
+    def test_valid_from_opens_that_midnight(self):
+        deck = [{"name": "s", "valid_from": "2026-12-25"}]
+        b = next_window_boundary(deck, _ln(2026, 12, 20, 10, 0))
+        assert b == _ln(2026, 12, 25, 0, 0)
+
+    def test_strictly_future_only(self):
+        # An edge exactly at now is not a *future* boundary; the next one
+        # (the close edge) is returned instead.
+        deck = [{"name": "s", "active_start": "13:00:00", "active_end": "14:00:00"}]
+        b = next_window_boundary(deck, _ln(2026, 6, 1, 13, 0))
+        assert b == _ln(2026, 6, 1, 14, 0)
+
+    def test_expired_slide_falls_back_to_midnight(self):
+        # Every computed edge is in the past -> daily safety-net midnight.
+        deck = [{"name": "s", "valid_to": "2020-01-01"}]
+        b = next_window_boundary(deck, _ln(2026, 6, 1, 10, 0))
+        assert b == _ln(2026, 6, 2, 0, 0)
+
+    def test_weekday_slide_wakes_at_midnight(self):
+        deck = [{"name": "s", "active_days": [0]}]  # Mondays only
+        b = next_window_boundary(deck, _ln(2026, 6, 1, 10, 0))
+        # The weekday dimension can change at the next midnight.
+        assert b == _ln(2026, 6, 2, 0, 0)
+
+
+class TestWindowBoundaryConstant:
+    def test_documented_value(self):
+        assert WINDOW_BOUNDARY_MAX_SLEEP_S == 900

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -169,15 +169,15 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.5")
+        ], version="1.6")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
         assert player._slideshow is not None
-        assert player._slideshow["schema_version"] == "1.5"
+        assert player._slideshow["schema_version"] == "1.6"
         # INFO logged, mentions both the observed and the player-max version.
         assert any(
-            "manifest_schema_version=1.5" in rec.getMessage()
-            and "player max=1.4" in rec.getMessage()
+            "manifest_schema_version=1.6" in rec.getMessage()
+            and "player max=1.5" in rec.getMessage()
             for rec in caplog.records
         ), f"forward-version INFO not logged: {[r.getMessage() for r in caplog.records]}"
 
@@ -187,14 +187,14 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.5")
+        ], version="1.6")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
             player._clear_slideshow()
             player._start_slideshow("Show", None)
         forward_logs = [
             r for r in caplog.records
-            if "manifest_schema_version=1.5" in r.getMessage()
+            if "manifest_schema_version=1.6" in r.getMessage()
         ]
         assert len(forward_logs) == 1, (
             f"forward-version INFO should fire once per digest, got "


### PR DESCRIPTION
Device-side implementation of **per-slide visibility windows** (Phase 2 PR2). Complements agora-cms #830 (manifest schema 1.4 -> 1.5, already shipped to dev).

## What

Ports the CMS scheduler's per-slide window predicate into the firmware so windowed slides flip open/closed at exact local-clock boundaries -- **including while the device is network-isolated**. A slide hidden by the server stays hidden on-device; a slide that opens at 1pm appears at 1pm with no network round-trip.

Window fields (all optional, per slide):
- `valid_from` / `valid_to` -- inclusive date range
- `active_days` -- weekday allowlist
- `active_start` / `active_end` -- time-of-day, start-incl/end-excl, overnight wrap supported

## Changes

- **slideshow_engine.py** (pure, shared Pi + softplayer): bump max schema 1.4 -> 1.5; add `parse_window` / `slide_has_window` / `slide_window_open` / `visible_slides` / `next_window_boundary`. Every dimension fails **open** on garbage input.
- **player/service.py**: `_resolve_anchored_target` filters to the visible deck, recomputes the cycle, records the next boundary, signals all-closed; `_anchored_tick_ms` wakes precisely on the boundary; `_enter_windows_closed` holds on splash (once) and resumes automatically when a slide reopens. Windowing gated on clock-trust (pre-NTP boot plays the full deck). Windowless decks are byte-identical to schema <= 1.4.
- **cms_client/service.py**: advertise `slideshow_visibility_v1` capability.

## Tests

- 6 new engine test classes -- predicate parity ported 1:1 from agora-cms `test_slideshow_visibility.py`, plus fail-open parsing, filtering, next-boundary, boundary constant.
- Forward-version logging tests bumped to 1.6 (1.5 is now the supported max).
- `test_slideshow_engine.py` 78 passed; player + slideshow suites green.

## Validation plan

After merge: cut an agora-os image, reflash Pi100, author a near-future window slide, confirm it appears/vanishes at the exact local minute and flips correctly while the device is network-isolated.
