### PR TITLE
feat(slideshow): honor per-slide video clip (trim) + fix play-to-end double-advance

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -63,11 +63,18 @@ PROTOCOL_VERSION = 2
 #   (including currently-closed slides) to such devices and lets the
 #   firmware do the windowing; pre-feature firmware keeps receiving the
 #   server-side filtered deck.
+# - "slideshow_clip_v1": this firmware honours per-slide source trim
+#   (manifest schema 1.6: ``clip_start_ms``) by seeking the source video
+#   to that offset (stacked on top of the within-slot anchored offset)
+#   and disabling loop for clipped slides so they never wrap back to
+#   pre-clip frames. Pre-feature firmware ignores the field and plays
+#   the slide from t=0.
 DEVICE_CAPABILITIES = [
     "slideshow_v1",
     "composed_siblings_v1",
     "slideshow_composed_v1",
     "slideshow_visibility_v1",
+    "slideshow_clip_v1",
 ]
 
 # Bootstrap v2 renewal policy (issue #420 stage B.3).

--- a/player/service.py
+++ b/player/service.py
@@ -886,10 +886,19 @@ class AgoraPlayer:
             slide_duration_ms = int(slide.get("duration_ms") or 0)
             slide_fit = slide.get("fit") or None
             slide_effect = slide.get("effect") or None
-            start_offset_ms = (
+            # Per-slide source trim (manifest 1.6): ``clip_start_ms`` is a
+            # seek offset into the *source* file. It stacks on top of the
+            # within-slot offset so a late/restarted player still lines up
+            # with the rest of the wall: source currentTime =
+            # clip_start_ms + (how far into this slide's slot we are).
+            clip_start_ms = (
+                int(slide.get("clip_start_ms") or 0) if is_video_slide else 0
+            )
+            within_slot_ms = (
                 max(0, slide_duration_ms - remaining_ms)
                 if is_video_slide and slide_duration_ms > 0 else 0
             )
+            start_offset_ms = within_slot_ms + clip_start_ms
             if play_to_end:
                 self._play_slide_to_end_chromium(
                     slide, slide_name, path, ss,
@@ -907,8 +916,11 @@ class AgoraPlayer:
                     duration_ms=slide_transition_ms,
                 )
             elif is_video_slide:
+                # A clipped video (clip_start_ms > 0) must NOT loop: looping
+                # would wrap past the clip's source EOF back to pre-clip
+                # frames. Un-clipped videos keep looping within their slot.
                 self._chromium_player.show_video(
-                    path, loop=True, muted=False,
+                    path, loop=(clip_start_ms == 0), muted=False,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
                     start_offset_ms=start_offset_ms,
@@ -950,6 +962,56 @@ class AgoraPlayer:
         )
         return False
 
+    def _should_defer_anchored_snap(
+        self, ss: dict, current_idx: int, target_idx: int,
+    ) -> bool:
+        """Anchored-resync SNAP guard.
+
+        When a ``play_to_end`` video is a hair from its natural ``ended``
+        event, a wall-clock SNAP to the next slide would (a) tear the
+        video down a fraction early and (b) leave a stale
+        ``pending_play_to_end*`` record that the late ``ended`` then
+        matches → a spurious *second* advance. Defer the SNAP (re-arm a
+        tick) so the natural end wins — but only while we're still inside
+        the overrun tolerance. Past that, the normal SNAP / overrun
+        watchdog takes over so playback can never wedge.
+
+        Only ``play_to_end`` slides arm a ``pending`` record, so a pure
+        bounded video clip (no pending) is *never* deferred — its SNAP at
+        the slot edge IS its advance mechanism. Likewise a multi-slide
+        jump (genuine drift) snaps immediately to catch up.
+        """
+        slides = ss.get("active_cycle_slides") or ss["slides"]
+        n = len(slides)
+        if n <= 0 or not (0 <= current_idx < n):
+            return False
+        # Only the immediate-next slide is a natural-end race; a jump of
+        # more than one slide means we've genuinely drifted → snap now.
+        if target_idx != (current_idx + 1) % n:
+            return False
+        if self._use_chromium_backend and self._chromium_player:
+            pending = ss.get("pending_play_to_end_chromium")
+        else:
+            pending = ss.get("pending_play_to_end")
+        # No pending, or pending for a different slide → not a play_to_end
+        # end-wait we need to protect (e.g. a bounded clip or plain timed
+        # slide) → snap normally.
+        if not pending or pending.get("slide_index") != current_idx:
+            return False
+        armed_at = pending.get("armed_at")
+        if armed_at is None:
+            return False
+        slide_dur = int((slides[current_idx] or {}).get("duration_ms") or 0)
+        if slide_dur <= 0:
+            return False
+        cycle_ms = int(ss.get("cycle_duration_ms") or 0)
+        overrun_tolerance = max(2 * _RESYNC_CAP_MS, cycle_ms // 4, 10_000)
+        elapsed_since_arm = (
+            datetime.now(timezone.utc) - armed_at
+        ).total_seconds() * 1000
+        # Inside the natural-end window → hold and let the video finish.
+        return elapsed_since_arm <= slide_dur + overrun_tolerance
+
     def _on_anchored_resync_tick(self, epoch: int) -> bool:
         """GLib timeout for the wall-clock-anchored resync tick.
 
@@ -977,6 +1039,17 @@ class AgoraPlayer:
         current_idx = ss.get("anchored_current_idx", -1)
 
         if target_idx != current_idx:
+            if self._should_defer_anchored_snap(ss, current_idx, target_idx):
+                logger.info(
+                    "Slideshow %s: anchored resync deferring SNAP idx=%d→%d "
+                    "(play_to_end still within natural-end window)",
+                    ss["name"], current_idx, target_idx,
+                )
+                tick_ms = self._anchored_tick_ms(ss, remaining_ms)
+                ss["timeout_id"] = GLib.timeout_add(
+                    tick_ms, self._on_anchored_resync_tick, epoch,
+                )
+                return False
             logger.info(
                 "Slideshow %s: anchored resync SNAP from idx=%d to idx=%d "
                 "(remaining_ms=%d)",
@@ -1163,11 +1236,16 @@ class AgoraPlayer:
                 return False
             if is_video_slide:
                 # Slideshow videos loop within their fixed duration; the
-                # next-slide timeout drives advance.
+                # next-slide timeout drives advance. A clipped video
+                # (clip_start_ms > 0) seeks into the source and must NOT
+                # loop (it would wrap past the clip back to pre-clip
+                # frames).
+                clip_start_ms = int(slide.get("clip_start_ms") or 0)
                 self._chromium_player.show_video(
-                    path, loop=True, muted=False,
+                    path, loop=(clip_start_ms == 0), muted=False,
                     transition=slide_transition,
                     duration_ms=slide_transition_ms,
+                    start_offset_ms=clip_start_ms,
                     fit=slide_fit,
                 )
             elif is_composed_slide:

--- a/player/slideshow_engine.py
+++ b/player/slideshow_engine.py
@@ -42,7 +42,7 @@ from typing import Optional
 #: with a higher version are still played back (best-effort) but log a
 #: one-shot "CMS is ahead of this player" INFO message.  Older versions
 #: are accepted unconditionally.
-PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.5"
+PLAYER_MAX_MANIFEST_SCHEMA_VERSION = "1.6"
 
 
 def parse_schema_version(version: str) -> tuple[int, int]:

--- a/tests/test_slideshow_composed_fetch.py
+++ b/tests/test_slideshow_composed_fetch.py
@@ -169,6 +169,11 @@ class TestSlideshowComposedCapability:
         only emits composed slideshow members to capable firmware."""
         assert "slideshow_composed_v1" in DEVICE_CAPABILITIES
 
+    def test_clip_capability_advertised(self):
+        """Per-slide video clip (trim) capability must be advertised so
+        the CMS only emits clip_start_ms slides to capable firmware."""
+        assert "slideshow_clip_v1" in DEVICE_CAPABILITIES
+
 
 class TestSlideshowComposedFetch:
     @pytest.mark.asyncio

--- a/tests/test_slideshow_engine.py
+++ b/tests/test_slideshow_engine.py
@@ -225,7 +225,7 @@ class TestConstants:
         # docs and the CMS-side scheduler.
         assert CLOCK_SKEW_TOLERANCE_S == 3600
         assert RESYNC_CAP_MS == 5000
-        assert PLAYER_MAX_MANIFEST_SCHEMA_VERSION == "1.5"
+        assert PLAYER_MAX_MANIFEST_SCHEMA_VERSION == "1.6"
 
 
 class TestCycleIndexAt:

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -169,15 +169,15 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.6")
+        ], version="1.7")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
         assert player._slideshow is not None
-        assert player._slideshow["schema_version"] == "1.6"
+        assert player._slideshow["schema_version"] == "1.7"
         # INFO logged, mentions both the observed and the player-max version.
         assert any(
-            "manifest_schema_version=1.6" in rec.getMessage()
-            and "player max=1.5" in rec.getMessage()
+            "manifest_schema_version=1.7" in rec.getMessage()
+            and "player max=1.6" in rec.getMessage()
             for rec in caplog.records
         ), f"forward-version INFO not logged: {[r.getMessage() for r in caplog.records]}"
 
@@ -187,14 +187,14 @@ class TestManifestSchemaVersion:
         self._write_versioned_manifest(player, "Show", [
             {"name": "a.png", "asset_type": "image",
              "duration_ms": 1000, "play_to_end": False},
-        ], version="1.6")
+        ], version="1.7")
         with patch.object(svc, "GLib"), caplog.at_level("INFO", logger="agora.player"):
             player._start_slideshow("Show", None)
             player._clear_slideshow()
             player._start_slideshow("Show", None)
         forward_logs = [
             r for r in caplog.records
-            if "manifest_schema_version=1.6" in r.getMessage()
+            if "manifest_schema_version=1.7" in r.getMessage()
         ]
         assert len(forward_logs) == 1, (
             f"forward-version INFO should fire once per digest, got "
@@ -1296,3 +1296,177 @@ class TestAnchoredPlayback:
             "overrun branch must NOT call stop() -- that kills the "
             "kiosk + shell server and orphans every subsequent show_*"
         )
+
+
+class TestSlideshowVideoClip:
+    """Per-slide source trim (manifest schema 1.6, capability
+    ``slideshow_clip_v1``).
+
+    ``clip_start_ms`` is a seek offset into the *source* video. On the
+    anchored path it stacks on top of the within-slot offset so a
+    late/restarted player lines up with the rest of the wall; a clipped
+    video must not loop (looping would wrap past the clip's source EOF
+    back to pre-clip frames).
+    """
+
+    def _write_anchored(self, player, name, slides, started_at,
+                        schema="1.6"):
+        import json
+        path = player.assets_dir / "slideshows" / f"{name}.json"
+        path.write_text(json.dumps({
+            "name": name,
+            "manifest_schema_version": schema,
+            "started_at": started_at,
+            "cycle_duration_ms": sum(s["duration_ms"] for s in slides),
+            "slides": slides,
+        }))
+        return path
+
+    def test_anchored_clip_stacks_on_within_slot_offset(self, mpv_player):
+        """source seek = within_slot_offset + clip_start_ms."""
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        from datetime import datetime, timedelta, timezone
+        # 60s slide, anchored 25s ago -> within_slot == 25_000;
+        # clip_start_ms == 10_000 -> source seek ~= 35_000.
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=25)
+        self._write_anchored(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 60_000,
+             "play_to_end": False, "clip_start_ms": 10_000},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/v.mp4"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_video.assert_called_once()
+        kwargs = player._chromium_player.show_video.call_args.kwargs
+        assert 34_000 <= kwargs["start_offset_ms"] <= 36_000
+        # Clipped video must not loop.
+        assert kwargs["loop"] is False
+
+    def test_anchored_unclipped_video_still_loops(self, mpv_player):
+        """No clip_start_ms -> loop stays True (no source-seek wrap risk)."""
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        from datetime import datetime, timedelta, timezone
+        anchor = datetime.now(timezone.utc) - timedelta(seconds=5)
+        self._write_anchored(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 60_000,
+             "play_to_end": False},
+        ], started_at=anchor.isoformat().replace("+00:00", "Z"))
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/v.mp4"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_video.assert_called_once()
+        kwargs = player._chromium_player.show_video.call_args.kwargs
+        assert kwargs["loop"] is True
+
+    def test_nonanchored_clip_seek_and_no_loop(self, mpv_player):
+        """On the non-anchored next-slide path, clip_start_ms is the bare
+        source seek (no within-slot stacking) and loop is disabled."""
+        player, svc = mpv_player
+        (player.assets_dir / "videos" / "v.mp4").touch()
+        _write_manifest(player, "Show", [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 8_000,
+             "play_to_end": False, "clip_start_ms": 3_000},
+        ])
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        player._chromium_player.asset_url.return_value = "file:///x/v.mp4"
+        with patch.object(svc, "GLib") as glib:
+            glib.timeout_add.return_value = 1
+            player._start_slideshow("Show", None)
+        player._chromium_player.show_video.assert_called_once()
+        kwargs = player._chromium_player.show_video.call_args.kwargs
+        assert kwargs["start_offset_ms"] == 3_000
+        assert kwargs["loop"] is False
+
+
+class TestAnchoredSnapGuard:
+    """``_should_defer_anchored_snap`` — defers a wall-clock SNAP only
+    while a play_to_end video is inside its natural-end window, so the
+    natural ``ended`` event wins instead of an early teardown +
+    double-advance. A bounded clip (no pending record) or a multi-slide
+    jump must NOT be deferred.
+    """
+
+    def _ss(self, slides, pending=None, cycle_ms=None):
+        return {
+            "name": "Show",
+            "slides": slides,
+            "cycle_duration_ms": (
+                cycle_ms if cycle_ms is not None
+                else sum(s["duration_ms"] for s in slides)
+            ),
+            "pending_play_to_end_chromium": pending,
+        }
+
+    def _slides(self):
+        return [
+            {"name": "v.mp4", "asset_type": "video", "duration_ms": 10_000,
+             "play_to_end": True},
+            {"name": "n.png", "asset_type": "image", "duration_ms": 10_000,
+             "play_to_end": False},
+        ]
+
+    def _armed(self, slide_index, seconds_ago):
+        from datetime import datetime, timedelta, timezone
+        return {
+            "slide_index": slide_index,
+            "slide_name": "v.mp4",
+            "armed_at": datetime.now(timezone.utc) - timedelta(seconds=seconds_ago),
+            "asset_url": "/assets/v.mp4",
+        }
+
+    def test_defers_play_to_end_at_immediate_next(self, mpv_player):
+        player, _ = mpv_player
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        ss = self._ss(self._slides(), pending=self._armed(0, seconds_ago=11))
+        # current=0 (the play_to_end video), target=1 (immediate next),
+        # armed 11s ago vs 10s slide -> within overrun tolerance -> defer.
+        assert player._should_defer_anchored_snap(ss, 0, 1) is True
+
+    def test_does_not_defer_bounded_clip_no_pending(self, mpv_player):
+        player, _ = mpv_player
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        # A pure bounded clip arms NO pending record: its SNAP at the
+        # slot edge IS its advance mechanism -> must not be deferred.
+        ss = self._ss(self._slides(), pending=None)
+        assert player._should_defer_anchored_snap(ss, 0, 1) is False
+
+    def test_does_not_defer_multi_slide_jump(self, mpv_player):
+        player, _ = mpv_player
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        slides = self._slides() + [
+            {"name": "c.png", "asset_type": "image", "duration_ms": 10_000,
+             "play_to_end": False},
+        ]
+        ss = self._ss(slides, pending=self._armed(0, seconds_ago=5))
+        # target jumps from 0 to 2 (genuine drift) -> snap immediately.
+        assert player._should_defer_anchored_snap(ss, 0, 2) is False
+
+    def test_does_not_defer_past_overrun_tolerance(self, mpv_player):
+        player, _ = mpv_player
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        # Armed 5 minutes ago: well past slide_dur + tolerance -> stop
+        # holding so playback can never wedge.
+        ss = self._ss(self._slides(), pending=self._armed(0, seconds_ago=300))
+        assert player._should_defer_anchored_snap(ss, 0, 1) is False
+
+    def test_does_not_defer_pending_for_other_slide(self, mpv_player):
+        player, _ = mpv_player
+        player._use_chromium_backend = True
+        player._chromium_player = MagicMock()
+        # Pending record is for a different slide index than current ->
+        # not the end-wait we protect.
+        ss = self._ss(self._slides(), pending=self._armed(1, seconds_ago=5))
+        assert player._should_defer_anchored_snap(ss, 0, 1) is False


### PR DESCRIPTION
## Firmware: per-slide video clip (trim) + play-to-end double-advance fix

Firmware half of the slideshow per-slide video clip feature. Pairs with
CMS PR sslivins/agora-cms#832 (already in flight). Manifest schema **1.6**
carries an optional `clip_start_ms` on video slides.

### What changed

**Clip seek (`clip_start_ms`)**
- **Anchored path:** source seek = within-slot offset + `clip_start_ms`,
  so a late/restarted player still lines up with the rest of the wall.
- **Non-anchored path:** bare `clip_start_ms` seek.
- A clipped video (`clip_start_ms > 0`) is dispatched with `loop=False` —
  looping would wrap past the clip's source EOF back to pre-clip frames.
  Un-clipped videos keep looping within their slot (unchanged).

The chromium shell already does `video.currentTime = start_offset_ms/1000`,
so no JS change is needed.

**Generalized anchored-resync SNAP guard (`_should_defer_anchored_snap`)**
- A `play_to_end` video advances via its natural `ended` event. The
  resync tick could compute `target_idx = current_idx + 1` and SNAP a
  fraction before `ended` arrives, tearing the video down early AND
  leaving a stale `pending_play_to_end_chromium` record that the late
  `ended` then matches → a spurious **second** advance.
- The guard defers the SNAP only while inside the overrun tolerance, so
  the natural end wins.
- **Pure bounded clips are never deferred** — they arm no pending record,
  so their slot-edge SNAP *is* their advance mechanism. Multi-slide jumps
  (genuine drift) and past-tolerance overruns snap immediately so
  playback can never wedge.

**Capability + schema**
- Bump `PLAYER_MAX_MANIFEST_SCHEMA_VERSION` 1.5 → 1.6.
- Advertise `slideshow_clip_v1` so the CMS only emits `clip_start_ms`
  slides to capable firmware.

### Tests
- Anchored clip seek stacks within-slot + clip_start; anchored clipped →
  `loop=False`; anchored un-clipped → `loop=True`.
- Non-anchored clip seek + `loop=False`.
- 5 `_should_defer_anchored_snap` cases: defer play-to-end at immediate
  next; do NOT defer bounded clip / no-pending, multi-slide jump,
  past-tolerance, or pending-for-other-slide.
- `slideshow_clip_v1` advertised.
- Forward/above-max version fixtures rebased 1.6 → 1.7.

163 targeted tests green locally (player + engine + composed-fetch).

### Out of scope
- mpv path does not seek (Pi fleet is chromium; acceptable for v1).
- Wire carries only `clip_start_ms` (no `clip_duration_ms`); CMS only
  emits `clip_start_ms > 0` for clipped slides.
