### PR TITLE
fix(slideshow): persist clip_start_ms so trimmed videos seek to the start offset

### DIFF
--- a/cms_client/service.py
+++ b/cms_client/service.py
@@ -2470,6 +2470,16 @@ class CMSClient:
                     # direction. Persist verbatim; default None so pre-1.4
                     # manifests stay a no-op.
                     "effect_direction": s.get("effect_direction"),
+                    # Per-slide source trim (manifest schema 1.6, capability
+                    # ``slideshow_clip_v1``). ``clip_start_ms`` is a seek
+                    # offset into the source video. The player honours it
+                    # (player/service.py) ONLY if it survives persistence —
+                    # without this line the wire value was silently dropped
+                    # here, so a trimmed slide played from 0 (duration was
+                    # still honoured because ``duration_ms`` is persisted).
+                    # Persist as an int; default 0 so legacy/untrimmed and
+                    # pre-1.6 manifests read as a no-op (no seek).
+                    "clip_start_ms": int(s.get("clip_start_ms") or 0),
                     # Composed members persist their sibling list so cold-start
                     # completeness + eviction-protection survive a reboot.
                     **(

--- a/tests/test_slideshow_fetch.py
+++ b/tests/test_slideshow_fetch.py
@@ -328,6 +328,64 @@ class TestSlideshowFetch:
         assert manifest["slides"][0]["effect_direction"] == "out_down_right"
 
     @pytest.mark.asyncio
+    async def test_clip_start_ms_propagated_from_wire(self, cms_client):
+        """Per-slide source trim regression (manifest schema 1.6,
+        capability ``slideshow_clip_v1``): when CMS provides
+        ``clip_start_ms``, it must be persisted into the on-disk
+        manifest. The player reads it from there to seek the source
+        video; dropping it here silently played trimmed videos from 0
+        (the symptom the user hit: duration honoured, start ignored).
+        """
+        b1 = b"trimmed-video-bytes"
+        slide = _make_slide("Sony_AV1.mp4", b1, asset_type="video",
+                            duration_ms=30000)
+        slide["clip_start_ms"] = 15000
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "Trimmed.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "manifest_schema_version": "1.6",
+            "slides": [slide],
+        }
+        mapping = {slide["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest_path = cms_client.settings.slideshows_dir / "Trimmed.slideshow.json"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["slides"][0]["clip_start_ms"] == 15000
+
+    @pytest.mark.asyncio
+    async def test_clip_start_ms_defaults_to_zero_when_absent(self, cms_client):
+        """Older CMS (pre-1.6) or untrimmed slides omit ``clip_start_ms``.
+        Persist ``0`` so the player's seek is a no-op (plays from start).
+        """
+        b1 = b"sb"
+        slides = [_make_slide("a.mp4", b1, asset_type="video", duration_ms=5000)]
+        msg = {
+            "type": "fetch_asset",
+            "asset_name": "NoClip.slideshow",
+            "asset_type": "slideshow",
+            "download_url": "",
+            "checksum": "h",
+            "size_bytes": 0,
+            "slides": slides,
+        }
+        mapping = {slides[0]["download_url"]: b1}
+        fake_aiohttp, _ = _patch_aiohttp(mapping)
+        with patch.dict(sys.modules, {"aiohttp": fake_aiohttp}):
+            await cms_client._handle_fetch_asset(msg, cms_client._ws)
+
+        manifest = json.loads(
+            (cms_client.settings.slideshows_dir / "NoClip.slideshow.json").read_text()
+        )
+        assert manifest["slides"][0]["clip_start_ms"] == 0
+
+    @pytest.mark.asyncio
     async def test_fit_effect_default_when_absent(self, cms_client):
         """Older CMS (pre-1.3) omits ``fit``/``effect``. Persist ``null``
         so the player's ``slide.get(...) or None`` reads a no-op,


### PR DESCRIPTION
## Problem

A trimmed slideshow video honored the clip **duration** (e.g. 30s) but ignored the clip **start offset** (e.g. `start at 15s`) — it played from 0 for 30s instead of 15s–45s.

## Root cause (firmware persist drop)

CMS correctly emits `clip_start_ms=15000` on the wire (manifest schema 1.6, capability `slideshow_clip_v1`), and the firmware **player already honors it** (`player/service.py` seeks the source video). But `_write_slideshow_manifest` in `cms_client/service.py` rebuilds each slide via an explicit field whitelist that **omitted `clip_start_ms`**. The value was silently dropped at persist time, so the player read it back as `0` → seek 0. `duration_ms` is in the whitelist (hence duration was honored), which is exactly why duration worked but start offset did not.

## Fix

Add `clip_start_ms` to the persist whitelist as an `int`, defaulting to `0` so legacy/untrimmed and pre-1.6 manifests read as a no-op — the same persist-verbatim/default-noop pattern already used for `fit` / `effect` / `effect_direction`.

## Tests

- `test_clip_start_ms_propagated_from_wire` — persisted manifest carries `15000` when on wire.
- `test_clip_start_ms_defaults_to_zero_when_absent` — defaults to `0` when absent.
- Full `test_slideshow_fetch.py` + `test_slideshow_player.py` green locally (102 passed).

Goodwill dev / test fleet only.
