### PR TITLE
fix(player): refresh process timezone before evaluating slide visibility windows

### DIFF
--- a/player/service.py
+++ b/player/service.py
@@ -50,6 +50,29 @@ from player.slideshow_engine import (  # noqa: E402
 logger = logging.getLogger("agora.player")
 
 
+def _device_local_now() -> datetime:
+    """Return naive device-local civil time, refreshing the process
+    timezone from ``/etc/localtime`` first.
+
+    The player process can start *before* ``cms_client`` sets the OS
+    timezone (a boot-ordering race). When that happens glibc caches UTC
+    at the first ``localtime()`` call and a naive ``datetime.now()``
+    stays on UTC for the whole process lifetime — so every per-slide
+    visibility window (manifest schema >= 1.5) is evaluated against the
+    wrong civil clock and otherwise-open slides are suppressed (or
+    closed slides shown) until the player happens to restart.
+
+    ``time.tzset()`` forces glibc to re-read ``/etc/localtime`` so the
+    process picks up the timezone even if it was set after launch, and
+    windows flip at the correct local boundary. ``tzset`` is Unix-only;
+    on Windows (softplayer dev tool) it is absent and the call is a
+    no-op, preserving the existing behavior.
+    """
+    if hasattr(time, "tzset"):
+        time.tzset()
+    return datetime.now()
+
+
 def _parse_schema_version(version: str) -> tuple[int, int]:
     """Parse a ``major.minor`` (or ``major.minor.patch``) version string.
 
@@ -642,10 +665,14 @@ class AgoraPlayer:
         now = datetime.now(timezone.utc)
         # Naive system-local civil time for per-slide visibility windows.
         # On the Pi the OS timezone is set by cms_client, so a naive
-        # ``datetime.now()`` reads the device's local wall clock — exactly
-        # what the CMS predicate evaluates against. Softplayer on Windows
-        # gets Windows-local time (a dev-tool caveat, not a fleet concern).
-        local_now = datetime.now()
+        # device-local clock reads the device's local wall clock — exactly
+        # what the CMS predicate evaluates against. ``_device_local_now``
+        # refreshes the process timezone first so a player that started
+        # before cms_client set ``/etc/localtime`` does not stay stuck on
+        # UTC (which would mis-evaluate every window). Softplayer on
+        # Windows gets Windows-local time (a dev-tool caveat, not a fleet
+        # concern).
+        local_now = _device_local_now()
         base_slides = ss.get("slides") or []
         anchor = ss.get("anchor")
 
@@ -768,7 +795,7 @@ class AgoraPlayer:
         boundary = ss.get("window_boundary")
         if boundary is not None:
             ms_to_boundary = int(
-                (boundary - datetime.now()).total_seconds() * 1000
+                (boundary - _device_local_now()).total_seconds() * 1000
             )
             ms_to_boundary = max(
                 1,

--- a/tests/test_slideshow_player.py
+++ b/tests/test_slideshow_player.py
@@ -1470,3 +1470,62 @@ class TestAnchoredSnapGuard:
         # not the end-wait we protect.
         ss = self._ss(self._slides(), pending=self._armed(1, seconds_ago=5))
         assert player._should_defer_anchored_snap(ss, 0, 1) is False
+
+
+# --- Regression: player cached-timezone window suppression -------------------
+#
+# The agora-player process can start *before* cms_client finalizes the OS
+# timezone (a boot-ordering race). With TZ unset, glibc reads /etc/localtime
+# exactly once and caches it for the process lifetime, so a naive
+# datetime.now() is permanently stuck on UTC -- and every per-slide
+# visibility window (manifest schema >= 1.5) is evaluated against the wrong
+# civil clock. _device_local_now() forces time.tzset() before reading the
+# clock so the process self-heals once the zone is set, without a restart.
+
+
+def _import_player_service():
+    """Import player.service with gi mocked (works on Windows + Linux)."""
+    with patch.dict("sys.modules", {
+        "gi": MagicMock(),
+        "gi.repository": MagicMock(),
+    }):
+        import importlib
+        import player.service as svc
+        importlib.reload(svc)
+        return svc
+
+
+def test_device_local_now_forces_timezone_refresh(monkeypatch):
+    """The helper must call time.tzset() (re-reading /etc/localtime) before
+    sampling the clock, so a process that cached UTC at boot recovers the
+    correct device-local zone for window math."""
+    svc = _import_player_service()
+    if not hasattr(svc.time, "tzset"):
+        pytest.skip("time.tzset is POSIX-only")
+
+    calls = {"n": 0}
+    real_tzset = svc.time.tzset
+
+    def counting_tzset():
+        calls["n"] += 1
+        return real_tzset()
+
+    monkeypatch.setattr(svc.time, "tzset", counting_tzset)
+
+    result = svc._device_local_now()
+
+    assert calls["n"] == 1, "expected exactly one tzset() refresh per call"
+    assert isinstance(result, svc.datetime)
+    assert result.tzinfo is None, "window math relies on naive local civil time"
+
+
+def test_device_local_now_no_tzset_is_safe(monkeypatch):
+    """On platforms without tzset (Windows / softplayer dev tool) the helper
+    is a no-op over datetime.now() -- it must not raise."""
+    svc = _import_player_service()
+    monkeypatch.delattr(svc.time, "tzset", raising=False)
+
+    result = svc._device_local_now()
+
+    assert isinstance(result, svc.datetime)
+    assert result.tzinfo is None


### PR DESCRIPTION
## Problem

On Pi100 (agora-os v1.0.18-test / firmware 1.11.113) a slide with a
per-slide visibility window (manifest schema >= 1.5) that **should** be
showing was suppressed. Diagnosed live on-device to a **cached-timezone
race**, not a window-engine bug.

`agora-player` (PID seen starting at 10:22:18) launched **before**
`cms_client` symlinked `/etc/localtime` to `America/Los_Angeles`
(10:22:35). With `TZ` unset, glibc reads `/etc/localtime` **once** and
caches it for the process lifetime, so the long-running player's naive
`datetime.now()` was permanently stuck on **UTC** (logs showed 18:xx
while a fresh python read 10:xx). Every visibility window was therefore
evaluated against UTC -> otherwise-open slides filtered out of the deck
(6/7 instead of 7/7). Restarting the player immediately restored 7/7,
confirming the cached-UTC root cause.

The CMS preview also showed the slide because it shares no state with
the device clock -- the *device* was the only place misbehaving.

## Fix

Add `_device_local_now()` which forces `time.tzset()` (re-reading
`/etc/localtime`) before sampling `datetime.now()`, so the process picks
up the zone even when it was set after launch and self-heals within one
resync tick -- no restart. `tzset` is POSIX-only; on Windows/softplayer
it's absent and the helper is a no-op (existing behavior preserved).

Wired into both naive window-time call sites in `player/service.py`:
- `_resolve_anchored_target` (deck visibility filter)
- `_anchored_tick_ms` (next-boundary wake math)

The pure `slideshow_engine` is unchanged -- it already takes `local_now`
as a parameter; `service.py` was the only layer computing naive now.

## Tests

- `test_device_local_now_forces_timezone_refresh` -- proves exactly one
  `tzset()` refresh per call + naive local return (Linux CI).
- `test_device_local_now_no_tzset_is_safe` -- proves the no-tzset
  (Windows) path is a safe no-op.
- Full `test_slideshow_player.py`: 79 passed, 1 skipped locally.

Goodwill dev / test fleet only.
